### PR TITLE
hack: add simple pre-flight check to cluster-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 cluster-up:
-	./cluster-up/check.sh && ./cluster-up/up.sh
+	./cluster-up/check.sh
+	./cluster-up/up.sh
 
 cluster-down:
 	./cluster-up/down.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 cluster-up:
-	./cluster-up/up.sh
+	./cluster-up/check.sh && ./cluster-up/up.sh
 
 cluster-down:
 	./cluster-up/down.sh

--- a/cluster-up/check.sh
+++ b/cluster-up/check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2019 Red Hat, Inc.
+#
+
+set -e
+if [ ! -c /dev/kvm ]; then
+	echo "[ERR ] missing /dev/kvm"
+	exit 1
+fi
+echo "[ OK ] found /dev/kvm"
+
+KVM_ARCH=""
+KVM_NESTED="unknown"
+if [ -f "/sys/module/kvm_intel/parameters/nested" ]; then
+	KVM_NESTED=$( cat /sys/module/kvm_intel/parameters/nested )
+	KVM_ARCH="intel"
+elif [ -f "/sys/module/kvm_amd/parameters/nested" ]; then
+	KVM_NESTED=$( cat /sys/module/kvm_amd/parameters/nested )
+	KVM_ARCH="amd"
+fi
+if [ "$KVM_NESTED" != "Y" ]; then
+	echo "[ERR ] $KVM_ARCH nested virtualization not enabled"
+	exit 1
+fi
+echo "[ OK ] $KVM_ARCH nested virtualization enabled"

--- a/cluster-up/check.sh
+++ b/cluster-up/check.sh
@@ -20,9 +20,9 @@
 set -e
 if [ ! -c /dev/kvm ]; then
 	echo "[ERR ] missing /dev/kvm"
-	exit 1
+else
+	echo "[ OK ] found /dev/kvm"
 fi
-echo "[ OK ] found /dev/kvm"
 
 KVM_ARCH=""
 KVM_NESTED="unknown"
@@ -35,6 +35,6 @@ elif [ -f "/sys/module/kvm_amd/parameters/nested" ]; then
 fi
 if [ "$KVM_NESTED" != "Y" ]; then
 	echo "[ERR ] $KVM_ARCH nested virtualization not enabled"
-	exit 1
+else
+	echo "[ OK ] $KVM_ARCH nested virtualization enabled"
 fi
-echo "[ OK ] $KVM_ARCH nested virtualization enabled"


### PR DESCRIPTION
It still happens nowdays that we run kubevirtci on wrongly provisioned
boxes with incorrect kvm setup.
This patch adds a simple pre-flight check script to catch the most
common issues, hopefully preventing more time wasted in debugging
cluster running on these wrong setups.

Signed-off-by: Francesco Romani <fromani@redhat.com>