### PR TITLE
Fix ASB not working properly for OS-3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@
 * `kubevirtci/centos:1804_02`: `sha256:70653d952edfb8002ab8efe9581d01960ccf21bb965a9b4de4775c8fbceaab39`
 * **Deprecated**: `kubevirtci/os-3.9.0:`: `sha256:234b3ae5c335c9fa32fa3bc01d5833f8f4d45420d82a8f8b12adc02687eb88b1`
 * **Deprecated**: `kubevirtci/os-3.9.0-crio:`: `sha256:107d03dad4da6957e28774b121a45e177f31d7b4ad43c6eab7b24d467e59e213`
-* `kubevirtci/os-3.10.0:`: `sha256:c0c929e28cb64a4391f2d1e612c7fdea11f162e57ead5e52b935b5d8e9b0e83d`
-* `kubevirtci/os-3.10.0-crio:`: `sha256:7ec0a18f2b29b31f8f2325e4c3a24761acbbe6541e63aa660d45a3d032e73656`
-* `kubevirtci/os-3.10.0-multus`: `sha256:4ddd2e946a0487a9df5192118cc5d52d77d3a0b4ec78cf44ba6b89d6aa784e8d`
+* `kubevirtci/os-3.10.0:`: `sha256:b026dba96571a6732171c45b1f9fbdbbb3c3bbb1aa2118e99e12368c15ffb6f6`
+* `kubevirtci/os-3.10.0-crio:`: `sha256:f79ae12ab7e0934c0786fcd08632c5b372163459b3e6c10aa85b329c1085e8e3`
+* `kubevirtci/os-3.10.0-multus`: `sha256:7254ea84efcf8ae12ea0a97cbf5f2118803197ca9edfb422efe32dc3c1332fa0`
 * **Deprecated**: `kubevirtci/k8s-1.9.3:`: `sha256:f6ffb23261fb8aa15ed45b8d17e1299e284ea75e1d2814ee6b4ec24ecea6f24b`
 * **Deprecated**: `kubevirtci/k8s-1.10.3:`: `sha256:d6290260e7e6b84419984f12719cf592ccbe327373b8df76aa0481f8ec01d357`
 * `kubevirtci/k8s-1.10.4:`: `sha256:c340a67190364b0e0c5864a8ce8edf38ccc35af6c4284a56118b2c38adf619cd`

--- a/os-3.10-multus/scripts/provision.sh
+++ b/os-3.10-multus/scripts/provision.sh
@@ -91,6 +91,7 @@ openshift_master_identity_providers=[{'name': 'allow_all_auth', 'login': 'true',
 openshift_disable_check=memory_availability,disk_availability,docker_storage,package_availability,docker_image_availability
 openshift_image_tag=v3.10.0-rc.0
 ansible_service_broker_registry_whitelist=['.*-apb$']
+ansible_service_broker_image=docker.io/ansibleplaybookbundle/origin-ansible-service-broker:ansible-service-broker-1.2.17-1
 openshift_hosted_etcd_storage_kind=nfs
 openshift_hosted_etcd_storage_nfs_options="*(rw,root_squash,sync,no_wdelay)"
 openshift_hosted_etcd_storage_nfs_directory=/opt/etcd-vol

--- a/os-3.10/scripts/provision.sh
+++ b/os-3.10/scripts/provision.sh
@@ -86,6 +86,7 @@ openshift_master_identity_providers=[{'name': 'allow_all_auth', 'login': 'true',
 openshift_disable_check=memory_availability,disk_availability,docker_storage,package_availability,docker_image_availability
 openshift_image_tag=v3.10.0-rc.0
 ansible_service_broker_registry_whitelist=['.*-apb$']
+ansible_service_broker_image=docker.io/ansibleplaybookbundle/origin-ansible-service-broker:ansible-service-broker-1.2.17-1
 openshift_hosted_etcd_storage_kind=nfs
 openshift_hosted_etcd_storage_nfs_options="*(rw,root_squash,sync,no_wdelay)"
 openshift_hosted_etcd_storage_nfs_directory=/opt/etcd-vol


### PR DESCRIPTION
- Due to a bug[1] in openshift-ansible, the default image of the ASB is
  latest, however for OS 3.10 that is not the correct image. This PR
  fixes this by defining the asb image to point to the latest for
  3.10.

[1] https://github.com/openshift/openshift-ansible/issues/9960

Signed-off-by: Alexander Wels <awels@redhat.com>