### PR TITLE
Add more insecure registries to okd provider

### DIFF
--- a/cluster-provision/README.md
+++ b/cluster-provision/README.md
@@ -57,7 +57,7 @@
 ## Versions to use
 
 * `kubevirtci/okd-base`: `sha256:90b0522eed6dc2593300b33b05977d3a2d30581e58f05943658791c87d2bae89`
-* `kubevirtci/okd-4.1.0`: `sha256:38e4a63587e6a3910624e5ef8b6dee9fd0dd6072984600b1624f07c73cc1aebf`
+* `kubevirtci/okd-4.1.0`: `sha256:8a89ea659ffcfc6402d7d6ee43418bf2194b27ea74c239699e8268e29639aaa4`
 
 ## Using gocli
 
@@ -102,7 +102,7 @@ NOTE: OpenShift cluster consumes a lot of resources, you should have at least 18
 
 You should run `gocli` command:
 ```bash
-gocli run okd --prefix okd-4.1.0 --ocp-console-port 443 --background kubevirtci/okd-4.1.0@sha256:38e4a63587e6a3910624e5ef8b6dee9fd0dd6072984600b1624f07c73cc1aebf
+gocli run okd --prefix okd-4.1.0 --ocp-console-port 443 --background kubevirtci/okd-4.1.0@sha256:8a89ea659ffcfc6402d7d6ee43418bf2194b27ea74c239699e8268e29639aaa4
 ```
 
 ### How to connect to the OKD console

--- a/cluster-provision/okd/4.1.0/run.sh
+++ b/cluster-provision/okd/4.1.0/run.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-okd_image_hash="sha256:38e4a63587e6a3910624e5ef8b6dee9fd0dd6072984600b1624f07c73cc1aebf"
+okd_image_hash="sha256:8a89ea659ffcfc6402d7d6ee43418bf2194b27ea74c239699e8268e29639aaa4"
 gocli_image_hash="sha256:b52e44d4e44e4c03811a42af9136492fd22f725523c4a3b9258ca9556447736d"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"

--- a/cluster-provision/okd/scripts/provision.sh
+++ b/cluster-provision/okd/scripts/provision.sh
@@ -155,7 +155,7 @@ for master in ${masters}; do
 done
 
 # Add registry:5000 to insecure registries
-until oc patch image.config.openshift.io/cluster --type merge --patch '{"spec": {"registrySources": {"insecureRegistries": ["registry:5000"]}}}'
+until oc patch image.config.openshift.io/cluster --type merge --patch '{"spec": {"registrySources": {"insecureRegistries": ["registry:5000", "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888"]}}}'
 do
     sleep 5
 done

--- a/cluster-up/cluster/okd-4.1.0/provider.sh
+++ b/cluster-up/cluster/okd-4.1.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="okd-4.1.0@sha256:38e4a63587e6a3910624e5ef8b6dee9fd0dd6072984600b1624f07c73cc1aebf"
+image="okd-4.1.0@sha256:8a89ea659ffcfc6402d7d6ee43418bf2194b27ea74c239699e8268e29639aaa4"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 


### PR DESCRIPTION
When a new insecure registry is added to an okd cluster, the okd control control plane begins rebooting nodes as part of the process.  This is disruptive to dev workflows that consistently need a specific insecure registry to be in use because it adds around 10-15 minutes to add the registry to a list and wait for the cluster to stabilize.

At rh, we have an insecure registry that is used consistently for our internal dev flows that I have added to this provider at build time. Since these clusters are only meant to be used for dev purposes, this should not impact anyone who doesn't have access to this repo.

I propose we add this repo to the registry list at provision time, and extend the offer to do this for any other users who would like to include their own registries here as well. 