### PR TITLE
Don't break run params when $OS_NFS_DIR isn't defined

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -31,9 +31,9 @@ function _registry_volume() {
 
 function _add_common_params() {
     local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 5 --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
-    if [[ $TARGET =~ windows.* ]]; then
+    if [[ $TARGET =~ windows.* ]] && [ -n "$WINDOWS_NFS_DIR" ]; then
         params=" --nfs-data $WINDOWS_NFS_DIR $params"
-    elif [[ $TARGET =~ os-.* ]]; then
+    elif [[ $TARGET =~ os-.* ]] && [ -n "$RHEL_NFS_DIR" ]; then
         params=" --nfs-data $RHEL_NFS_DIR $params"
     fi
     echo $params


### PR DESCRIPTION
Or you get this:

```
+ docker run --privileged --net=host --rm -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/gocli@sha256:b52e44d4e44e4c03811a42af9136492fd22f725523c4a3b9258ca9556447736d run --reverse --nfs-data --nodes 1 --memory 5120M --cpu 5 --random-ports --background --prefix os-3.11.0 --registry-volume kubevirt_registry kubevirtci/os-3.11.0@sha256:2d0a8f59dfebe181f550c4fbcd90d491a56a7d642d761c32a3c7732644325c0b --ocp-port 8443
accepts 1 arg(s), received 2
```

Full log: https://jenkins.ovirt.org/job/nmstate_kubernetes-nmstate_standard-check-pr/229//artifact/check-patch.os-3.11.0.el7.x86_64/mock_logs/script/stdout_stderr.log