### PR TITLE
Add validation that no unexpected node exists after cluster up

### DIFF
--- a/cluster-up/up.sh
+++ b/cluster-up/up.sh
@@ -11,3 +11,10 @@ fi
 source ${KUBEVIRTCI_PATH}hack/common.sh
 source ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/provider.sh
 up
+
+# check if the environment has a corrupted host
+if [[ $(${KUBEVIRTCI_PATH}kubectl.sh get nodes | grep localhost) != "" ]]; then
+    echo "The environment has a corrupted host"
+    exit 1
+fi
+


### PR DESCRIPTION
In case node deploying fails, there will be a corrutped node named
localhost, in this case make cluster-up should failed with an error.