### PR TITLE
Fix the terminal len error

### DIFF
--- a/gocli/docker/docker.go
+++ b/gocli/docker/docker.go
@@ -207,7 +207,11 @@ func PrintProgress(progressReader io.ReadCloser, writer *os.File) {
 		scanner := bufio.NewScanner(progressReader)
 		for scanner.Scan() {
 			line := scanner.Text()
-			fmt.Print("\r" + line + strings.Repeat(" ", w-len(line)))
+			clearLength := w - len(line)
+			if clearLength < 0 {
+				clearLength = 0
+			}
+			fmt.Print("\r" + line + strings.Repeat(" ", clearLength))
 		}
 	} else {
 		fmt.Fprint(writer, "Downloading ...")


### PR DESCRIPTION
Fixes the panic error caused by the long
command not fitting in the terminal window.

Signed-off-by: Petr Kotas <petr.kotas@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirtci/7)
<!-- Reviewable:end -->
