### PR TITLE
Don't use host kubectl when provisioning sriov provider

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 set -x
 
+source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
+
 MANIFESTS_DIR="${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/manifests"
 
 MASTER_NODE="${CLUSTER_NAME}-control-plane"
@@ -11,9 +13,9 @@ OPERATOR_GIT_HASH=b3ab84a316e16df392fbe9e07dbe0667ad075855
 # not using kubectl wait since with the sriov operator the pods get restarted a couple of times and this is
 # more reliable
 function wait_pods_ready {
-    while [ -n "$(kubectl get pods --all-namespaces -o'custom-columns=status:status.containerStatuses[*].ready,metadata:metadata.name' --no-headers | grep false)" ]; do
+    while [ -n "$(_kubectl get pods --all-namespaces -o'custom-columns=status:status.containerStatuses[*].ready,metadata:metadata.name' --no-headers | grep false)" ]; do
         echo "Waiting for all pods to become ready ..."
-        kubectl get pods --all-namespaces -o'custom-columns=status:status.containerStatuses[*].ready,metadata:metadata.name' --no-headers
+        _kubectl get pods --all-namespaces -o'custom-columns=status:status.containerStatuses[*].ready,metadata:metadata.name' --no-headers
         sleep 10
     done
 }
@@ -31,11 +33,11 @@ function deploy_sriov_operator {
     sed -i '/SRIOV_CNI_IMAGE/!b;n;c\              value: nfvpe\/sriov-cni' ./deploy/operator.yaml
 
     # on prow nodes the default shell is dash and some commands are not working
-    make deploy-setup-k8s SHELL=/bin/bash OPERATOR_EXEC=kubectl
+    make deploy-setup-k8s SHELL=/bin/bash OPERATOR_EXEC="${KUBECTL}"
   popd
 }
 
-if [[ -z "$(kubectl get nodes | grep $FIRST_WORKER_NODE)" ]]; then
+if [[ -z "$(_kubectl get nodes | grep $FIRST_WORKER_NODE)" ]]; then
   SRIOV_NODE=$MASTER_NODE
 else
   SRIOV_NODE=$FIRST_WORKER_NODE
@@ -57,9 +59,9 @@ for ifs in "${sriov_pfs[@]}"; do
     continue
   fi
 
-  # These values are used to populate the network definition policy yaml. 
+  # These values are used to populate the network definition policy yaml.
   # We just use the first suitable pf
-  # We need the num of vfs because if we don't set this value equals to the total, in case of mellanox 
+  # We need the num of vfs because if we don't set this value equals to the total, in case of mellanox
   # the sriov operator will trigger a node reboot to update the firmware
   export NODE_PF="$ifs_name"
   export NODE_PF_NUM_VFS=$(cat /sys/class/net/"$NODE_PF"/device/sriov_totalvfs)
@@ -69,7 +71,7 @@ done
 ip link set "$NODE_PF" netns "$SRIOV_NODE"
 
 # deploy multus
-kubectl create -f $MANIFESTS_DIR/multus.yaml
+_kubectl create -f $MANIFESTS_DIR/multus.yaml
 
 # give them some time to create pods before checking pod status
 sleep 10
@@ -83,9 +85,9 @@ ${SRIOV_NODE_CMD} mount -o remount,rw /sys     # kind remounts it as readonly wh
 
 deploy_sriov_operator
 
-kubectl label node $SRIOV_NODE node-role.kubernetes.io/worker=
-kubectl label node $SRIOV_NODE sriov=true 
-envsubst < $MANIFESTS_DIR/network_config_policy.yaml | kubectl create -f -
+_kubectl label node $SRIOV_NODE node-role.kubernetes.io/worker=
+_kubectl label node $SRIOV_NODE sriov=true
+envsubst < $MANIFESTS_DIR/network_config_policy.yaml | _kubectl create -f -
 
 
 wait_pods_ready

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -8,6 +8,8 @@ export KIND_NODE_CLI="docker exec -it "
 export KUBEVIRTCI_PATH
 export KUBEVIRTCI_CONFIG_PATH
 
+KUBECTL="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl --kubeconfig=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig"
+
 REGISTRY_NAME=${CLUSTER_NAME}-registry
 
 function _wait_kind_up {
@@ -119,8 +121,7 @@ function kind_up() {
 }
 
 function _kubectl() {
-    export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
-    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl "$@"
+    ${KUBECTL} "$@"
 }
 
 function down() {


### PR DESCRIPTION
The host client version may be too old and not compatible with our
manifests.

```release-note
NONE
```