### PR TITLE
option added to set docker daemon proxy setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## Versions to use
 
 * `kubevirtci/cli`: `sha256:1dd015dea4f12e6dcb8e31be3eeb677fed96f290ef4a4892a33c43d666053536`
-* `kubevirtci/gocli`: `sha256:fa7f615a1b07925b27027c57bf09bba0e9874ca92e4f67559556950665598c49`
+* `kubevirtci/gocli`: `sha256:837ab7fff4e00d74ad9d6b8952c79dbf3df1db380da1fc13a87df34d70745003`
 * `kubevirtci/base`: `sha256:034de1a154409d87498050ccc281d398ce1a0fed32efdbd66d2041a99a46b322`
 * `kubevirtci/centos:1804_02`: `sha256:70653d952edfb8002ab8efe9581d01960ccf21bb965a9b4de4775c8fbceaab39`
 * **Deprecated**: `kubevirtci/os-3.9.0:`: `sha256:234b3ae5c335c9fa32fa3bc01d5833f8f4d45420d82a8f8b12adc02687eb88b1`


### PR DESCRIPTION
   
    --docker-proxy option added to gocli run command.
    This helps to set proxy setting for docker daemon
    without rebuilding of base VM image.
    
Fixes https://github.com/kubevirt/kubevirtci/issues/69 along with https://github.com/kubevirt/kubevirtci/pull/71

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>