### PR TITLE
Ensure os-3.11.0-multus provider is using the new sha256 hash

### DIFF
--- a/cluster-up/cluster/os-3.11.0-multus/provider.sh
+++ b/cluster-up/cluster/os-3.11.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source ${KUBEVIRTCI_PATH}/cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-multus@sha256:278b5eb240fcf968add7bb2ae32b629ac056b56b8dd1d2d33446edb44f7e27b3"
+image="os-3.11.0-multus@sha256:b799a707e2c42caa1e3a7e7677cd14bbd834b3e3f6f1bce48b7a32d705e383fb"


### PR DESCRIPTION
The cluster/ dir was sourced from kubevirt last week and missed this update to the os-3.11.0-multus provider. 