### PR TITLE
Pass --qemu-args as a single argument to vm.sh

### DIFF
--- a/gocli/cmd/run.go
+++ b/gocli/cmd/run.go
@@ -314,7 +314,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		volumes <- vol.Name
 
 		if len(qemu_args) > 0 {
-			qemu_args = "--qemu-args " + qemu_args
+			qemu_args = fmt.Sprintf("--qemu-args '%s'", qemu_args)
 		}
 		node, err := cli.ContainerCreate(ctx, &container.Config{
 			Image: cluster,


### PR DESCRIPTION
A lot of qemu arguments are comprised of multiple words, f.e.:

-device vfio-pci,...

We should pass them into vm.sh as a single argument.