### PR TITLE
update sdn network plugin to use openshift-ovs-networkpolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 * `kubevirtci/centos:1804_02`: `sha256:5539557ff8cbe96a3ef05e5705f82b58c38e1ff1cdf09f55a47aa5eb542f4ce8`
 * `kubevirtci/os-3.9.0:`: `sha256:234b3ae5c335c9fa32fa3bc01d5833f8f4d45420d82a8f8b12adc02687eb88b1`
 * `kubevirtci/os-3.9.0-crio:`: `sha256:107d03dad4da6957e28774b121a45e177f31d7b4ad43c6eab7b24d467e59e213`
-* `kubevirtci/os-3.10.0:`: `sha256:14ffc4a28e24a2510c9b455b56f35f6193a00b71c9150705f6afec41b003fc76`
+* `kubevirtci/os-3.10.0:`: `sha256:74309d2d0b03e0ec4297fe2ad2e8641a0689cd75bccd4eac422901d24194f7ea`
 * `kubevirtci/os-3.10.0-crio:`: `sha256:8f93b2e8a561b72ee19c0b9b225019c51fe5d1f1fdbee88c46b8f7336e95e815`
 * `kubevirtci/k8s-1.9.3:`: `sha256:f6ffb23261fb8aa15ed45b8d17e1299e284ea75e1d2814ee6b4ec24ecea6f24b`
 * `kubevirtci/k8s-1.10.3:`: `sha256:d6290260e7e6b84419984f12719cf592ccbe327373b8df76aa0481f8ec01d357`

--- a/os-3.10/scripts/provision.sh
+++ b/os-3.10/scripts/provision.sh
@@ -95,6 +95,7 @@ openshift_hosted_etcd_storage_volume_size=1G
 openshift_hosted_etcd_storage_labels={'storage': 'etcd'}
 openshift_node_kubelet_args={'max-pods': ['40'], 'pods-per-core': ['40']}
 openshift_master_admission_plugin_config={"ValidatingAdmissionWebhook":{"configuration":{"kind": "DefaultAdmissionConfig","apiVersion": "v1","disable": false}},"MutatingAdmissionWebhook":{"configuration":{"kind": "DefaultAdmissionConfig","apiVersion": "v1","disable": false}}}
+os_sdn_network_plugin_name=redhat/openshift-ovs-networkpolicy
 
 [nfs]
 node01 openshift_ip=$master_ip


### PR DESCRIPTION
Add a parameter here to use openshift-ovs-networkpolicy plugin since the networkpolicy test require a dev cluster with openshift-ovs-networkpolicy plugin.

Without this parameter, the dev cluster will use openshift-ovs-subnet plugin by default, pods/vms can be connected across the namespaces. After changing to openshift-ovs-networkpolicy plugin, it is same as subnet if you don't create any networkpolicy rules in the namespace. So I think it is no harm to other testing.