### PR TITLE
Allow remote execute of commands with ssh.sh

### DIFF
--- a/cluster-up/ssh.sh
+++ b/cluster-up/ssh.sh
@@ -39,7 +39,8 @@ if [[ $provider_prefix =~ okd.* ]]; then
         echo "no ssh port found for $node"
         exit 1
     fi
-    ssh -lcore -p $port core@127.0.0.1 -i ${ssh_key}
+    shift
+    ssh -lcore -p $port core@127.0.0.1 -i ${ssh_key} $@
 else
-    ${_cli} --prefix $provider_prefix ssh "$1"
+    ${_cli} --prefix $provider_prefix ssh "$@"
 fi

--- a/cluster-up/ssh.sh
+++ b/cluster-up/ssh.sh
@@ -27,7 +27,7 @@ if [ -z "$node" ]; then
 fi
 
 if [[ $provider_prefix =~ okd.* ]]; then
-    ports=$($KUBEVIRTCI_PATH/cluster/cli.sh --prefix $provider_prefix ports --container-name cluster)
+    ports=$(${KUBEVIRTCI_PATH}cli.sh --prefix $provider_prefix ports --container-name cluster)
 
     if [[ $node =~ worker-0.* ]]; then
         port=$(echo "$ports" | grep 2202 | awk -F':' '{print $2}')
@@ -40,7 +40,7 @@ if [[ $provider_prefix =~ okd.* ]]; then
         exit 1
     fi
     shift
-    ssh -lcore -p $port core@127.0.0.1 -i ${ssh_key} $@
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -q -lcore -p $port core@127.0.0.1 -i ${ssh_key} $@
 else
     ${_cli} --prefix $provider_prefix ssh "$@"
 fi


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

This PR allows one to remote execute commands using ssh.sh instead of getting a shell into the VM. So I can do things like:

cluster-up/ssh.sh node01 touch /tmp/example.txt

This will touch example.txt in /tmp on node01. It allows one to run some customization on a node after the cluster is up.