### PR TITLE
Fix sriov kind provider

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -5,6 +5,7 @@ set -e
 NODE_CMD="docker exec -it -d "
 export KIND_MANIFESTS_DIR="${KUBEVIRTCI_PATH}/cluster/kind/manifests"
 export KIND_NODE_CLI="docker exec -it "
+export KUBEVIRTCI_PATH
 
 function _wait_kind_up {
     echo "Waiting for kind to be ready ..."  


### PR DESCRIPTION
This is a followup to https://github.com/kubevirt/kubevirtci/pull/119 . 

After the refactor `KUBEVIRTCI_PATH` env variable was not available anymore to consumers of `common.sh` and for that reason the sriov ci was failing because the sriov configuration script was not able to find the manifests. 

This pr addresses this problem.