### PR TITLE
Use KUBEVIRT_NUM_NODES to determine the number of workers for OKD 4.1

### DIFF
--- a/cluster-up/cluster/okd-4.1/provider.sh
+++ b/cluster-up/cluster/okd-4.1/provider.sh
@@ -11,7 +11,12 @@ function _port() {
 }
 
 function up() {
-    params="--random-ports --background --prefix $provider_prefix --master-cpu 6 --workers-cpu 6 --registry-volume $(_registry_volume) --workers 2 kubevirtci/${image}"
+    workers=$(($KUBEVIRT_NUM_NODES-1))
+    if [[ ( $workers < 1 ) ]]; then
+        workers=1
+    fi
+    echo "Number of workers: $workers"
+    params="--random-ports --background --prefix $provider_prefix --master-cpu 6 --workers-cpu 6 --registry-volume $(_registry_volume) --workers $workers kubevirtci/${image}"
     if [[ ! -z "${RHEL_NFS_DIR}" ]]; then
         params=" --nfs-data $RHEL_NFS_DIR ${params}"
     fi


### PR DESCRIPTION
A minimum of 1 worker
KUBEVIRT_NUM_NODES=4 = 3 workers
KUBEVIRT_NUM_NODES=3 = 2 workers
KUBEVIRT_NUM_NODES=2 = 1 workers
KUBEVIRT_NUM_NODES=1 = 1 workers
KUBEVIRT_NUM_NODES=0 = 1 workers

Signed-off-by: Alexander Wels <awels@redhat.com>