### PR TITLE
Update OKD 4.1 version

### DIFF
--- a/cluster-provision/README.md
+++ b/cluster-provision/README.md
@@ -36,7 +36,7 @@
 ## Versions to use
 
 * `kubevirtci/okd-base`: `sha256:259e776998da3a503a30fdf935b29102443b24ca4ea095c9478c37e994e242bb`
-* `kubevirtci/okd-4.1`: `sha256:76b487d894ab89a91ba4985591a7ff05e91be9665face1492c23405aad2d0201`
+* `kubevirtci/okd-4.1`: `sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8`
 
 ## Using gocli
 
@@ -81,7 +81,7 @@ NOTE: OpenShift cluster consumes a lot of resources, you should have at least 18
 
 You should run `gocli` command:
 ```bash
-gocli run okd --prefix okd-4.1 --ocp-console-port 443 --background kubevirtci/okd-4.1@sha256:76b487d894ab89a91ba4985591a7ff05e91be9665face1492c23405aad2d0201
+gocli run okd --prefix okd-4.1 --ocp-console-port 443 --background kubevirtci/okd-4.1@sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8
 ```
 
 ### How to connect to the OKD console

--- a/cluster-provision/okd/4.1/provision.sh
+++ b/cluster-provision/okd/4.1/provision.sh
@@ -23,5 +23,5 @@ ${gocli} provision okd \
 --master-memory 10240 \
 --installer-pull-token-file ${INSTALLER_PULL_SECRET} \
 --installer-repo-tag release-4.1 \
---installer-release-image docker.io/kubevirtci/ocp-release:4.1.15 \
+--installer-release-image docker.io/kubevirtci/ocp-release:4.1.18 \
 "kubevirtci/okd-base@${okd_base_hash}"

--- a/cluster-provision/okd/4.1/run.sh
+++ b/cluster-provision/okd/4.1/run.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-okd_image_hash="sha256:76b487d894ab89a91ba4985591a7ff05e91be9665face1492c23405aad2d0201"
+okd_image_hash="sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8"
 gocli_image_hash="sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"

--- a/cluster-up/cluster/okd-4.1/provider.sh
+++ b/cluster-up/cluster/okd-4.1/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="okd-4.1@sha256:76b487d894ab89a91ba4985591a7ff05e91be9665face1492c23405aad2d0201"
+image="okd-4.1@sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 
@@ -27,7 +27,7 @@ function up() {
         workers=1
     fi
     echo "Number of workers: $workers"
-    params="--random-ports --background --prefix $provider_prefix --master-cpu 6 --workers-cpu 6 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --registry-volume $(_registry_volume) --workers $workers kubevirtci/${image}"
+    params="--random-ports --background --prefix $provider_prefix --master-cpu 6 --workers-cpu 6 --workers-memory 8192 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --registry-volume $(_registry_volume) --workers $workers kubevirtci/${image}"
     if [[ ! -z "${RHEL_NFS_DIR}" ]]; then
         params=" --nfs-data $RHEL_NFS_DIR ${params}"
     fi


### PR DESCRIPTION
- update version to 4.1.18
- increase workers memory on the runtime
- increase workers disk space(injected via our custom release image)

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>