### PR TITLE
Upgrade gocli go_rules version to 0.18.6

### DIFF
--- a/cluster-provision/gocli/WORKSPACE
+++ b/cluster-provision/gocli/WORKSPACE
@@ -3,8 +3,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.0/rules_go-0.18.0.tar.gz"],
-    sha256 = "301c8b39b0808c49f98895faa6aa8c92cbd605ab5ad4b6a3a652da33a1a2ba2e",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz"],
+    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 http_archive(
     name = "bazel_gazelle",


### PR DESCRIPTION
Trying compile gocli fails at [1] upgrading go rules to 0.18.6
fix the issue.

bazel RPM: bazel-0.27.0-3.fc30.x86_64

[1] https://github.com/bazelbuild/bazel/issues/7793

Signed-off-by: Quique Llorente <ellorent@redhat.com>