### PR TITLE
Keep scp quiet

### DIFF
--- a/gocli/cmd/scp.go
+++ b/gocli/cmd/scp.go
@@ -191,7 +191,7 @@ func scp(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(wrPipe, "\x00")
 	}()
 
-	err = session.Run("sudo -i /usr/bin/scp -vf " + src)
+	err = session.Run("sudo -i /usr/bin/scp -qf " + src)
 
 	copyError := <-errChan
 


### PR DESCRIPTION
There are two ways to define the `gocli` alias. One is with `-it` and the other is without it.

When `-it` is present:

- `gocli ssh node01` works
- `gocli scp /some/file - > file` mangles the file, because all of the scp output goes into stdout, as there is no stderr separation

When `-it` is absent:

- `gocli ssh node01` doesn't work
- `gocli scp /some/file - > file` works fine, with the `Sending file modes: ` line ending up nicely on stderr

Since making `gocli ssh` work without `-it` is likely impossible, the other option is to make sure `gocli scp` doesn't mangle transferred files. Which is what this patch does.