### PR TITLE
Kubernetes 1.13.3 provider with cluster-network-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 * **Deprecated**: `kubevirtci/k8s-multus-1.10.4:`: `sha256:1d16d436347fcb9eba28cad08f6e074d4628e9a097a7325eb1ab87351e7f6d5c`
 * **Deprecated**: `kubevirtci/k8s-multus-1.11.1:`: `sha256:3d35b19105344e270be168920e98287fbefcd5366fdf78681712d05725204559`
 * **Deprecated**: `kubevirtci/k8s-multus-1.12.2:`: `sha256:d3ebf4a59ed379e59552ce8165596ade121d32e6b8782c192ff4f29863547c78`
-* `kubevirtci/k8s-multus-1.13.3:`: `sha256:75a4433cee49381d1715dcb7fff6599754614d6fc815826a48645621f7fc0ce6`
+* `kubevirtci/k8s-multus-1.13.3:`: `sha256:8418163abbc4acddefa26a63706446af9fd67aab20388a5e8d453cff0c0169f1`
 * `kubevirtci/k8s-genie-1.11.1:`: `sha256:f1e2e729302bc0f2d4a176807f36c02b44c62605ad80d10249bb85682433b3a4`
 
 ## Using gocli

--- a/cli/cli
+++ b/cli/cli
@@ -188,6 +188,8 @@ if [ "$COMMAND" == "provision" ] ; then
   docker exec ${VM_CID} /bin/bash -c "scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i vagrant.key -P 22 /manifests/*.yaml vagrant@192.168.66.101:/tmp"
   docker exec ${VM_CID} /bin/bash -c "ssh.sh mkdir -p /tmp/ceph"
   docker exec ${VM_CID} /bin/bash -c "scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i vagrant.key -P 22 /manifests/ceph/*.yaml vagrant@192.168.66.101:/tmp/ceph"
+  docker exec ${VM_CID} /bin/bash -c "ssh.sh mkdir -p /tmp/cna"
+  docker exec ${VM_CID} /bin/bash -c "scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i vagrant.key -P 22 /manifests/cna/*.yaml vagrant@192.168.66.101:/tmp/cna"
   docker exec ${VM_CID} /bin/bash -c "ssh.sh sudo version=${K8S_VERSION} /bin/bash -s ${CRIO} < /scripts/provision.sh"
   docker exec ${VM_CID} ssh.sh "sudo shutdown -h"
   docker exec ${VM_CID} /bin/bash -c "rm /usr/local/bin/ssh.sh"

--- a/k8s-multus/scripts/node01.sh
+++ b/k8s-multus/scripts/node01.sh
@@ -17,13 +17,18 @@ else
 kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/flannel.yaml
 fi
 
-kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/kubernetes-multus.yaml
-kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/multus.yaml
-
-kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/cni-plugins-ds.yaml
-kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/kubernetes-ovs-cni.yaml
-
 kubectl --kubeconfig=/etc/kubernetes/admin.conf taint nodes node01 node-role.kubernetes.io/master:NoSchedule-
+
+kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/cna/namespace.yaml
+kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/cna/network-addons-config.crd.yaml
+kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/cna/operator.yaml
+kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/cna/network-addons-config-example.cr.yaml
+
+# Wait until flannel cluster-network-addons-operator and core dns pods are running.
+# Wait until all the network components are ready.
+kubectl --kubeconfig=/etc/kubernetes/admin.conf wait networkaddonsconfig cluster --for condition=Ready --timeout=800s
+
+kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/kubernetes-ovs-cni.yaml
 
 # Wait for api server to be up.
 kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes --no-headers

--- a/k8s-multus/scripts/provision.sh
+++ b/k8s-multus/scripts/provision.sh
@@ -93,10 +93,18 @@ else
 kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/flannel.yaml
 fi
 
-kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/kubernetes-multus.yaml
-kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/multus.yaml
+# we need this command to allow the cluster-network-addons-operator to start and deploy all the requested components
+kubectl --kubeconfig=/etc/kubernetes/admin.conf taint nodes node01 node-role.kubernetes.io/master:NoSchedule-
 
-kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/cni-plugins-ds.yaml
+kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/cna/namespace.yaml
+kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/cna/network-addons-config.crd.yaml
+kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/cna/operator.yaml
+kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/cna/network-addons-config-example.cr.yaml
+
+# Wait until flannel cluster-network-addons-operator and core dns pods are running.
+# Wait until all the network components are ready.
+kubectl --kubeconfig=/etc/kubernetes/admin.conf wait networkaddonsconfig cluster --for condition=Ready --timeout=800s
+
 kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/kubernetes-ovs-cni.yaml
 
 # Wait at least for one pod

--- a/manifests/cna/namespace.yaml
+++ b/manifests/cna/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-network-addons-operator
+  labels:
+    name: cluster-network-addons-operator

--- a/manifests/cna/network-addons-config-example.cr.yaml
+++ b/manifests/cna/network-addons-config-example.cr.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1
+kind: NetworkAddonsConfig
+metadata:
+  name: cluster
+spec:
+  imagePullPolicy: Always
+  kubeMacPool: {}
+  linuxBridge: {}
+  multus: {}

--- a/manifests/cna/network-addons-config.crd.yaml
+++ b/manifests/cna/network-addons-config.crd.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io
+spec:
+  group: networkaddonsoperator.network.kubevirt.io
+  names:
+    kind: NetworkAddonsConfig
+    listKind: NetworkAddonsConfigList
+    plural: networkaddonsconfigs
+    singular: networkaddonsconfig
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/cna/operator.yaml
+++ b/manifests/cna/operator.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    name: cluster-network-addons-operator
+  name: cluster-network-addons-operator
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networkaddonsoperator.network.kubevirt.io
+  resources:
+  - networkaddonsconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: cluster-network-addons-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-network-addons-operator
+subjects:
+  - kind: ServiceAccount
+    name: cluster-network-addons-operator
+    namespace: cluster-network-addons-operator
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    name: cluster-network-addons-operator
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-network-addons-operator
+subjects:
+  - kind: ServiceAccount
+    name: cluster-network-addons-operator
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-network-addons-operator
+  namespace: cluster-network-addons-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cluster-network-addons-operator
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        name: cluster-network-addons-operator
+    spec:
+      containers:
+      - env:
+        - name: MULTUS_IMAGE
+          value: quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002
+        - name: LINUX_BRIDGE_IMAGE
+          value: quay.io/kubevirt/cni-default-plugins:v0.1.0
+        - name: LINUX_BRIDGE_MARKER_IMAGE
+          value: quay.io/kubevirt/bridge-marker:0.1.0
+        - name: SRIOV_DP_IMAGE
+          value: quay.io/kubevirt/cluster-network-addon-sriov-device-plugin:v2.0.0-1.git9a20829
+        - name: SRIOV_CNI_IMAGE
+          value: quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973
+        - name: SRIOV_ROOT_DEVICES
+        - name: SRIOV_NETWORK_NAME
+          value: sriov-network
+        - name: SRIOV_NETWORK_TYPE
+          value: sriov
+        - name: KUBEMACPOOL_IMAGE
+          value: quay.io/kubevirt/kubemacpool:v0.3.0
+        - name: OPERATOR_IMAGE
+          value: quay.io/kubevirt/cluster-network-addons-operator:0.7.0
+        - name: OPERATOR_NAME
+          value: cluster-network-addons-operator
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: WATCH_NAMESPACE
+        image: quay.io/kubevirt/cluster-network-addons-operator:0.7.0
+        imagePullPolicy: Always
+        name: cluster-network-addons-operator
+        resources: {}
+      serviceAccountName: cluster-network-addons-operator


### PR DESCRIPTION
Update the Kubernetes 1.13.3 provider to use the cluster network operator.

The operator install all the components:
* multus
* linux-bridge
* bridge-marker
* kubemacpool
* sriov-cni
* sriov-device-plugin

This provider will update the k8s-multus-1.13.3 image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirtci/78)
<!-- Reviewable:end -->
