### PR TITLE
Set docker client version to 1.24

### DIFF
--- a/gocli/cmd/root.go
+++ b/gocli/cmd/root.go
@@ -6,6 +6,12 @@ import (
 	"os"
 )
 
+func init() {
+	if os.Getenv("DOCKER_API_VERSION") == "" {
+		os.Setenv("DOCKER_API_VERSION", "1.24")
+	}
+}
+
 func NewRootCommand() *cobra.Command {
 
 	root := &cobra.Command{


### PR DESCRIPTION
Make sure that we support docker 1.12 too.

@davidvossel could you try `sha256:aa7f295a7908fa333ab5e98ef3af0bfafbabfd3cee2b83f9af47f722e3000f6a` for gocli?