### PR TITLE
Remove kubevirt specifics from external provider.

### DIFF
--- a/cluster-up/cluster/external/README.md
+++ b/cluster-up/cluster/external/README.md
@@ -15,22 +15,4 @@ export IMAGE_PULL_POLICY=Always
 make cluster-up
 ```
 
-## Building and pushing to the registry
-
-```bash
-make cluster-build
-```
-
-## Installing Kubevirt artifacts on the cluster
-
-```bash
-make cluster-deploy
-```
-
-## Or do the build and deploy in one step
-
-```bash
-make cluster-sync
-```
-```
 

--- a/cluster-up/cluster/external/provider.sh
+++ b/cluster-up/cluster/external/provider.sh
@@ -29,9 +29,3 @@ function down() {
     echo "Not supported by this provider"
 }
 
-function build() {
-    prepare_config
-    # Build code and manifests
-    ${KUBEVIRTCI_PATH}hack/dockerized "DOCKER_TAG=${DOCKER_TAG} DOCKER_PREFIX=${docker_prefix} KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./hack/build-manifests.sh"
-    DOCKER_PREFIX=${docker_prefix} DOCKER_TAG=${docker_tag} make build bazel-push-images
-}


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

Remove kubevirt specific things from the external provider. Pushing to the external cluster should be handled by the specific project, not the kubevirtci external provider.