### PR TITLE
Make okd console port configurable so people can access UI

### DIFF
--- a/cluster-up/cluster/okd-4.1.0/provider.sh
+++ b/cluster-up/cluster/okd-4.1.0/provider.sh
@@ -16,6 +16,10 @@ function up() {
         params=" --nfs-data $RHEL_NFS_DIR ${params}"
     fi
 
+    if [[ ! -z "${OKD_CONSOLE_PORT}" ]]; then
+        params=" --ocp-console-port $OKD_CONSOLE_PORT ${params}"
+    fi
+
     ${_cli} run okd ${params}
 
     # Copy k8s config and kubectl


### PR DESCRIPTION
This allows someone to set an env var (export OKD_CONSOLE_PORT=443) in order to gain UI access to okd provider. We don't want to do this by default because it would cause running multiple providers on the same host to potentially fail since the port isn't randomized. 