### PR TITLE
Set selinux to permissive for openshift

### DIFF
--- a/os-3.9/scripts/provision.sh
+++ b/os-3.9/scripts/provision.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+# Set SELinux to permissive. Still logging the denials.
+setenforce 0
+sed -i "s/^SELINUX=.*/SELINUX=permissive/" /etc/selinux/config
+
 # Install epel
 yum -y install epel-release
 


### PR DESCRIPTION
This PR introduces permissive selinux on openshift test cluster.
The permissive setting simplifies the deployment while still logging
every denial.

This PR is preliminary requirement for aggregated logging and will simplify
our life for running tests in the future.

@cynepco3hahue @rmohr Would you kindly review and merge?
Thank you.

Signed-off-by: Petr Kotas <petr.kotas@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirtci/18)
<!-- Reviewable:end -->
