### PR TITLE
Export KUBEVIRTCI_CONFIG_PATH to fix sriov provider.

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -6,6 +6,7 @@ NODE_CMD="docker exec -it -d "
 export KIND_MANIFESTS_DIR="${KUBEVIRTCI_PATH}/cluster/kind/manifests"
 export KIND_NODE_CLI="docker exec -it "
 export KUBEVIRTCI_PATH
+export KUBEVIRTCI_CONFIG_PATH
 
 function _wait_kind_up {
     echo "Waiting for kind to be ready ..."  


### PR DESCRIPTION
While porting the setup from https://github.com/kubevirt/kubevirt/pull/2562 to here, I forgot a tiny change on common.sh to export `KUBEVIRT_CI_CONFIG_PATH` .
