### PR TITLE
Enable CustomResourceSubresources feature gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * `k8s-1.9.3` k8s-1.9.3 cluster based on the centos7 image, provisioned with kubeadm
 * `k8s-1.10.3` k8s-1.10.3 cluster based on the centos7 image, provisioned with kubeadm
 * `k8s-1.10.4` k8s-1.10.4 cluster based on the centos7 image, provisioned with kubeadm
+* `k8s-1.10.11` k8s-1.10.11 cluster based on the centos7 image, provisioned with kubeadm
 * `k8s-1.11.0` k8s-1.11.0 cluster based on the centos7 image, provisioned with kubeadm
 * `k8s-multus-1.10.4:`: k8s-1.10.4 cluster based on the centos7 image and uses multus CNI, provisioned with kubeadm
 * `k8s-multus-1.11.1:`: k8s-1.11.1 cluster based on the centos7 image and uses multus CNI, provisioned with kubeadm
@@ -36,7 +37,8 @@
 * `kubevirtci/os-3.11.0-crio:`: `sha256:3f11a6f437fcdf2d70de4fcc31e0383656f994d0d05f9a83face114ea7254bc0`
 * **Deprecated**: `kubevirtci/k8s-1.9.3:`: `sha256:f6ffb23261fb8aa15ed45b8d17e1299e284ea75e1d2814ee6b4ec24ecea6f24b`
 * **Deprecated**: `kubevirtci/k8s-1.10.3:`: `sha256:d6290260e7e6b84419984f12719cf592ccbe327373b8df76aa0481f8ec01d357`
-* `kubevirtci/k8s-1.10.4:`: `sha256:2ed70abfa8f6c30d990b76b816577040c0709258cbbd7c70f71a70d547f5544f`
+* **Deprecated**: `kubevirtci/k8s-1.10.4:`: `sha256:2ed70abfa8f6c30d990b76b816577040c0709258cbbd7c70f71a70d547f5544f`
+* `kubevirtci/k8s-1.10.11:`: `sha256:b97e556795a56b9aa1763ddf3a49322b49f96877dccb7a164bbca779df078536`
 * `kubevirtci/k8s-1.11.0:`: `sha256:e02ec414c7673a3644b5ba742b550a124c9195eaacb280151406bf9e8201a95f`
 * **Deprecated**: `kubevirtci/k8s-multus-1.10.4:`: `sha256:1d16d436347fcb9eba28cad08f6e074d4628e9a097a7325eb1ab87351e7f6d5c`
 * **Deprecated**: `kubevirtci/k8s-multus-1.11.1:`: `sha256:3d35b19105344e270be168920e98287fbefcd5366fdf78681712d05725204559`

--- a/k8s/1.10.11/README.md
+++ b/k8s/1.10.11/README.md
@@ -1,0 +1,91 @@
+# Example Cluster
+
+## Provisioning the cluster
+
+Running `cli` directly:
+
+```bash
+cli provision --scripts /scripts --base kubevirtci/centos:1804_02 --tag kubevirtci/k8s-1.10.11
+```
+
+Running `cli` from within docker:
+
+```bash
+docker run --privileged --rm -v ${PWD}/scripts/:/scripts/ -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli provision --scripts /scripts --base kubevirtci/centos:1804_02 --tag kubevirtci/k8s-1.10.11
+```
+
+## Run the cluster
+
+The cluster is self contained.
+
+Running `cli` directly:
+
+```bash
+cli run --nodes 2 --base kubevirtci/k8s-1.10.11
+```
+
+Running `cli` from within docker:
+
+```bash
+docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli:latest run --nodes 2 --base kubevirtci/k8s-1.10.11
+```
+
+`--background` can be added to the `run` subcommand to exit the script after
+the initial provisioning of all vms is done. If an error occures during the
+initialization, the whole cluster is toren down.
+
+## Expsosing host data via NFS
+
+In order to share huge files (e.g. images which are only present on CI),
+sharing via NFS is possible. If a directory is added via `--nfs-data` when
+invoking the `run` sub-command, an additional nfs server is started and the data
+can be accessed from within the VMs. The DNS name of the nfs server is `nfs`
+inside the the vms.
+
+```bash
+docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock -v /nfs/data:/nfs/data kubevirtci/cli:latest run --nfs-data /nfs/data --nodes 2 --base kubevirtci/k8s-1.10.11
+```
+
+Within the vm it can be mounted via
+
+```bash
+sudo mount -t nfs4 nfs:/ /mnt/nfs
+```
+
+It is also very conveninent to share this data via PVs with pods this way.
+
+## SSH into a running machine
+
+Running `cli` directly:
+
+```bash
+cli ssh node01
+```
+
+Running `cli` from within docker:
+
+```bash
+docker run --privileged --rm -it -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli:latest ssh node01 
+```
+## Stopping the cluster
+
+Running `cli` directly:
+
+```bash
+cli rm
+```
+
+Running `cli` from within docker:
+
+```bash
+docker run --privileged -it -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli:latest rm 
+```
+
+
+## Parallel execution
+
+By default all the created containers will have a `kubevirt-` prefix. This way,
+`cli` can detect containers which belong to it. In order to allow running
+multiple clusters in parallel, a different container prefix needs to be chosen.
+Every command from `cli` can be executed with `--prefix` flag to swich the
+cluster and allow parallel executions.

--- a/k8s/1.10.11/provision.sh
+++ b/k8s/1.10.11/provision.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+export version=1.10.11
+../provision.sh

--- a/k8s/1.10.11/publish.sh
+++ b/k8s/1.10.11/publish.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+export version=1.10.11
+../publish.sh

--- a/k8s/scripts/provision.sh
+++ b/k8s/scripts/provision.sh
@@ -32,7 +32,15 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
-yum install -y docker
+yum install -y \
+  docker-common-1.13.1-75.git8633870.el7.centos.x86_64 \
+  origin-docker-excluder-3.11.0-1.el7.git.0.62803d0.noarch \
+  python-docker-py-1.10.6-4.el7.noarch \
+  docker-client-1.13.1-75.git8633870.el7.centos.x86_64 \
+  cockpit-docker-176-2.el7.centos.x86_64 \
+  docker-1.13.1-75.git8633870.el7.centos.x86_64 \
+  python-docker-pycreds-1.10.6-4.el7.noarch
+
 
 # Log to json files instead of journald
 sed -i 's/--log-driver=journald //g' /etc/sysconfig/docker
@@ -87,9 +95,9 @@ echo br_netfilter >> /etc/modules
 kubeadm init --pod-network-cidr=10.244.0.0/16 --kubernetes-version v${version} --token abcdef.1234567890123456
 kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
 
-# Wait at least for one pod
-while [ -z "$(kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods -n kube-system | grep kube)" ]; do
-    echo "Waiting for at least one pod ..."
+# Wait at least for 7 pods
+while [[ "$(kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods -n kube-system --no-headers | wc -l)" -lt 7 ]]; do
+    echo "Waiting for at least 7 pods to appear ..."
     kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods -n kube-system
     sleep 10
 done

--- a/k8s/scripts/provision.sh
+++ b/k8s/scripts/provision.sh
@@ -130,7 +130,7 @@ apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
 apiServerExtraArgs:
   runtime-config: admissionregistration.k8s.io/v1alpha1
-  ${admission_flag}: Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
+  ${admission_flag}: Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,CustomResourceSubresources
   feature-gates: "BlockVolume=true"
 controllerManagerExtraArgs:
   feature-gates: "BlockVolume=true"


### PR DESCRIPTION
Needs to be enabled for any cluster which we still use which is prior to
ck8s 1.11 or 3.11.

Allows using the status endpoint for our CRDs to not allow kubevirt
users to override the status section by accident or intentionally.