### PR TITLE
Fix ssh.sh to use KUBEVIRT_PROVIDER instead of $provider_prefix

### DIFF
--- a/cluster-up/ssh.sh
+++ b/cluster-up/ssh.sh
@@ -26,7 +26,7 @@ if [ -z "$node" ]; then
     exit 1
 fi
 
-if [[ $provider_prefix =~ okd.* ]]; then
+if [[ $KUBEVIRT_PROVIDER =~ okd.* ]]; then
     ports=$(${KUBEVIRTCI_PATH}cli.sh --prefix $provider_prefix ports --container-name cluster)
 
     if [[ $node =~ worker-0.* ]]; then
@@ -41,7 +41,7 @@ if [[ $provider_prefix =~ okd.* ]]; then
     fi
     shift
     ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -q -lcore -p $port core@127.0.0.1 -i ${ssh_key} $@
-elif [[ $provider_prefix =~ kind.* ]]; then
+elif [[ $KUBEVIRT_PROVIDER =~ kind.* ]]; then
     _ssh_into_node "$@"
 else
     ${_cli} --prefix $provider_prefix ssh "$@"


### PR DESCRIPTION
Background:
For CDI for OKD, we run a script on each host to prepare storage which requires ssh.sh to complete. This runs great as is on a development system. However when calling ssh.sh in a jenkins environment, $provider_prefix is overriden to be the JOB_NAME in hack/common.sh

```bash
#If run on jenkins, let us create isolated environments based on the job and
provider_prefix=${JOB_NAME:-${KUBEVIRT_PROVIDER}}${EXECUTOR_NUMBER}
job_prefix=${JOB_NAME:-kubevirt}${EXECUTOR_NUMBER}
```

This will then fail the regex in the if to determine what type of system we are connecting to. This PR changes the $provider_prefix back to $KUBEVIRT_PROVIDER so that the regex will properly work in jenkins as well as development environments.

Signed-off-by: Alexander Wels <awels@redhat.com>