### PR TITLE
Increase pods per node to 110 on openshift

### DIFF
--- a/cluster-provision/os-3.11-multus/scripts/provision.sh
+++ b/cluster-provision/os-3.11-multus/scripts/provision.sh
@@ -161,10 +161,10 @@ all:
             - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,BlockVolume=true
           - key: kubeletArguments.max-pods
             value:
-            - '60'
+            - '110'
           - key: kubeletArguments.pods-per-core
             value:
-            - '60'
+            - '110'
         - name: node-config-compute-kubevirt
           labels:
           - node-role.kubernetes.io/compute=true
@@ -183,10 +183,10 @@ all:
             - cpu=500m
           - key: kubeletArguments.max-pods
             value:
-            - '60'
+            - '110'
           - key: kubeletArguments.pods-per-core
             value:
-            - '60'
+            - '110'
 EOF
 
 mkdir -p /etc/origin/master

--- a/cluster-provision/os-3.11/scripts/provision.sh
+++ b/cluster-provision/os-3.11/scripts/provision.sh
@@ -156,10 +156,10 @@ all:
             - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,BlockVolume=true
           - key: kubeletArguments.max-pods
             value:
-            - '40'
+            - '110'
           - key: kubeletArguments.pods-per-core
             value:
-            - '40'
+            - '110'
         - name: node-config-compute-kubevirt
           labels:
           - node-role.kubernetes.io/compute=true
@@ -178,10 +178,10 @@ all:
             - cpu=500m
           - key: kubeletArguments.max-pods
             value:
-            - '40'
+            - '110'
           - key: kubeletArguments.pods-per-core
             value:
-            - '40'
+            - '110'
 EOF
 
 mkdir -p /etc/origin/master

--- a/cluster-up/cluster/os-3.11.0-crio/provider.sh
+++ b/cluster-up/cluster/os-3.11.0-crio/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source ${KUBEVIRTCI_PATH}/cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-crio@sha256:5eb4a00c89a9dcadccd3360a43973ac38897511260ce192598d6d8731c0c3e7a"
+image="os-3.11.0-crio@sha256:862be28595834f8fa686f4f77869ee0ca051ef612fc66b4728034ac786a1a67f"

--- a/cluster-up/cluster/os-3.11.0-multus/provider.sh
+++ b/cluster-up/cluster/os-3.11.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source ${KUBEVIRTCI_PATH}/cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-multus@sha256:f8de6bda57209553e1a9e428dca1432270b7db0e5206376898b93aea64afd053"
+image="os-3.11.0-multus@sha256:ffd92718c888645e0a55f750a7c9091eefc17c850e09b1490ad0fc9425c88459"

--- a/cluster-up/cluster/os-3.11.0/provider.sh
+++ b/cluster-up/cluster/os-3.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="os-3.11.0@sha256:527daa78a9e460053925a862324f67390d45ffacaf26fe3fd5a6dc20a7892534"
+image="os-3.11.0sha256:812068b83cdda9fcf53386009faa10b8fcb40ccf733cc968f1b8e40c99808d00"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 


### PR DESCRIPTION
Openshift + Kubevirt alone consists of roughly 40 pods already. There are tests in kubevirt which can fail because of scheduling issues if we don't give it more pods.