### PR TITLE
Do not set TechPreview feature gate

### DIFF
--- a/cluster-provision/README.md
+++ b/cluster-provision/README.md
@@ -36,8 +36,8 @@
 ## Versions to use
 
 * `kubevirtci/okd-base`: `sha256:259e776998da3a503a30fdf935b29102443b24ca4ea095c9478c37e994e242bb`
-* `kubevirtci/okd-4.1.0`: `sha256:2b65ed85e98470794408df955bb1716fa7b555d3e221262030f223d1d315bfce`
-* `kubevirtci/okd-4.1.2`: `sha256:7cdb7357a7d9e8055ae2b26a9d8c926fb81440c3c5cf917407ec51297c31479f`
+* `kubevirtci/okd-4.1.0`: `sha256:d190cee4bb30e231ceb9a7c9eb1ade10c036225e126cd0abf60e9706ebd696fd`
+* `kubevirtci/okd-4.1.2`: `sha256:88fba5c00ba973c8da712d14689f1d93c40fa6a8e8efdb4da501b572adbd3d6b`
 
 ## Using gocli
 
@@ -82,7 +82,7 @@ NOTE: OpenShift cluster consumes a lot of resources, you should have at least 18
 
 You should run `gocli` command:
 ```bash
-gocli run okd --prefix okd-4.1.0 --ocp-console-port 443 --background kubevirtci/okd-4.1.0@sha256:2b65ed85e98470794408df955bb1716fa7b555d3e221262030f223d1d315bfce
+gocli run okd --prefix okd-4.1.0 --ocp-console-port 443 --background kubevirtci/okd-4.1.0@sha256:d190cee4bb30e231ceb9a7c9eb1ade10c036225e126cd0abf60e9706ebd696fd
 ```
 
 ### How to connect to the OKD console

--- a/cluster-provision/okd/4.1.0/run.sh
+++ b/cluster-provision/okd/4.1.0/run.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-okd_image_hash="sha256:2b65ed85e98470794408df955bb1716fa7b555d3e221262030f223d1d315bfce"
+okd_image_hash="sha256:d190cee4bb30e231ceb9a7c9eb1ade10c036225e126cd0abf60e9706ebd696fd"
 gocli_image_hash="sha256:1e21a7b0fc959ae2a47d1d6462ceb74f9e9181d52f9bc618e61bcab80bedaa9e"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"

--- a/cluster-provision/okd/4.1.2/run.sh
+++ b/cluster-provision/okd/4.1.2/run.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-okd_image_hash="sha256:7cdb7357a7d9e8055ae2b26a9d8c926fb81440c3c5cf917407ec51297c31479f"
+okd_image_hash="sha256:88fba5c00ba973c8da712d14689f1d93c40fa6a8e8efdb4da501b572adbd3d6b"
 gocli_image_hash="sha256:1e21a7b0fc959ae2a47d1d6462ceb74f9e9181d52f9bc618e61bcab80bedaa9e"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"

--- a/cluster-provision/okd/scripts/provision.sh
+++ b/cluster-provision/okd/scripts/provision.sh
@@ -172,24 +172,6 @@ until [[ $(oc get nodes --no-headers | grep -v SchedulingDisabled | grep Ready |
     sleep 10
 done
 
-# Update machine-api-operator feature gate to enable TechPreview features
-until oc -n openshift-machine-api patch featuregates.config.openshift.io/cluster --type merge --patch '{"spec": {"featureSet": "TechPreviewNoUpgrade"}}'; do
-    sleep 5
-done
-
-until [[ $(oc get nodes --no-headers | grep master | grep Ready,SchedulingDisabled | wc -l) -ge 1 ]]; do
-    sleep 10
-done
-
-# Make master nodes schedulable
-for master in ${masters}; do
-    oc adm uncordon ${master}
-done
-
-until [[ $(oc get nodes --no-headers | grep -v SchedulingDisabled | grep Ready | wc -l) -ge 2 ]]; do
-    sleep 10
-done
-
 # Disable updates of machines configurations, because on the update the machine-config
 # controller will try to drain the master node, but it not possible with only one master
 # so the node will stay in cordon state forewer.

--- a/cluster-up/cluster/okd-4.1.0/provider.sh
+++ b/cluster-up/cluster/okd-4.1.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="okd-4.1.0@sha256:2b65ed85e98470794408df955bb1716fa7b555d3e221262030f223d1d315bfce"
+image="okd-4.1.0@sha256:d190cee4bb30e231ceb9a7c9eb1ade10c036225e126cd0abf60e9706ebd696fd"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/okd-4.1.2/provider.sh
+++ b/cluster-up/cluster/okd-4.1.2/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="okd-4.1.2@sha256:7cdb7357a7d9e8055ae2b26a9d8c926fb81440c3c5cf917407ec51297c31479f"
+image="okd-4.1.2@sha256:88fba5c00ba973c8da712d14689f1d93c40fa6a8e8efdb4da501b572adbd3d6b"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 


### PR DESCRIPTION
Until 4.3 we will use our fork for fencing features, so do not need this fg.