### PR TITLE
Added os-3.11.0-multus-sriov provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 * `os-3.11.0` os-3.11.0 cluster based on the centos7 image, provisioned with openshift-ansible
 * `os-3.11-crio` os-3.11 cluster with CRI-O support based on the centos7 image, provisioned
 * `os-3.11-multus` os-3.11 cluster with multus cni support based on the centos7 image, provisioned with openshift-ansible
+* `os-3.11-multus-sriov` os-3.11 cluster with multus and sriov cni support based on the centos7 image, provisioned with openshift-ansible
 
 ## Versions to use
 
@@ -32,6 +33,7 @@
 * **Deprecated**: `kubevirtci/os-3.10.0-crio:`: `sha256:56debd7bc2ce87dd616ebc30f06971e388b6983c0cda8646a7563e1dafadb69b`
 * **Deprecated**: `kubevirtci/os-3.10.0-multus`: `sha256:875c973099141ab2013aaf51ec2b35b5326be943ef1437e4a87e041405e724ca`
 * `kubevirtci/os-3.11.0-multus`: `sha256:46155f973cb4637be5f73cf0307bb09e4caf5c66bd921cf5d1988db2598a8995`
+* `kubevirtci/os-3.11.0-multus-sriov`: `sha256:7141ff31cc9d044dd52a9362e37c592ec4a820fb954349df34f689bf8a656b6b`
 * `kubevirtci/os-3.11.0:`: `sha256:2d0a8f59dfebe181f550c4fbcd90d491a56a7d642d761c32a3c7732644325c0b`
 * `kubevirtci/os-3.11.0-crio:`: `sha256:3f11a6f437fcdf2d70de4fcc31e0383656f994d0d05f9a83face114ea7254bc0`
 * **Deprecated**: `kubevirtci/k8s-1.9.3:`: `sha256:f6ffb23261fb8aa15ed45b8d17e1299e284ea75e1d2814ee6b4ec24ecea6f24b`

--- a/manifests/cni-plugins-ds.yaml
+++ b/manifests/cni-plugins-ds.yaml
@@ -23,7 +23,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cni-plugins
-        image: quay.io/schseba/cni-plugins@sha256:e76ae2b1f393ea9056d9964c8664647f1c4afafcc0bfd949aacdc32f30b7b779
+        image: quay.io/schseba/cni-plugins@sha256:868a233a03b856d7edf03937507b61fac0e4057c7c2cea1f50744a647e9d0501
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/manifests/sriov-cni.yaml
+++ b/manifests/sriov-cni.yaml
@@ -1,17 +1,18 @@
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: ovs-cni-plugin-amd64
+  name: kube-sriov-cni-amd64
   namespace: kube-system
   labels:
     tier: node
-    app: ovs-cni
+    app: sriov-cni
 spec:
   template:
     metadata:
       labels:
         tier: node
-        app: ovs-cni
+        app: sriov-cni
     spec:
       hostNetwork: true
       nodeSelector:
@@ -21,9 +22,10 @@ spec:
         operator: Exists
         effect: NoSchedule
       containers:
-      - name: ovs-cni-plugin
-        image: quay.io/kubevirt/ovs-cni-plugin@sha256:66225e9eb1eae46a0dd9ce52b216ee856e9f495d94eda65967d6d92ae52956f2
-        imagePullPolicy: IfNotPresent
+      - name: kube-sriov-cni
+        image: docker.io/nfvpe/sriov-cni:latest
+        securityContext:
+          privileged: true
         resources:
           requests:
             cpu: "100m"
@@ -31,8 +33,6 @@ spec:
           limits:
             cpu: "100m"
             memory: "50Mi"
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: cnibin
           mountPath: /host/opt/cni/bin

--- a/manifests/sriov-crd.yaml
+++ b/manifests/sriov-crd.yaml
@@ -1,0 +1,20 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net
+  namespace: kube-system
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
+spec:
+  config: '{
+  "type": "sriov",
+  "name": "sriov",
+  "ipam": {
+    "type": "host-local",
+    "subnet": "10.56.217.0/24",
+    "routes": [{
+      "dst": "0.0.0.0/0"
+    }],
+    "gateway": "10.56.217.1"
+  }
+}'

--- a/manifests/sriovdp.yaml
+++ b/manifests/sriovdp.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-device-plugin
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: sriovdp
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+        image: quay.io/booxter/sriov-device-plugin:latest
+        args:
+        - --log-level=10
+        securityContext:
+          privileged: false
+          seLinuxOptions:
+            type: "spc_t"
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/device-plugins/
+          readOnly: false
+        - name: sysfs
+          mountPath: /sys
+          readOnly: true
+        - name: config
+          mountPath: /etc/pcidp/config.json
+          readOnly: true
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/device-plugins/
+        - name: sysfs
+          hostPath:
+            path: /sys
+        - name: config
+          hostPath:
+            path: /etc/pcidp/config.json

--- a/os-3.11-multus-sriov/provision.sh
+++ b/os-3.11-multus-sriov/provision.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+../cli/cli provision --prefix os-3.11-multus-sriov-provision --memory 5120M --scripts ./scripts --base kubevirtci/centos@sha256:70653d952edfb8002ab8efe9581d01960ccf21bb965a9b4de4775c8fbceaab39 --tag kubevirtci/os-3.11.0-multus-sriov

--- a/os-3.11-multus-sriov/publish.sh
+++ b/os-3.11-multus-sriov/publish.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker tag kubevirtci/os-3.11.0-multus-sriov:latest docker.io/kubevirtci/os-3.11.0-multus-sriov:latest
+docker push docker.io/kubevirtci/os-3.11.0-multus-sriov:latest

--- a/os-3.11-multus-sriov/scripts/logging.sh
+++ b/os-3.11-multus-sriov/scripts/logging.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -xe
+
+oc new-project logging
+oc project logging
+oc adm policy add-scc-to-user privileged system:serviceaccount:logging:fluentd
+oc adm policy add-cluster-role-to-user cluster-reader system:serviceaccount:logging:fluentd
+oc patch namespace kube-system -p '{"metadata": {"annotations": {"openshift.io/node-selector": ""}}}'
+oc apply -f /tmp/logging.yaml

--- a/os-3.11-multus-sriov/scripts/node01.sh
+++ b/os-3.11-multus-sriov/scripts/node01.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -x
+
+inventory_file="/root/inventory"
+openshift_ansible="/root/openshift-ansible"
+
+# Update inventory
+nodes_found=0
+for i in $(seq 2 100); do
+  node=$(printf "node%02d" ${i})
+  node_ip=$(printf "192.168.66.1%02d" ${i})
+  set +e
+  ping ${node_ip} -c 1
+  if [ $? -ne 0 ]; then
+      break
+  fi
+  echo "Found ${node}. Adding it to inventory and hosts files."
+  # add after first "hosts:" line
+  sed -i "0,/hosts:/{s//hosts:\n        ${node}:\n          openshift_ip: $node_ip\n          openshift_node_group_name: node-config-compute-kubevirt\n          openshift_schedulable: true/}" $inventory_file
+  echo "$node_ip $node" >> /etc/hosts
+  let "nodes_found++"
+done
+
+# Run playbook if extra nodes were discovered
+if [ "$nodes_found" -gt 0 ]; then
+  # first modify inventory: add new_nodes to OSEv3 children (which is the first children line prefixed with 6 spaces)
+  let last_node_nr=nodes_found+1
+  last_node_nr=$(printf "%02d" ${last_node_nr})
+  sed -i "0,/      children:/{s//      children:\n        new_nodes:\n          hosts:\n            node[02:${last_node_nr}]:/}" $inventory_file
+  ansible-playbook -i $inventory_file $openshift_ansible/playbooks/openshift-node/scaleup.yml
+fi
+
+set +e
+crio=false
+grep crio $inventory_file
+if [ $? -eq 0 ]; then
+  crio=true
+fi
+set -e
+
+cat >post_deployment_configuration <<EOF
+- hosts: nodes, new_nodes
+  tasks:
+    - name: Configure CRI-O support
+      block:
+        - replace:
+            path: /etc/crio/crio.conf
+            regexp: 'insecure_registries = \[\n""\n\]'
+            replace: 'insecure_registries = ["docker.io", "registry:5000"]'
+        - replace:
+            path: /etc/crio/crio.conf
+            regexp: 'registries = \[\n"docker.io"\n\]'
+            replace: 'registries = ["docker.io", "registry:5000"]'
+        - service:
+            name: cri-o
+            state: restarted
+            enabled: yes
+      when: crio
+    - name: Clean cpu manager state
+      block:
+        - file:
+            state: absent
+            path: /var/lib/origin/openshift.local.volumes/cpu_manager_state
+        - service:
+            name: origin-node
+            state: restarted
+            enabled: yes
+
+EOF
+ansible-playbook -i $inventory_file post_deployment_configuration --extra-vars="crio=${crio}"
+
+# Wait for api server to be up.
+set -x
+set +e
+/usr/bin/oc get nodes --no-headers
+os_rc=$?
+retry_counter=0
+while [[ $retry_counter -lt 20  && $os_rc -ne 0 ]]; do
+    sleep 10
+    echo "Waiting for api server to be available..."
+    /usr/bin/oc get nodes --no-headers
+    os_rc=$?
+    retry_counter=$((retry_counter + 1))
+done
+set -e
+
+# Remove the multus pod to recreate it.
+# openshift-sdn remove the content of the cni folder on restart.
+# Needs to recreate the multus cni config after the openshift-sdn is up.
+oc -n kube-system delete po `oc get po -n kube-system | grep kube-multus-ds | awk '{print $1}'`
+oc -n kube-system delete po `oc get po -n kube-system | grep kube-cni-plugins | awk '{print $1}'`
+oc -n kube-system delete po `oc get po -n kube-system | grep kube-sriov-cni | awk '{print $1}'`
+oc -n kube-system delete po `oc get po -n kube-system | grep ovs-cni-plugin | awk '{print $1}'`
+oc -n kube-system delete po `oc get po -n kube-system | grep ovs-vsctl-amd64 | awk '{print $1}'`
+
+/usr/bin/oc create -f /tmp/local-volume.yaml

--- a/os-3.11-multus-sriov/scripts/nodes.sh
+++ b/os-3.11-multus-sriov/scripts/nodes.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+systemctl stop origin-node.service
+rm -rf /etc/origin/ /etc/etcd/ /var/lib/origin /var/lib/etcd/
+
+containers="$(docker ps -q)"
+if [ -n "$containers" ]; then
+  docker stop $containers
+fi
+
+containers="$(docker ps -q -a)"
+if [ -n "$containers" ]; then
+  docker rm -f $containers
+fi

--- a/os-3.11-multus-sriov/scripts/provision.sh
+++ b/os-3.11-multus-sriov/scripts/provision.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+
+set -ex
+
+# Install epel
+yum -y install epel-release
+
+# Install storage requirements for iscsi and cluster
+yum -y install centos-release-gluster
+yum -y install --nogpgcheck -y glusterfs-fuse
+yum -y install iscsi-initiator-utils
+
+# Create Origin latest repo, enter correct repository address
+cat >/etc/yum.repos.d/origin-311.repo <<EOF
+[origin-311]
+name=Origin packages v3.11.0
+baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin311/
+enabled=1
+gpgcheck=0
+EOF
+
+# Install OpenShift packages
+yum install -y ansible \
+  wget \
+  git \
+  net-tools \
+  bind-utils \
+  yum-utils \
+  iptables-services \
+  bridge-utils \
+  bash-completion \
+  kexec-tools \
+  sos \
+  psacct \
+  docker-common-1.13.1-75.git8633870.el7.centos.x86_64 \
+  origin-docker-excluder-3.11.0-1.el7.git.0.62803d0.noarch \
+  python-docker-py-1.10.6-4.el7.noarch \
+  docker-client-1.13.1-75.git8633870.el7.centos.x86_64 \
+  cockpit-docker-176-2.el7.centos.x86_64 \
+  docker-1.13.1-75.git8633870.el7.centos.x86_64 \
+  python-docker-pycreds-1.10.6-4.el7.noarch
+
+# Disable spectre and meltdown patches
+sed -i 's/quiet"/quiet spectre_v2=off nopti hugepagesz=2M hugepages=64"/' /etc/default/grub
+grub2-mkconfig -o /boot/grub2/grub.cfg
+
+echo '{ "insecure-registries" : ["registry:5000"] }' > /etc/docker/daemon.json
+
+systemctl start docker
+systemctl enable docker
+
+dnsmasq_ip="192.168.66.2"
+echo "$dnsmasq_ip nfs" >> /etc/hosts
+echo "$dnsmasq_ip registry" >> /etc/hosts
+
+# Allow connecting to ssh via password
+sed -i -e "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config
+systemctl restart sshd
+
+# Disable host key checking under ansible.cfg file
+sed -i '/host_key_checking/s/^#//g' /etc/ansible/ansible.cfg
+
+openshift_ansible="/root/openshift-ansible"
+inventory_file="/root/inventory"
+master_ip="192.168.66.101"
+echo "$master_ip node01" >> /etc/hosts
+
+git clone https://github.com/openshift/openshift-ansible.git -b v3.11.0 --depth 1 $openshift_ansible
+
+# Apply fix https://github.com/openshift/openshift-ansible/pull/10459
+# TODO: remove it when the fix will be available under the v3.11.0 tag
+sed -i 's/python-docker/python-docker-py/' $openshift_ansible/playbooks/init/base_packages.yml
+
+# Create ansible inventory file
+cat >$inventory_file <<EOF
+all:
+  vars:
+    olm_operator_image: quay.io/coreos/olm:master-08ea39b7
+    olm_catalog_operator_image: quay.io/coreos/catalog:master-57dd618d
+  children:
+    OSEv3:
+      hosts:
+        node01:
+          openshift_ip: $master_ip
+          openshift_node_group_name: node-config-master-infra-kubevirt
+          openshift_schedulable: true
+      children:
+        masters:
+          hosts:
+            node01:
+        nodes:
+          hosts:
+            node01:
+        nfs:
+          hosts:
+            node01:
+        etcd:
+          hosts:
+            node01:
+      vars:
+        ansible_service_broker_registry_whitelist:
+        - .*-apb$
+        ansible_service_broker_image: docker.io/ansibleplaybookbundle/origin-ansible-service-broker:ansible-service-broker-1.2.17-1
+        ansible_ssh_pass: vagrant
+        ansible_ssh_user: root
+        deployment_type: origin
+        openshift_clock_enabled: true
+        openshift_deployment_type: origin
+        openshift_disable_check: memory_availability,disk_availability,docker_storage,package_availability,docker_image_availability
+        openshift_hosted_etcd_storage_access_modes:
+        - ReadWriteOnce
+        openshift_hosted_etcd_storage_kind: nfs
+        openshift_hosted_etcd_storage_labels:
+          storage: etcd
+        openshift_hosted_etcd_storage_nfs_directory: /opt/etcd-vol
+        openshift_hosted_etcd_storage_nfs_options: '*(rw,root_squash,sync,no_wdelay)'
+        openshift_hosted_etcd_storage_volume_name: etcd-vol
+        openshift_hosted_etcd_storage_volume_size: 1G
+        openshift_image_tag: v3.11.0
+        os_sdn_network_plugin_name: redhat/openshift-ovs-networkpolicy
+        openshift_master_admission_plugin_config:
+          MutatingAdmissionWebhook:
+            configuration:
+              apiVersion: v1
+              disable: false
+              kind: DefaultAdmissionConfig
+          ValidatingAdmissionWebhook:
+            configuration:
+              apiVersion: v1
+              disable: false
+              kind: DefaultAdmissionConfig
+        openshift_master_identity_providers:
+        - challenge: 'true'
+          kind: AllowAllPasswordIdentityProvider
+          login: 'true'
+          name: allow_all_auth
+        osm_api_server_args:
+          feature-gates:
+          - BlockVolume=true
+        osm_controller_args:
+          feature-gates:
+          - BlockVolume=true
+        openshift_node_groups:
+        - name: node-config-master-infra-kubevirt
+          labels:
+          - node-role.kubernetes.io/master=true
+          - node-role.kubernetes.io/infra=true
+          - node-role.kubernetes.io/compute=true
+          edits:
+          - key: kubeletArguments.feature-gates
+            value:
+            - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,BlockVolume=true
+          - key: kubeletArguments.max-pods
+            value:
+            - '40'
+          - key: kubeletArguments.pods-per-core
+            value:
+            - '40'
+        - name: node-config-compute-kubevirt
+          labels:
+          - node-role.kubernetes.io/compute=true
+          edits:
+          - key: kubeletArguments.feature-gates
+            value:
+            - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,BlockVolume=true,CPUManager=true
+          - key: kubeletArguments.cpu-manager-policy
+            value:
+            - static
+          - key: kubeletArguments.system-reserved
+            value:
+            - cpu=500m
+          - key: kubeletArguments.kube-reserved
+            value:
+            - cpu=500m
+          - key: kubeletArguments.max-pods
+            value:
+            - '40'
+          - key: kubeletArguments.pods-per-core
+            value:
+            - '40'
+EOF
+
+# Add cri-o variable to inventory file
+if [[ $1 == "true" ]]; then
+    sed -i "s/    vars\:/    vars\:\n        openshift_use_crio: 'true'/" $inventory_file
+fi
+
+# Install prerequisites
+ansible-playbook -e "ansible_user=root ansible_ssh_pass=vagrant" -i $inventory_file $openshift_ansible/playbooks/prerequisites.yml
+ansible-playbook -i $inventory_file $openshift_ansible/playbooks/deploy_cluster.yml
+# Install OLM
+ansible-playbook -i $inventory_file $openshift_ansible/playbooks/olm/config.yml
+
+# Create OpenShift user
+/usr/bin/oc create user admin
+/usr/bin/oc create identity allow_all_auth:admin
+/usr/bin/oc create useridentitymapping allow_all_auth:admin admin
+/usr/bin/oc adm policy add-cluster-role-to-user cluster-admin admin
+
+# Create local-volume directories
+for i in {1..10}
+do
+  mkdir -p /var/local/kubevirt-storage/local-volume/disk${i}
+  mkdir -p /mnt/local-storage/local/disk${i}
+  echo "/var/local/kubevirt-storage/local-volume/disk${i} /mnt/local-storage/local/disk${i} none defaults,bind 0 0" >> /etc/fstab
+done
+chmod -R 777 /var/local/kubevirt-storage/local-volume
+
+# Setup selinux permissions to local volume directories.
+chcon -R unconfined_u:object_r:svirt_sandbox_file_t:s0 /mnt/local-storage/
+# Add privileged to local volume provision service account
+/usr/bin/oc adm policy add-scc-to-user privileged -z local-storage-admin
+
+# Pre pull fluentd image used in logging
+docker pull docker.io/fluent/fluentd:v1.2-debian
+docker pull fluent/fluentd-kubernetes-daemonset:v1.2-debian-syslog
+
+/usr/bin/oc create -f /tmp/openshift-multus.yaml
+/usr/bin/oc create -f /tmp/cni-plugins-ds.yaml
+/usr/bin/oc create -f /tmp/ovs.yaml
+/usr/bin/oc create -f /tmp/openshift-ovs-vsctl.yaml
+
+# create empty file; when deploying, one needs to update rootDevices and
+# restart device plugin pod for PF allocation pool update to take effect
+mkdir -p /etc/pcidp
+cat >/etc/pcidp/config.json <<EOF
+{
+    "resourceList":
+    [
+        {
+            "resourceName": "sriov",
+            "rootDevices": [],
+            "sriovMode": true,
+            "deviceType": "vfio"
+        }
+    ]
+}
+EOF
+
+# create the rest of sriov daemons
+/usr/bin/oc create -f /tmp/sriov-cni.yaml
+/usr/bin/oc create -f /tmp/sriov-crd.yaml
+/usr/bin/oc create -f /tmp/sriovdp.yaml
+
+# Wait before checking the pod status.
+# Give time to the scheduler to create the pods.
+sleep 10
+
+while [[ $(/usr/bin/oc get po -n kube-system --no-headers | grep -v Running | wc -l) -ne 0 ]]
+do
+    echo "Waiting for all the containers to be running"
+    sleep 5
+done
+
+# Wait for the daemonset to create the ovs file
+while  [ ! -f /usr/bin/ovs-vsctl ]
+do
+    echo "ovs-vsctl not found!"
+    sleep 5
+done
+
+# Create a bridge for the tests
+ovs-vsctl add-br br1

--- a/provisionAndPublishAll.sh
+++ b/provisionAndPublishAll.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-IMAGES="k8s/1.10.4 k8s/1.11.0 k8s-multus/1.10.4 k8s-multus/1.11.1 os-3.10 os-3.10-crio os-3.10-multus"
+IMAGES="k8s/1.10.4 k8s/1.11.0 k8s-multus/1.10.4 k8s-multus/1.11.1 os-3.10 os-3.10-crio os-3.10-multus os-3.11-multus-sriov"
 LOG=`pwd`/log.txt
 
 echo


### PR DESCRIPTION
This provider is based on regular os-3.11-multus provider. It deploys SR-IOV
components (CNI, DP with config file, sriov network attachment) on top.

Note that when deploying from this image, to make SR-IOV device plugin to
allocate VFs from PFs available on the node, one should list PF addresses in
/etc/pcidp/config.json and then restart sriov device plugin pods.