### PR TITLE
Enable user namespaces. This configuration is required by buildah.

### DIFF
--- a/k8s-genie/scripts/provision.sh
+++ b/k8s-genie/scripts/provision.sh
@@ -13,6 +13,9 @@ sed -i '/ swap / s/^/#/' /etc/fstab
 sed -i 's/quiet"/quiet spectre_v2=off nopti hugepagesz=2M hugepages=64"/' /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
 
+# Allow user namespaces
+sysctl -w user.max_user_namespaces=1024
+
 systemctl stop firewalld NetworkManager || :
 systemctl disable firewalld NetworkManager || :
 # Make sure the firewall is never enabled again

--- a/k8s-multus/scripts/provision.sh
+++ b/k8s-multus/scripts/provision.sh
@@ -13,6 +13,9 @@ sed -i '/ swap / s/^/#/' /etc/fstab
 sed -i 's/quiet"/quiet spectre_v2=off nopti hugepagesz=2M hugepages=64"/' /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
 
+# Allow user namespaces
+sysctl -w user.max_user_namespaces=1024
+
 systemctl stop firewalld NetworkManager || :
 systemctl disable firewalld NetworkManager || :
 # Make sure the firewall is never enabled again

--- a/k8s/scripts/provision.sh
+++ b/k8s/scripts/provision.sh
@@ -13,6 +13,9 @@ sed -i '/ swap / s/^/#/' /etc/fstab
 sed -i 's/quiet"/quiet spectre_v2=off nopti hugepagesz=2M hugepages=64"/' /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
 
+# Allow user namespaces
+sysctl -w user.max_user_namespaces=1024
+
 systemctl stop firewalld NetworkManager || :
 systemctl disable firewalld NetworkManager || :
 # Make sure the firewall is never enabled again

--- a/os-3.11-multus/scripts/provision.sh
+++ b/os-3.11-multus/scripts/provision.sh
@@ -46,6 +46,9 @@ grub2-mkconfig -o /boot/grub2/grub.cfg
 
 echo '{ "insecure-registries" : ["registry:5000"] }' > /etc/docker/daemon.json
 
+# Allow user namespaces
+sysctl -w user.max_user_namespaces=1024
+
 systemctl start docker
 systemctl enable docker
 

--- a/os-3.11/scripts/provision.sh
+++ b/os-3.11/scripts/provision.sh
@@ -46,6 +46,9 @@ grub2-mkconfig -o /boot/grub2/grub.cfg
 
 echo '{ "insecure-registries" : ["registry:5000"] }' > /etc/docker/daemon.json
 
+# Allow user namespaces
+sysctl -w user.max_user_namespaces=1024
+
 systemctl start docker
 systemctl enable docker
 


### PR DESCRIPTION
In order to use buildah tool, it is required to enable max_user_namespaces on cluster node. 
