### PR TITLE
Fix sriov ci local path

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -57,7 +57,7 @@ function configure-sriovdp() {
 }
 
 function sriovdp-config-cmd() {
-    ./automation/kind-cluster/sriovdp_setup.sh
+    ${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/sriovdp_setup.sh
     echo "cat <<EOF > /etc/pcidp/config.json
 $(cat /etc/pcidp/config.json)
 EOF


### PR DESCRIPTION
This PR should (hopefully) fix the sriov ci provider.

Sorry I have to send this too, but I did not notice it since on https://github.com/kubevirt/kubevirt/pull/2419 the automation path was there and tests were passing.
