### PR TITLE
Add gocli qemu option to attach serial to PTY

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ SSH into a node
 cluster-up/ssh.sh node01
 ```
 
+Attach to node console with socat and pty (non okd4 providers)
+```
+# Get node01 container id
+node01_id=$(docker ps |grep node01 |awk '{print $1}')
+
+# Install socat
+docker exec $node01_id yum install -y socat
+
+# Attach to node01 console
+docker exec -it $node01_id socat - /dev/pts/0
+```
+
 # Getting Started with multi-node OKD Provider
 
 Download this repo

--- a/cluster-provision/README.md
+++ b/cluster-provision/README.md
@@ -15,7 +15,7 @@
 ## Versions to use
 
 * `kubevirtci/cli`: `sha256:1dd015dea4f12e6dcb8e31be3eeb677fed96f290ef4a4892a33c43d666053536`
-* `kubevirtci/gocli`: `sha256:9ca5dfbb4c4e70aefcc63942073808037a39eec3394bb6f9416d4c1ca3340997`
+* `kubevirtci/gocli`: `sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a`
 * `kubevirtci/base`: `sha256:850ac2e2828610b5f35f004f2a8a1ab23609a4c7891c8a1b68cbb7eef5f5dda0`
 * `kubevirtci/centos:1905_01`: `sha256:4b292b646f382d986c75a2be8ec49119a03467fe26dccc3a0886eb9e6e38c911`
 * `kubevirtci/os-3.11.0-multus`: `sha256:0c8be10799490a1f86740eaa490063f51eab78b920540f0a2946abc5e0bf30fe`

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -371,6 +371,10 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
+	// Add serial pty so we can do stuff like 'socat - /dev/pts0' to access
+	// the VM console from the container without ssh
+	qemuArgs += " -serial pty"
+
 	wg := sync.WaitGroup{}
 	wg.Add(int(nodes))
 	// start one vm after each other

--- a/cluster-provision/okd/4.1/provision.sh
+++ b/cluster-provision/okd/4.1/provision.sh
@@ -5,7 +5,7 @@ set -x
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )"
 
 okd_base_hash="sha256:259e776998da3a503a30fdf935b29102443b24ca4ea095c9478c37e994e242bb"
-gocli_image_hash="sha256:9ca5dfbb4c4e70aefcc63942073808037a39eec3394bb6f9416d4c1ca3340997"
+gocli_image_hash="sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a"
 
 gocli="docker run \
 --privileged \

--- a/cluster-provision/okd/4.1/run.sh
+++ b/cluster-provision/okd/4.1/run.sh
@@ -3,7 +3,7 @@
 set -x
 
 okd_image_hash="sha256:76b487d894ab89a91ba4985591a7ff05e91be9665face1492c23405aad2d0201"
-gocli_image_hash="sha256:9ca5dfbb4c4e70aefcc63942073808037a39eec3394bb6f9416d4c1ca3340997"
+gocli_image_hash="sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"
 

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-_cli_container="kubevirtci/gocli@sha256:9ca5dfbb4c4e70aefcc63942073808037a39eec3394bb6f9416d4c1ca3340997"
+_cli_container="kubevirtci/gocli@sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a"
 _cli_with_tty="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 _cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 


### PR DESCRIPTION
In case ssh is down or not accesible is not possible
to attach directly to the console with current providers.

This patch add a gocli option 'serial-pty' to attach serial port to pty device
at qemu run so one can do 'socat - /dev/pts/0' and access the virtual machines