### PR TITLE
Create secondary nics tuntap before qemu starts

### DIFF
--- a/cluster-provision/README.md
+++ b/cluster-provision/README.md
@@ -16,16 +16,16 @@
 
 * `kubevirtci/cli`: `sha256:1dd015dea4f12e6dcb8e31be3eeb677fed96f290ef4a4892a33c43d666053536`
 * `kubevirtci/gocli`: `sha256:868fd9f2b6e5ff6473ab92cdd7d3a762ec8a8c66dac29f5db841879d40038f2a`
-* `kubevirtci/base`: `sha256:1f9f2e12571cf96a89a3e24b15de0b2857db159b4c7d3657c81541845040c1bd`
-* `kubevirtci/centos:1905_01`: `sha256:728232c8b5b79bb69e1386a6b47acd72876faa386202b535e227bc605adffe33`
-* `kubevirtci/os-3.11.0-multus`: `sha256:adabdd119fe04d1808c57418369ea7ec84b94770f1686ca168f079c6618b23a4`
-* `kubevirtci/os-3.11.0:`: `sha256:ff54198c7eaa51ccf2aeff6d5dd1e9ca51ccfec6ee0237b0305fb3b6761f95f6`
-* `kubevirtci/os-3.11.0-crio:`: `sha256:66b348692b70c8017ef4e914f08252de5c26145640c516f749d38fc78c666589`
+* `kubevirtci/base`: `sha256:850ac2e2828610b5f35f004f2a8a1ab23609a4c7891c8a1b68cbb7eef5f5dda0`
+* `kubevirtci/centos:1905_01`: `sha256:4b292b646f382d986c75a2be8ec49119a03467fe26dccc3a0886eb9e6e38c911`
+* `kubevirtci/os-3.11.0-multus`: `sha256:0c8be10799490a1f86740eaa490063f51eab78b920540f0a2946abc5e0bf30fe`
+* `kubevirtci/os-3.11.0:`: `sha256:ebc9048f25eb5cc720b8b4eeab7b58b5fa3648d27c9612d87bf338d5dbee46a7`
+* `kubevirtci/os-3.11.0-crio:`: `sha256:71ea794ff45e06ac521e2fe867f192b98ae989755629e4830ab919ecd3905337`
 * `kubevirtci/k8s-1.10.11:`: `sha256:f563a8ab4719e53c2372c4f41dfe55256677ec7afc442dfaebd494926005e3e5`
-* `kubevirtci/k8s-1.11.0:`: `sha256:afa15dbea2b520e7c5abe5880127bbfd5a9c15207792082d2cc6409943890001`
-* `kubevirtci/k8s-1.13.3:`: `sha256:40cc8c51bfcf87eb0e206ad38c3319a5a26ea479f71ee63195705f7dae59e00d`
-* `kubevirtci/k8s-multus-1.13.3:`: `sha256:6e7245922c44d06374534bbce7981934a964efd075e6de44bd532d869f267811`
-* `kubevirtci/k8s-genie-1.11.1:`: `sha256:b63ec1515bd88ee39dc46159c32fa4ee23c890005cbda7745a90dd9b72c25254`
+* `kubevirtci/k8s-1.11.0:`: `sha256:696ba7860fc635628e36713a2181ef72568d825f816911cf857b2555ea80a98a`
+* `kubevirtci/k8s-1.13.3:`: `sha256:afbdd9b4208e5ce2ec327f302c336cea3ed3c22488603eab63b92c3bfd36d6cd`
+* `kubevirtci/k8s-multus-1.13.3:`: `sha256:c0bcf0d2e992e5b4d96a7bcbf988b98b64c4f5aef2f2c4d1c291e90b85529738`
+* `kubevirtci/k8s-genie-1.11.1:`: `sha256:19af1961fdf92c08612d113a3cf7db40f02fd213113a111a0b007a4bf0f3f7e7`
 
 # OKD clusters in the container with libvirt
 

--- a/cluster-provision/base/scripts/dnsmasq.sh
+++ b/cluster-provision/base/scripts/dnsmasq.sh
@@ -17,6 +17,7 @@ for i in $(seq 1 ${NUM_NODES}); do
   DHCP_HOSTS="${DHCP_HOSTS} --dhcp-host=52:55:00:d1:55:${n},192.168.66.1${n},node${n},infinite"
   for s in $(seq 1 ${NUM_SECONDARY_NICS}); do
     tap_name=stap$(($i - 1))-$(($s - 1))
+    ip tuntap add dev $tap_name mode tap user $(whoami)
     ip link set $tap_name master br0
     ip link set dev $tap_name up
   done

--- a/cluster-provision/centos7/Dockerfile
+++ b/cluster-provision/centos7/Dockerfile
@@ -1,4 +1,4 @@
-FROM kubevirtci/base@sha256:1f9f2e12571cf96a89a3e24b15de0b2857db159b4c7d3657c81541845040c1bd
+FROM kubevirtci/base@sha256:850ac2e2828610b5f35f004f2a8a1ab23609a4c7891c8a1b68cbb7eef5f5dda0
 
 ENV CENTOS_URL http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-1905_01.Libvirt.box
 

--- a/cluster-provision/k8s-genie/provision.sh
+++ b/cluster-provision/k8s-genie/provision.sh
@@ -5,4 +5,4 @@ set -ex
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $DIR
-../cli/cli provision --prefix k8s-genie-${version}-provision --scripts ./scripts --k8s-version ${version} --base kubevirtci/centos@sha256:728232c8b5b79bb69e1386a6b47acd72876faa386202b535e227bc605adffe33 --tag kubevirtci/k8s-genie-${version}
+../cli/cli provision --prefix k8s-genie-${version}-provision --scripts ./scripts --k8s-version ${version} --base kubevirtci/centos@sha256:4b292b646f382d986c75a2be8ec49119a03467fe26dccc3a0886eb9e6e38c911 --tag kubevirtci/k8s-genie-${version}

--- a/cluster-provision/k8s-multus/provision.sh
+++ b/cluster-provision/k8s-multus/provision.sh
@@ -5,4 +5,4 @@ set -ex
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $DIR
-../cli/cli provision --prefix k8s-multus-${version}-provision --scripts ./scripts --k8s-version ${version} --base kubevirtci/centos@sha256:728232c8b5b79bb69e1386a6b47acd72876faa386202b535e227bc605adffe33 --tag kubevirtci/k8s-multus-${version}
+../cli/cli provision --prefix k8s-multus-${version}-provision --scripts ./scripts --k8s-version ${version} --base kubevirtci/centos@sha256:4b292b646f382d986c75a2be8ec49119a03467fe26dccc3a0886eb9e6e38c911 --tag kubevirtci/k8s-multus-${version}

--- a/cluster-provision/k8s/provision.sh
+++ b/cluster-provision/k8s/provision.sh
@@ -6,4 +6,4 @@ set -ex
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $DIR
-../cli/cli provision --prefix k8s-${version}-provision --scripts ./scripts --k8s-version ${version} --base kubevirtci/centos@sha256:728232c8b5b79bb69e1386a6b47acd72876faa386202b535e227bc605adffe33 --tag kubevirtci/k8s-${version}
+../cli/cli provision --prefix k8s-${version}-provision --scripts ./scripts --k8s-version ${version} --base kubevirtci/centos@sha256:4b292b646f382d986c75a2be8ec49119a03467fe26dccc3a0886eb9e6e38c911 --tag kubevirtci/k8s-${version}

--- a/cluster-provision/manifests/kubernetes-ovs-cni.yaml
+++ b/cluster-provision/manifests/kubernetes-ovs-cni.yaml
@@ -23,7 +23,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: ovs-cni-plugin
-          image: quay.io/kubevirt/ovs-cni-plugin@sha256:bb74637f5be4c2a4eb6f06c891fbe5595d6e46cedacc1f78cd1fff6bececd28c
+          image: quay.io/kubevirt/ovs-cni-plugin@sha256:b3ff427b973f9e8622dedc8d469efa646c708d2cf72080a3fd149d1297025b23
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -38,7 +38,7 @@ spec:
             - name: cnibin
               mountPath: /host/opt/cni/bin
         - name: ovs-cni-marker
-          image: quay.io/kubevirt/ovs-cni-marker@sha256:0df07306c25894743d0e36f177cf15ebf5e1b54657e87b441a6d8341de9a80f3
+          image: quay.io/kubevirt/ovs-cni-marker@sha256:8b937290a5b140b0307d09e542041dbc76ff038dadc19bfe9ead35cf392a4cda
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/cluster-provision/manifests/openshift-ovs-cni.yaml
+++ b/cluster-provision/manifests/openshift-ovs-cni.yaml
@@ -49,7 +49,7 @@ spec:
               mountPath: /host/usr/bin
       containers:
         - name: ovs-cni-plugin
-          image: quay.io/kubevirt/ovs-cni-plugin@sha256:bb74637f5be4c2a4eb6f06c891fbe5595d6e46cedacc1f78cd1fff6bececd28c
+          image: quay.io/kubevirt/ovs-cni-plugin@sha256:b3ff427b973f9e8622dedc8d469efa646c708d2cf72080a3fd149d1297025b23
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -64,7 +64,7 @@ spec:
             - name: cnibin
               mountPath: /host/opt/cni/bin
         - name: ovs-cni-marker
-          image: quay.io/kubevirt/ovs-cni-marker@sha256:0df07306c25894743d0e36f177cf15ebf5e1b54657e87b441a6d8341de9a80f3
+          image: quay.io/kubevirt/ovs-cni-marker@sha256:8b937290a5b140b0307d09e542041dbc76ff038dadc19bfe9ead35cf392a4cda
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/cluster-provision/os-3.11-crio/provision.sh
+++ b/cluster-provision/os-3.11-crio/provision.sh
@@ -4,4 +4,4 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-../cli/cli provision --prefix os-3.11-crio-provision --crio --scripts ../os-3.11/scripts --base kubevirtci/centos@sha256:728232c8b5b79bb69e1386a6b47acd72876faa386202b535e227bc605adffe33 --tag kubevirtci/os-3.11.0-crio
+../cli/cli provision --prefix os-3.11-crio-provision --crio --scripts ../os-3.11/scripts --base kubevirtci/centos@sha256:4b292b646f382d986c75a2be8ec49119a03467fe26dccc3a0886eb9e6e38c911 --tag kubevirtci/os-3.11.0-crio

--- a/cluster-provision/os-3.11-multus/provision.sh
+++ b/cluster-provision/os-3.11-multus/provision.sh
@@ -4,4 +4,4 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-../cli/cli provision --prefix os-3.11-multus-provision --memory 5120M --scripts ./scripts --base kubevirtci/centos@sha256:728232c8b5b79bb69e1386a6b47acd72876faa386202b535e227bc605adffe33 --tag kubevirtci/os-3.11.0-multus
+../cli/cli provision --prefix os-3.11-multus-provision --memory 5120M --scripts ./scripts --base kubevirtci/centos@sha256:4b292b646f382d986c75a2be8ec49119a03467fe26dccc3a0886eb9e6e38c911 --tag kubevirtci/os-3.11.0-multus

--- a/cluster-provision/os-3.11/provision.sh
+++ b/cluster-provision/os-3.11/provision.sh
@@ -4,4 +4,4 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-../cli/cli provision --prefix os-3.11-provision --scripts ./scripts --base kubevirtci/centos@sha256:728232c8b5b79bb69e1386a6b47acd72876faa386202b535e227bc605adffe33 --tag kubevirtci/os-3.11.0
+../cli/cli provision --prefix os-3.11-provision --scripts ./scripts --base kubevirtci/centos@sha256:4b292b646f382d986c75a2be8ec49119a03467fe26dccc3a0886eb9e6e38c911 --tag kubevirtci/os-3.11.0

--- a/cluster-up/cluster/k8s-1.11.0/provider.sh
+++ b/cluster-up/cluster/k8s-1.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.11.0@sha256:afa15dbea2b520e7c5abe5880127bbfd5a9c15207792082d2cc6409943890001"
+image="k8s-1.11.0@sha256:696ba7860fc635628e36713a2181ef72568d825f816911cf857b2555ea80a98a"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/k8s-1.13.3/provider.sh
+++ b/cluster-up/cluster/k8s-1.13.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.13.3@sha256:40cc8c51bfcf87eb0e206ad38c3319a5a26ea479f71ee63195705f7dae59e00d"
+image="k8s-1.13.3@sha256:afbdd9b4208e5ce2ec327f302c336cea3ed3c22488603eab63b92c3bfd36d6cd"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/k8s-genie-1.11.1/provider.sh
+++ b/cluster-up/cluster/k8s-genie-1.11.1/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-genie-1.11.1@sha256:b63ec1515bd88ee39dc46159c32fa4ee23c890005cbda7745a90dd9b72c25254"
+image="k8s-genie-1.11.1@sha256:19af1961fdf92c08612d113a3cf7db40f02fd213113a111a0b007a4bf0f3f7e7"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/k8s-multus-1.13.3/provider.sh
+++ b/cluster-up/cluster/k8s-multus-1.13.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-multus-1.13.3@sha256:6e7245922c44d06374534bbce7981934a964efd075e6de44bd532d869f267811"
+image="k8s-multus-1.13.3@sha256:c0bcf0d2e992e5b4d96a7bcbf988b98b64c4f5aef2f2c4d1c291e90b85529738"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/os-3.11.0-crio/provider.sh
+++ b/cluster-up/cluster/os-3.11.0-crio/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source ${KUBEVIRTCI_PATH}/cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-crio@sha256:66b348692b70c8017ef4e914f08252de5c26145640c516f749d38fc78c666589"
+image="os-3.11.0-crio@sha256:71ea794ff45e06ac521e2fe867f192b98ae989755629e4830ab919ecd3905337"

--- a/cluster-up/cluster/os-3.11.0-multus/provider.sh
+++ b/cluster-up/cluster/os-3.11.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source ${KUBEVIRTCI_PATH}/cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-multus@sha256:adabdd119fe04d1808c57418369ea7ec84b94770f1686ca168f079c6618b23a4"
+image="os-3.11.0-multus@sha256:0c8be10799490a1f86740eaa490063f51eab78b920540f0a2946abc5e0bf30fe"

--- a/cluster-up/cluster/os-3.11.0/provider.sh
+++ b/cluster-up/cluster/os-3.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="os-3.11.0@sha256:ff54198c7eaa51ccf2aeff6d5dd1e9ca51ccfec6ee0237b0305fb3b6761f95f6"
+image="os-3.11.0@sha256:ebc9048f25eb5cc720b8b4eeab7b58b5fa3648d27c9612d87bf338d5dbee46a7"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 


### PR DESCRIPTION
Qemu is able to create the tuntap devices, but we have to add them to the br0 bridge
before qemu, so let's pre-recreate them like we do with primary nic.

Signed-off-by: Quique Llorente <ellorent@redhat.com>