### PR TITLE
OS-3.10 images small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 * `k8s-1.10.4` k8s-1.10.4 cluster based on the centos7 image, provisioned with kubeadm
 * `os-3.9` os-3.9 cluster based on the centos7 image, provisioned with openshift-ansible
 * `os-3.9-crio` os-3.9 cluster with CRI-O support based on the centos7 image, provisioned with openshift-ansible
+* `os-3.10.0` os-3.10.0 cluster based on the centos7 image, provisioned with openshift-ansible
 
 ## Versions to use
 
@@ -17,7 +18,7 @@
 * `kubevirtci/centos:1804_02`: `sha256:5539557ff8cbe96a3ef05e5705f82b58c38e1ff1cdf09f55a47aa5eb542f4ce8`
 * `kubevirtci/os-3.9.0:`: `sha256:234b3ae5c335c9fa32fa3bc01d5833f8f4d45420d82a8f8b12adc02687eb88b1`
 * `kubevirtci/os-3.9.0-crio:`: `sha256:107d03dad4da6957e28774b121a45e177f31d7b4ad43c6eab7b24d467e59e213`
-* `kubevirtci/os-3.10.0:`: `sha256:0977f1c716862710c8324798b95802e11a149f4532e33be20dd70877fe8f5332`
+* `kubevirtci/os-3.10.0:`: `sha256:50a4b8ee3e07d592e7e4fbf3eb1401980a5947499dfdc3d847c085b5775aaa9a`
 * `kubevirtci/k8s-1.9.3:`: `sha256:f6ffb23261fb8aa15ed45b8d17e1299e284ea75e1d2814ee6b4ec24ecea6f24b`
 * `kubevirtci/k8s-1.10.3:`: `sha256:d6290260e7e6b84419984f12719cf592ccbe327373b8df76aa0481f8ec01d357`
 * `kubevirtci/k8s-1.10.4:`: `sha256:09ac918cc16f13a5d0af51d4c98e3e25cbf4f97b7b32fe18ec61b32f04ca1009`

--- a/base/scripts/vm.sh
+++ b/base/scripts/vm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 PROVISION=false
 MEMORY=3096M

--- a/os-3.10/scripts/provision.sh
+++ b/os-3.10/scripts/provision.sh
@@ -14,7 +14,7 @@ yum -y install iscsi-initiator-utils
 cat >/etc/yum.repos.d/origin-latest.repo <<EOF
 [my-origin]
 name=Origin packages v3.10.0-rc.0
-baseurl=http://10.35.4.116/v3.10.0-rc.0/
+baseurl=https://plain.resources.ovirt.org/repos/origin/3.10/v3.10.0-rc.0/
 enabled=1
 gpgcheck=0
 EOF
@@ -35,7 +35,7 @@ yum install -y yum-utils \
   docker
 
 # Disable spectre and meltdown patches
-sed -i 's/quiet"/quiet spectre_v2=off nopti"/' /etc/default/grub
+sed -i 's/quiet"/quiet spectre_v2=off nopti hugepagesz=2M hugepages=64"/' /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
 
 echo '{ "insecure-registries" : ["registry:5000"] }' > /etc/docker/daemon.json


### PR DESCRIPTION
- use the public Ovirt repository
- add verbosity flag to `vm.sh` script
- add hugepages to the image

Fixes #22 

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>