### PR TITLE
Provide a cluster based registry name - fix

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -68,7 +68,7 @@ function _run_registry() {
 
 function _configure_registry_on_node() {
     _configure-insecure-registry-and-reload "${NODE_CMD} $1 bash -c"
-    ${NODE_CMD} $1 socat TCP-LISTEN:5000,fork TCP:$(docker inspect --format '{{.NetworkSettings.IPAddress }}' registry):5000
+    ${NODE_CMD} $1 socat TCP-LISTEN:5000,fork TCP:$(docker inspect --format '{{.NetworkSettings.IPAddress }}' $REGISTRY_NAME):5000
 }
 
 function prepare_config() {


### PR DESCRIPTION
With https://github.com/kubevirt/kubevirtci/pull/156 we changed the name of the registry name, but the port mapping inside the nodes was not updated, so the cluster starts but it's not possible to pull images from the local registry.
