### PR TITLE
Update gocli hash to remove fmt.Println

### DIFF
--- a/cluster-provision/README.md
+++ b/cluster-provision/README.md
@@ -15,7 +15,7 @@
 ## Versions to use
 
 * `kubevirtci/cli`: `sha256:1dd015dea4f12e6dcb8e31be3eeb677fed96f290ef4a4892a33c43d666053536`
-* `kubevirtci/gocli`: `sha256:8571161d7956b830646216335453b995ba754e07319dde062241ccc025f5ee00`
+* `kubevirtci/gocli`: `sha256:99f7cd3009911a9dfc4e67a5adf9f75a8244a9ca2583540e81736e93c4bb0556`
 * `kubevirtci/base`: `sha256:034de1a154409d87498050ccc281d398ce1a0fed32efdbd66d2041a99a46b322`
 * `kubevirtci/centos:1804_02`: `sha256:70653d952edfb8002ab8efe9581d01960ccf21bb965a9b4de4775c8fbceaab39`
 * `kubevirtci/os-3.11.0-multus`: `sha256:f2d03ccbe60157e60a5be3b41536e1ba046fc1820c1ceec1f0018b0362c7808c`
@@ -65,7 +65,7 @@ gocli provision okd \
 --installer-pull-token-file <installer_pull_token_file> \
 --installer-repo-tag release-4.1 \
 --installer-release-image quay.io/openshift-release-dev/ocp-release:4.1.0-rc.7 \
-kubevirtci/okd-base@sha256:8571161d7956b830646216335453b995ba754e07319dde062241ccc025f5ee00
+kubevirtci/okd-base@sha256:99f7cd3009911a9dfc4e67a5adf9f75a8244a9ca2583540e81736e93c4bb0556
 ```
 
 ***

--- a/cluster-provision/okd/4.1.0/provision.sh
+++ b/cluster-provision/okd/4.1.0/provision.sh
@@ -5,7 +5,7 @@ set -x
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )"
 
 okd_base_hash="sha256:90b0522eed6dc2593300b33b05977d3a2d30581e58f05943658791c87d2bae89"
-gocli_image_hash="sha256:8571161d7956b830646216335453b995ba754e07319dde062241ccc025f5ee00"
+gocli_image_hash="sha256:99f7cd3009911a9dfc4e67a5adf9f75a8244a9ca2583540e81736e93c4bb0556"
 
 gocli="docker run \
 --privileged \

--- a/cluster-provision/okd/4.1.0/run.sh
+++ b/cluster-provision/okd/4.1.0/run.sh
@@ -3,7 +3,7 @@
 set -x
 
 okd_image_hash="sha256:8a89ea659ffcfc6402d7d6ee43418bf2194b27ea74c239699e8268e29639aaa4"
-gocli_image_hash="sha256:8571161d7956b830646216335453b995ba754e07319dde062241ccc025f5ee00"
+gocli_image_hash="sha256:99f7cd3009911a9dfc4e67a5adf9f75a8244a9ca2583540e81736e93c4bb0556"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"
 

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-_cli_container="kubevirtci/gocli@sha256:8571161d7956b830646216335453b995ba754e07319dde062241ccc025f5ee00"
+_cli_container="kubevirtci/gocli@sha256:99f7cd3009911a9dfc4e67a5adf9f75a8244a9ca2583540e81736e93c4bb0556"
 _cli_with_tty="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 _cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 


### PR DESCRIPTION
The PR #105 introduce a debug Println that is removed
in the latest versions of it but the container has not
being generated/pushed.
    
