### PR TITLE
Preserve $DOCKER_PREFIX if given

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -21,8 +21,8 @@ master_ip=$(_main_ip)
 kubeconfig=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 kubectl=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubectl
 gocli=${BASE_PATH}/../cluster-up/cli.sh
-docker_prefix=localhost:$(_port registry)/kubevirt
-manifest_docker_prefix=registry:5000/kubevirt
+docker_prefix=\${DOCKER_PREFIX:-localhost:$(_port registry)/kubevirt}
+manifest_docker_prefix=\${DOCKER_PREFIX:-registry:5000/kubevirt}
 EOF
 }
 


### PR DESCRIPTION
Preserve $DOCKER_PREFIX if given.
Otherwise it's impossible to generate manifests with or push to
other image registries.
You need to run "make cluster-up" for k8s-1.13.3 (default) or your
currently exported $KUBEVIRT_PROVIDER once, in order to apply this
change to your work environment.

/cc @rmohr 