### PR TITLE
Move dynamic cluster-up configs into _ci-configs dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cli
 .idea
 /gocli/bazel**
 log.txt
+_ci-configs/*

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -15,11 +15,11 @@ function _port() {
 }
 
 function prepare_config() {
-    BASE_PATH=${KUBEVIRTCI_PATH:-$PWD}
-    cat >$BASE_PATH/hack/config-provider-$KUBEVIRT_PROVIDER.sh <<EOF
+    BASE_PATH=${KUBEVIRTCI_CONFIG_PATH:-$PWD}
+    cat >$BASE_PATH/$KUBEVIRT_PROVIDER/config-provider-$KUBEVIRT_PROVIDER.sh <<EOF
 master_ip=$(_main_ip)
-kubeconfig=${BASE_PATH}/cluster/$KUBEVIRT_PROVIDER/.kubeconfig
-kubectl=${BASE_PATH}/cluster/$KUBEVIRT_PROVIDER/.kubectl
+kubeconfig=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+kubectl=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubectl
 docker_prefix=localhost:$(_port registry)/kubevirt
 manifest_docker_prefix=registry:5000/kubevirt
 EOF
@@ -40,8 +40,8 @@ function _add_common_params() {
 }
 
 function _kubectl() {
-    export KUBECONFIG=${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl "$@"
+    export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl "$@"
 }
 
 function down() {

--- a/cluster-up/cluster/k8s-1.11.0/provider.sh
+++ b/cluster-up/cluster/k8s-1.11.0/provider.sh
@@ -10,14 +10,14 @@ function up() {
     ${_cli} run $(_add_common_params)
 
     # Copy k8s config and kubectl
-    ${_cli} scp --prefix $provider_prefix /usr/bin/kubectl - >${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    chmod u+x ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${_cli} scp --prefix $provider_prefix /usr/bin/kubectl - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
     # Set server and disable tls check
-    export KUBECONFIG=${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(_port k8s)
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
+    export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(_port k8s)
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct
     prepare_config

--- a/cluster-up/cluster/k8s-1.13.3/provider.sh
+++ b/cluster-up/cluster/k8s-1.13.3/provider.sh
@@ -10,14 +10,14 @@ function up() {
     ${_cli} run $(_add_common_params)
 
     # Copy k8s config and kubectl
-    ${_cli} scp --prefix $provider_prefix /usr/bin/kubectl - >${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    chmod u+x ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${_cli} scp --prefix $provider_prefix /usr/bin/kubectl - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
     # Set server and disable tls check
-    export KUBECONFIG=${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(_port k8s)
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
+    export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(_port k8s)
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct
     prepare_config

--- a/cluster-up/cluster/k8s-genie-1.11.1/provider.sh
+++ b/cluster-up/cluster/k8s-genie-1.11.1/provider.sh
@@ -10,14 +10,14 @@ function up() {
     ${_cli} run $(_add_common_params)
 
     # Copy k8s config and kubectl
-    ${_cli} scp --prefix $provider_prefix /usr/bin/kubectl - >${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    chmod u+x ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${_cli} scp --prefix $provider_prefix /usr/bin/kubectl - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
     # Set server and disable tls check
-    export KUBECONFIG=${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(_port k8s)
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
+    export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(_port k8s)
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct
     prepare_config

--- a/cluster-up/cluster/k8s-multus-1.13.3/provider.sh
+++ b/cluster-up/cluster/k8s-multus-1.13.3/provider.sh
@@ -10,14 +10,14 @@ function up() {
     ${_cli} run $(_add_common_params)
 
     # Copy k8s config and kubectl
-    ${_cli} scp --prefix $provider_prefix /usr/bin/kubectl - >${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    chmod u+x ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${_cli} scp --prefix $provider_prefix /usr/bin/kubectl - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
     # Set server and disable tls check
-    export KUBECONFIG=${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(_port k8s)
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
+    export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(_port k8s)
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct
     prepare_config

--- a/cluster-up/cluster/okd-4.1.0/provider.sh
+++ b/cluster-up/cluster/okd-4.1.0/provider.sh
@@ -20,14 +20,14 @@ function up() {
 
     # Copy k8s config and kubectl
     cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
-    docker cp $cluster_container_id:/bin/oc ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    chmod u+x ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    docker cp $cluster_container_id:/root/install/auth/kubeconfig ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
+    docker cp $cluster_container_id:/bin/oc ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    docker cp $cluster_container_id:/root/install/auth/kubeconfig ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
     # Set server and disable tls check
-    export KUBECONFIG=${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster test-1 --server=https://$(_main_ip):$(_port k8s)
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster test-1 --insecure-skip-tls-verify=true
+    export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster test-1 --server=https://$(_main_ip):$(_port k8s)
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster test-1 --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct
     prepare_config

--- a/cluster-up/cluster/os-3.11.0/provider.sh
+++ b/cluster-up/cluster/os-3.11.0/provider.sh
@@ -12,14 +12,14 @@ function up() {
     ${_cli} ssh --prefix $provider_prefix node01 -- sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig
 
     # Copy oc tool and configuration file
-    ${_cli} scp --prefix $provider_prefix /usr/bin/oc - >${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    chmod u+x ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
-    ${_cli} scp --prefix $provider_prefix /etc/origin/master/admin.kubeconfig - >${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${_cli} scp --prefix $provider_prefix /usr/bin/oc - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    ${_cli} scp --prefix $provider_prefix /etc/origin/master/admin.kubeconfig - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
     # Update Kube config to support unsecured connection
-    export KUBECONFIG=${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster node01:8443 --server=https://$(_main_ip):$(_port ocp)
-    ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster node01:8443 --insecure-skip-tls-verify=true
+    export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster node01:8443 --server=https://$(_main_ip):$(_port ocp)
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster node01:8443 --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct
     prepare_config

--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -7,6 +7,14 @@ if [ -z "$KUBEVIRTCI_PATH" ]; then
     )"
 fi
 
+
+if [ -z "$KUBEVIRTCI_CONFIG_PATH" ]; then
+    KUBEVIRTCI_CONFIG_PATH="$(
+        cd "$(dirname "$BASH_SOURCE[0]")/../../"
+        echo "$(pwd)/_ci-configs"
+    )"
+fi
+
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.13.3}
 KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-5120M}
@@ -21,3 +29,4 @@ fi
 provider_prefix=${JOB_NAME:-${KUBEVIRT_PROVIDER}}${EXECUTOR_NUMBER}
 job_prefix=${JOB_NAME:-kubevirt}${EXECUTOR_NUMBER}
 
+mkdir -p $KUBEVIRTCI_CONFIG_PATH/$KUBEVIRT_PROVIDER

--- a/cluster-up/hack/config.sh
+++ b/cluster-up/hack/config.sh
@@ -5,10 +5,6 @@ KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-${PROVIDER}}
 source ${KUBEVIRTCI_PATH}hack/config-default.sh
 
 # Allow different providers to override default config values
-test -f "${KUBEVIRTCI_PATH}hack/config-provider-${KUBEVIRT_PROVIDER}.sh" && source ${KUBEVIRTCI_PATH}hack/config-provider-${KUBEVIRT_PROVIDER}.sh
-
-# Let devs override any default variables, to avoid needing
-# to change the version controlled config-default.sh file
-test -f "${KUBEVIRTCI_PATH}hack/config-local.sh" && source ${KUBEVIRTCI_PATH}hack/config-local.sh
+test -f "${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/config-provider-${KUBEVIRT_PROVIDER}.sh" && source ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/config-provider-${KUBEVIRT_PROVIDER}.sh
 
 export docker_prefix master_ip network_provider kubeconfig manifest_docker_prefix

--- a/cluster-up/kubeconfig.sh
+++ b/cluster-up/kubeconfig.sh
@@ -28,4 +28,4 @@ fi
 
 source ${KUBEVIRTCI_PATH}/hack/common.sh
 
-echo "${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig"
+echo "${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig"


### PR DESCRIPTION
Previously we had dynamic data (like .kubeconfig, .kubectl, provider configs) being populating throughout the cluster-up directory which cluttered up a source controlled directory.

Now all dynamically built data is isolated to the _ci-config by default, or a custom location by setting KUBEVIRTCI_CONFIG_PATH env var. This allows people vendoring the cluster-up dir and keep their environment configs separate.