### PR TITLE
Replace the sriov cni image used by the openshift operator with the upstream one.

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -22,6 +22,11 @@ function deploy_sriov_operator {
   fi
 
   pushd $OPERATOR_PATH
+    # TODO: right now in CI we need to use upstream sriov cni in order to have this
+    # https://github.com/intel/sriov-cni/pull/88 available. This can be removed once the feature will
+    # be merged in openshift sriov operator. We need latest since that feature was not tagged yet
+    sed -i '/SRIOV_CNI_IMAGE/!b;n;c\              value: nfvpe\/sriov-cni' ./deploy/operator.yaml
+
     # on prow nodes the default shell is dash and some commands are not working
     make deploy-setup-k8s SHELL=/bin/bash OPERATOR_EXEC=kubectl
   popd


### PR DESCRIPTION
In order to fully test the sr-iov feature we need to ship the intel sriov cni plugin instead of the one shipped with the operator (at least, until https://github.com/intel/sriov-cni/pull/88 is merged in the openshift sr-iov operator).

This pr replaces the sriov cni image with the intel one before deploying the operator.