### PR TITLE
setup linux bridge for functional tests

### DIFF
--- a/cluster-provision/k8s-multus/scripts/node01.sh
+++ b/cluster-provision/k8s-multus/scripts/node01.sh
@@ -42,3 +42,9 @@ while [[ $retry_counter -lt 20 && $kubectl_rc -ne 0 ]]; do
     retry_counter=$((retry_counter + 1))
 done
 kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /tmp/local-volume.yaml
+
+# Setup Linux bridge used in functional tests on nodes. This won't be needed once we
+# finish kubernetes-nmstate and use it for the setup instead.
+./cluster-up/kubectl.sh apply -f /tmp/linux-bridge-config-iptables.yaml
+while [ "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.numberDesiredNumberScheduled}')" == "0" ]; do sleep 1; done
+while [ "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.numberReady}')" != "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.desiredNumberScheduled}')" ]; do sleep 1; done

--- a/cluster-provision/manifests/linux-bridge-config-iptables.yaml
+++ b/cluster-provision/manifests/linux-bridge-config-iptables.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: linux-bridge-config
+spec:
+  selector:
+    matchLabels:
+      name: linux-bridge-config
+  template:
+    metadata:
+      labels:
+        name: linux-bridge-config
+    spec:
+      hostNetwork: true
+      containers:
+      - name: linux-bridge-config
+        image: centos:7
+        command:
+        - sh
+        - -c
+        - |
+          set -ex
+          yum -y install epel-release
+          yum -y install \
+            https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/python2-libnmstate-0.0.6-2.el7.noarch.rpm \
+            https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/nmstate-0.0.6-2.el7.noarch.rpm \
+            iptables
+          echo '
+          interfaces:
+          - description: Linux bridge used for KubeVirt functional tests
+            name: br10
+            type: linux-bridge
+            state: up
+          ' > state.yml
+          nmstatectl set state.yml
+          iptables -I FORWARD 1 -i br10 -j ACCEPT
+          touch /tmp/ready
+          sleep INF
+        volumeMounts:
+        - name: dbus-socket
+          mountPath: /run/dbus/system_bus_socket
+        securityContext:
+          privileged: true
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: dbus-socket
+        hostPath:
+          path: /run/dbus/system_bus_socket
+          type: Socket

--- a/cluster-provision/manifests/linux-bridge-config-nftables.yaml
+++ b/cluster-provision/manifests/linux-bridge-config-nftables.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: linux-bridge-config
+spec:
+  selector:
+    matchLabels:
+      name: linux-bridge-config
+  template:
+    metadata:
+      labels:
+        name: linux-bridge-config
+    spec:
+      hostNetwork: true
+      containers:
+      - name: linux-bridge-config
+        image: centos:7
+        command:
+        - sh
+        - -c
+        - |
+          set -ex
+          yum -y install epel-release
+          yum -y install \
+            https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/python2-libnmstate-0.0.6-2.el7.noarch.rpm \
+            https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/nmstate-0.0.6-2.el7.noarch.rpm \
+            nftables
+          echo '
+          interfaces:
+          - description: Linux bridge used for KubeVirt functional tests
+            name: br10
+            type: linux-bridge
+            state: up
+          ' > state.yml
+          nmstatectl set state.yml
+          add table ip filter
+          add chain ip filter INPUT { type filter hook input priority 0; policy accept; }
+          add chain ip filter FORWARD { type filter hook forward priority 0; policy accept; }
+          add chain ip filter OUTPUT { type filter hook output priority 0; policy accept; }
+          add rule ip filter FORWARD iifname br10 counter accept
+          touch /tmp/ready
+          sleep INF
+        volumeMounts:
+        - name: dbus-socket
+          mountPath: /run/dbus/system_bus_socket
+        securityContext:
+          privileged: true
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: dbus-socket
+        hostPath:
+          path: /run/dbus/system_bus_socket
+          type: Socket

--- a/cluster-provision/okd/scripts/provision.sh
+++ b/cluster-provision/okd/scripts/provision.sh
@@ -185,5 +185,11 @@ while [[ "$(virsh list --name)" != "" ]]; do
     sleep 1
 done
 
+# Setup Linux bridge used in functional tests on nodes. This won't be needed once we
+# finish kubernetes-nmstate and use it for the setup instead.
+./cluster-up/kubectl.sh apply -f /tmp/linux-bridge-config-nftables.yaml
+while [ "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.numberDesiredNumberScheduled}')" == "0" ]; do sleep 1; done
+while [ "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.numberReady}')" != "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.desiredNumberScheduled}')" ]; do sleep 1; done
+
 # remove the cache
 rm -rf /root/.cache/*

--- a/cluster-provision/os-3.10-multus/scripts/node01.sh
+++ b/cluster-provision/os-3.10-multus/scripts/node01.sh
@@ -93,3 +93,9 @@ oc -n kube-system delete po `oc get po -n kube-system | grep ovs-cni-plugin | aw
 oc -n kube-system delete po `oc get po -n kube-system | grep ovs-vsctl-amd64 | awk '{print $1}'`
 
 /usr/bin/oc create -f /tmp/local-volume.yaml
+
+# Setup Linux bridge used in functional tests on nodes. This won't be needed once we
+# finish kubernetes-nmstate and use it for the setup instead.
+./cluster-up/kubectl.sh apply -f /tmp/linux-bridge-config-iptables.yaml
+while [ "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.numberDesiredNumberScheduled}')" == "0" ]; do sleep 1; done
+while [ "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.numberReady}')" != "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.desiredNumberScheduled}')" ]; do sleep 1; done

--- a/cluster-provision/os-3.11-multus/scripts/node01.sh
+++ b/cluster-provision/os-3.11-multus/scripts/node01.sh
@@ -95,3 +95,9 @@ oc -n kube-system delete po `oc get po -n kube-system | grep ovs-cni | awk '{pri
 /usr/bin/oc create -f /tmp/local-volume.yaml
 
 oc get po -n openshift-sdn | grep ovs | awk '{print "oc exec -n openshift-sdn",$1,"-- ovs-vsctl --may-exist add-br br1"}' | sh
+
+# Setup Linux bridge used in functional tests on nodes. This won't be needed once we
+# finish kubernetes-nmstate and use it for the setup instead.
+./cluster-up/kubectl.sh apply -f /tmp/linux-bridge-config-iptables.yaml
+while [ "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.numberDesiredNumberScheduled}')" == "0" ]; do sleep 1; done
+while [ "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.numberReady}')" != "$(./cluster-up/kubectl.sh get ds linux-bridge-config -o 'jsonpath={.status.desiredNumberScheduled}')" ]; do sleep 1; done


### PR DESCRIPTION
Multus functional tests, starting with [1] will use Linux bridge CNI
as the default CNI plugin for L2. Since we don't yet have a node
network operator available to configure interfaces on nodes, this
patch introduces a workaround. We use a privileged daemonset to
create bridge br10 on every node and configure respective firewall
rules.

[1] https://github.com/kubevirt/kubevirt/pull/2361