### PR TITLE
Fixed enabling of CustomResourceSubresources feature-gate

### DIFF
--- a/k8s/scripts/provision.sh
+++ b/k8s/scripts/provision.sh
@@ -138,8 +138,8 @@ apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
 apiServerExtraArgs:
   runtime-config: admissionregistration.k8s.io/v1alpha1
-  ${admission_flag}: Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,CustomResourceSubresources
-  feature-gates: "BlockVolume=true"
+  ${admission_flag}: Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
+  feature-gates: "BlockVolume=true,CustomResourceSubresources=true"
 controllerManagerExtraArgs:
   feature-gates: "BlockVolume=true"
 token: abcdef.1234567890123456


### PR DESCRIPTION
This is a bit strange:

- the code which was committed with https://github.com/kubevirt/kubevirtci/pull/49 doesn't work (CustomResourceSubresources is a feature-gate, and no admission plugin). A cluster built from that code doesn't start, because apiserver fails
- but the k8s 1.10.11 docker image which was pushed with that PR is correct, the feature gate is enabled (I checked the apiserver logs). So no need to push new images with this PR

Signed-off-by: Marc Sluiter <msluiter@redhat.com>