### PR TITLE
Compose correctly the secondary-nics at multinode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ git clone https://github.com/kubevirt/kubevirtci.git
 cd kubevirtci
 ```
 
-Start multi node k8s cluster
+Start multi node k8s cluster with 2 nics
 ```
-export KUBEVIRT_PROVIDER=k8s-1.13.3 KUBEVIRT_NUM_NODES=2
+export KUBEVIRT_PROVIDER=k8s-1.13.3 KUBEVIRT_NUM_NODES=2 KUBEVIRT_NUM_SECONDARY_NICS 1
 make cluster-up
 ```
 
@@ -23,7 +23,7 @@ cluster-up/kubectl.sh get nodes
 cluster-up/kubectl.sh get pods --all-namespaces
 ```
 
-Use your own kubectl client by defining the KUBECONFIG environment variable 
+Use your own kubectl client by defining the KUBECONFIG environment variable
 ```
 export KUBECONFIG=$(cluster-up/kubeconfig.sh)
 
@@ -61,7 +61,7 @@ cluster-up/oc.sh get nodes
 cluster-up/oc.sh get pods --all-namespaces
 ```
 
-Use your own OC client by defining the KUBECONFIG environment variable 
+Use your own OC client by defining the KUBECONFIG environment variable
 ```
 export KUBECONFIG=$(cluster-up/kubeconfig.sh)
 
@@ -81,5 +81,5 @@ cluster-up/ssh.sh worker-0
 
 Accessing OKD UI
 ```
-TODO - in the process of working out the details here. 
+TODO - in the process of working out the details here.
 ```

--- a/cluster-provision/README.md
+++ b/cluster-provision/README.md
@@ -15,7 +15,7 @@
 ## Versions to use
 
 * `kubevirtci/cli`: `sha256:1dd015dea4f12e6dcb8e31be3eeb677fed96f290ef4a4892a33c43d666053536`
-* `kubevirtci/gocli`: `sha256:ac77baa6561557bb66d0f669b7aa4383430f2a7e5388627102f268f5558c3a8b`
+* `kubevirtci/gocli`: `sha256:caf1c3f63dc5f3137795084e492a48c802a7ef2e7f7fbe1d67e5cff684d376a3`
 * `kubevirtci/base`: `sha256:034de1a154409d87498050ccc281d398ce1a0fed32efdbd66d2041a99a46b322`
 * `kubevirtci/centos:1804_02`: `sha256:70653d952edfb8002ab8efe9581d01960ccf21bb965a9b4de4775c8fbceaab39`
 * `kubevirtci/os-3.11.0-multus`: `sha256:6cd635cdd8b121985ecf45cb997a2953aa03fea4bde60ee803dbb452fb74bec9`
@@ -65,7 +65,7 @@ gocli provision okd \
 --installer-pull-token-file <installer_pull_token_file> \
 --installer-repo-tag release-4.1 \
 --installer-release-image quay.io/openshift-release-dev/ocp-release:4.1.0-rc.7 \
-kubevirtci/okd-base@sha256:ac77baa6561557bb66d0f669b7aa4383430f2a7e5388627102f268f5558c3a8b
+kubevirtci/okd-base@sha256:caf1c3f63dc5f3137795084e492a48c802a7ef2e7f7fbe1d67e5cff684d376a3
 ```
 
 ***

--- a/cluster-provision/okd/4.1.0/provision.sh
+++ b/cluster-provision/okd/4.1.0/provision.sh
@@ -5,7 +5,7 @@ set -x
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )"
 
 okd_base_hash="sha256:90b0522eed6dc2593300b33b05977d3a2d30581e58f05943658791c87d2bae89"
-gocli_image_hash="sha256:ac77baa6561557bb66d0f669b7aa4383430f2a7e5388627102f268f5558c3a8b"
+gocli_image_hash="sha256:caf1c3f63dc5f3137795084e492a48c802a7ef2e7f7fbe1d67e5cff684d376a3"
 
 gocli="docker run \
 --privileged \

--- a/cluster-provision/okd/4.1.0/run.sh
+++ b/cluster-provision/okd/4.1.0/run.sh
@@ -3,7 +3,7 @@
 set -x
 
 okd_image_hash="sha256:8a89ea659ffcfc6402d7d6ee43418bf2194b27ea74c239699e8268e29639aaa4"
-gocli_image_hash="sha256:ac77baa6561557bb66d0f669b7aa4383430f2a7e5388627102f268f5558c3a8b"
+gocli_image_hash="sha256:caf1c3f63dc5f3137795084e492a48c802a7ef2e7f7fbe1d67e5cff684d376a3"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"
 

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-_cli_container="kubevirtci/gocli@sha256:ac77baa6561557bb66d0f669b7aa4383430f2a7e5388627102f268f5558c3a8b"
+_cli_container="kubevirtci/gocli@sha256:caf1c3f63dc5f3137795084e492a48c802a7ef2e7f7fbe1d67e5cff684d376a3"
 _cli_with_tty="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 _cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 


### PR DESCRIPTION
From stated here [1] running with multinode and
secondary nics fail since it was composing incorrectly
the quemu args line.

This remove the infinite concatenation and use unique
device names per node.

[1] https://github.com/kubevirt/kubevirtci/pull/105#discussion_r296142403

Signed-off-by: Quique Llorente <ellorent@redhat.com>