### PR TITLE
enable the cpu manager on nodes not on the master

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@
 * `kubevirtci/centos:1804_02`: `sha256:70653d952edfb8002ab8efe9581d01960ccf21bb965a9b4de4775c8fbceaab39`
 * `kubevirtci/os-3.9.0:`: `sha256:234b3ae5c335c9fa32fa3bc01d5833f8f4d45420d82a8f8b12adc02687eb88b1`
 * `kubevirtci/os-3.9.0-crio:`: `sha256:107d03dad4da6957e28774b121a45e177f31d7b4ad43c6eab7b24d467e59e213`
-* `kubevirtci/os-3.10.0:`: `sha256:cdc9f998e19915b28b5c5be1ccc4c6fa2c8336435f38a37855f75b206977cbc2`
-* `kubevirtci/os-3.10.0-crio:`: `sha256:36cc53fd72fbd247810b38618c0f3fa058c17bcb6744b0512193eba0728ebf05`
+* `kubevirtci/os-3.10.0:`: `sha256:faa467495207af8faa9214b1bf8adabf6161fab7f4da11b63efa41610a3ff0ab`
+* `kubevirtci/os-3.10.0-crio:`: `sha256:63e2f80caef0328960f3f72860ed19c59e4070cb6e9815a4c7f6051cd243f501`
 * `kubevirtci/k8s-1.9.3:`: `sha256:f6ffb23261fb8aa15ed45b8d17e1299e284ea75e1d2814ee6b4ec24ecea6f24b`
 * `kubevirtci/k8s-1.10.3:`: `sha256:d6290260e7e6b84419984f12719cf592ccbe327373b8df76aa0481f8ec01d357`
-* `kubevirtci/k8s-1.10.4:`: `sha256:ee6846957b58e1f56b240d9ba6410f082e4787a4c4f1e0d60f6b907b76146b3e`
-* `kubevirtci/k8s-1.11.0:`: `sha256:80e722a040fd6bcc5410239139a2cf0d33e1d52fe82d3cf9bdf5f5c3d09cfa7a`
+* `kubevirtci/k8s-1.10.4:`: `sha256:e697f59d5b3b09130a8854b08417959eb70197fcc1b47cf64fe83c5164f00cfa`
+* `kubevirtci/k8s-1.11.0:`: `sha256:de5606811adba4945e01d07ee77b5c1a7cddeed5412b020219dadb8fb96d77be`
 * `kubevirtci/k8s-multus-1.10.4:`: `sha256:c66c2e1fdae0f92093b3e462e81c9856d423a918ba4dcdfcf401da284ea2bda1`
 * `kubevirtci/k8s-multus-1.11.1:`: `sha256:ce7b961a449e20cf0628fba4deb90a8f399271659a0dd98eecdd249ec6c9d4b0`
 

--- a/k8s/scripts/nodes.sh
+++ b/k8s/scripts/nodes.sh
@@ -8,4 +8,16 @@ do
     sleep 2
 done
 
+# enable CPU manager
+echo Environment='"KUBELET_CPUMANAGER_ARGS=--feature-gates=CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m"' >> /etc/systemd/system/kubelet.service.d/09-kubeadm.conf
+sed -i 's/$KUBELET_EXTRA_ARGS/$KUBELET_EXTRA_ARGS $KUBELET_CPUMANAGER_ARGS/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+
+systemctl daemon-reload
+service kubelet restart
+kubelet_rc=$?
+if [[ $kubelet_rc -ne 0 ]]; then
+    rm -rf /var/lib/kubelet/cpu_manager_state
+    service kubelet restart
+fi
+
 kubeadm join --token abcdef.1234567890123456 192.168.66.101:6443 --ignore-preflight-errors=all --discovery-token-unsafe-skip-ca-verification=true

--- a/os-3.10/scripts/node01.sh
+++ b/os-3.10/scripts/node01.sh
@@ -74,3 +74,29 @@ done
 
 /usr/bin/oc create -f /tmp/local-volume.yaml
 
+# enable the CPU manager on compute nodes, besides master
+# updating it on the master as nodes cannot update comfigmaps
+
+sed -i 's/kubeletArguments:/kubeletArguments:\n  cpu-manager-policy:\n  - static\n  system-reserved:\n  - cpu=500m\n  kube-reserved:\n  - cpu=500m/' /etc/origin/node/node-config.yaml
+sed -i 's/feature-gates:/feature-gates:\n  - CPUManager=true/' /etc/origin/node/node-config.yaml
+
+/usr/bin/oc create cm node-config-compute -n openshift-node --from-file=/etc/origin/node/node-config.yaml -o yaml --dry-run |oc replace -f -
+
+cat >post_deployment_cpu_manager_config <<EOF
+- hosts: nodes, new_nodes
+  tasks:
+    - name: Clean cpu manager state
+      block:
+        - file:
+            state: absent
+            path: /var/lib/origin/openshift.local.volumes/cpu_manager_state
+        - service:
+            name: origin-node
+            state: restarted
+            enabled: yes
+EOF
+
+sleep 200
+
+ansible-playbook -i $inventory_file post_deployment_cpu_manager_config
+


### PR DESCRIPTION
Allow starting k8s CPU manager on any node besides master.
This is needed for testing features that uses k8s CPU manager

Signed-off-by: Vladik Romanovsky <vromanso@redhat.com>