### PR TITLE
Openshift 3.11 provider to use the cluster network operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 * **Deprecated**: `kubevirtci/os-3.10.0:`: `sha256:cc418c0c837d8e6c9a31a063762d9e4c8bfc70a1fcca10823b11c6d8a7ae2394`
 * **Deprecated**: `kubevirtci/os-3.10.0-crio:`: `sha256:56debd7bc2ce87dd616ebc30f06971e388b6983c0cda8646a7563e1dafadb69b`
 * **Deprecated**: `kubevirtci/os-3.10.0-multus`: `sha256:875c973099141ab2013aaf51ec2b35b5326be943ef1437e4a87e041405e724ca`
-* `kubevirtci/os-3.11.0-multus`: `sha256:3e962ef5042e6e03a25eea263d7474dd63e65e809d8d7b6ac3cf349e10dc13d9`
+* `kubevirtci/os-3.11.0-multus`: `sha256:278b5eb240fcf968add7bb2ae32b629ac056b56b8dd1d2d33446edb44f7e27b3`
 * `kubevirtci/os-3.11.0:`: `sha256:2d0a8f59dfebe181f550c4fbcd90d491a56a7d642d761c32a3c7732644325c0b`
 * `kubevirtci/os-3.11.0-crio:`: `sha256:3f11a6f437fcdf2d70de4fcc31e0383656f994d0d05f9a83face114ea7254bc0`
 * **Deprecated**: `kubevirtci/k8s-1.9.3:`: `sha256:f6ffb23261fb8aa15ed45b8d17e1299e284ea75e1d2814ee6b4ec24ecea6f24b`

--- a/manifests/openshift-ovs-cni.yaml
+++ b/manifests/openshift-ovs-cni.yaml
@@ -49,7 +49,7 @@ spec:
               mountPath: /host/usr/bin
       containers:
         - name: ovs-cni-plugin
-          image: quay.io/kubevirt/ovs-cni-plugin@sha256:86b188c07c62a4bd0847f19a9519f2bb4169a54bb4c74851ea4d8312f778fdf0
+          image: quay.io/kubevirt/ovs-cni-plugin@sha256:bb74637f5be4c2a4eb6f06c891fbe5595d6e46cedacc1f78cd1fff6bececd28c
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -64,7 +64,7 @@ spec:
             - name: cnibin
               mountPath: /host/opt/cni/bin
         - name: ovs-cni-marker
-          image: quay.io/kubevirt/ovs-cni-marker@sha256:cc31f483039be6f17ea4fce417c01c98d1263f1c86d1ae37de06ec69cbb5fb11
+          image: quay.io/kubevirt/ovs-cni-marker@sha256:0df07306c25894743d0e36f177cf15ebf5e1b54657e87b441a6d8341de9a80f3
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/os-3.11-multus/scripts/node01.sh
+++ b/os-3.11-multus/scripts/node01.sh
@@ -88,8 +88,8 @@ set -e
 # Remove the multus pod to recreate it.
 # openshift-sdn remove the content of the cni folder on restart.
 # Needs to recreate the multus cni config after the openshift-sdn is up.
-oc -n kube-system delete po `oc get po -n kube-system | grep kube-multus-ds | awk '{print $1}'`
-oc -n kube-system delete po `oc get po -n kube-system | grep kube-cni-plugins | awk '{print $1}'`
+oc -n multus delete po `oc get po -n multus | grep kube-multus-ds | awk '{print $1}'`
+oc -n linux-bridge delete po `oc get po -n linux-bridge | grep bridge | awk '{print $1}'`
 oc -n kube-system delete po `oc get po -n kube-system | grep ovs-cni | awk '{print $1}'`
 
 /usr/bin/oc create -f /tmp/local-volume.yaml


### PR DESCRIPTION
Update the Openshift 3.11 provider to use the cluster network operator.

The operator install all the components:
* multus
* linux-bridge
* bridge-marker
* kubemacpool
* sriov-cni
* sriov-device-plugin

This provider will update the os-3.11-multus image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirtci/79)
<!-- Reviewable:end -->
