### PR TITLE
Deploy github.com/intel/network-resources-injector to the cluster.

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -40,7 +40,7 @@ function deploy_sriov_operator {
 
 function deploy_network_resource_injector {
   webhook_path=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/network-resources-injector-${INJECTOR_GIT_HASH}
-  if [[ ! -d $webhook_path ]]; then
+  if [ ! -d $webhook_path ]; then
     curl -L https://github.com/intel/network-resources-injector/archive/${INJECTOR_GIT_HASH}/network-resources-injector.tar.gz | tar xz -C ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/
   fi
 

--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -47,7 +47,7 @@ function deploy_network_resource_injector {
   pushd $webhook_path
     make image
     docker tag network-resources-injector localhost:5000/network-resources-injector
-    sed -i 's/network-resources-injector:latest/registry:5000\/network-resources-injector:latest/g' ./deployments/server.yaml
+    sed -i 's#image: network-resources-injector:latest#image: registry:5000/network-resources-injector:latest#' ./deployments/server.yaml
     docker push localhost:5000/network-resources-injector
     _kubectl apply -f ./deployments/auth.yaml
     _kubectl apply -f ./deployments/server.yaml

--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -39,12 +39,12 @@ function deploy_sriov_operator {
 }
 
 function deploy_network_resource_injector {
-  WEBHOOK_PATH=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/network-resources-injector-${INJECTOR_GIT_HASH}
-  if [[ ! -d $WEBHOOK_PATH ]]; then
+  webhook_path=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/network-resources-injector-${INJECTOR_GIT_HASH}
+  if [[ ! -d $webhook_path ]]; then
     curl -L https://github.com/intel/network-resources-injector/archive/${INJECTOR_GIT_HASH}/network-resources-injector.tar.gz | tar xz -C ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/
   fi
 
-  pushd $WEBHOOK_PATH
+  pushd $webhook_path
     make image
     docker tag network-resources-injector localhost:5000/network-resources-injector
     sed -i 's/network-resources-injector:latest/registry:5000\/network-resources-injector:latest/g' ./deployments/server.yaml

--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -111,6 +111,8 @@ envsubst < $MANIFESTS_DIR/network_config_policy.yaml | _kubectl create -f -
 wait_pods_ready
 
 deploy_network_resource_injector
+
+# give the injector installer some time to create pods before checking pod status
 sleep 5
 wait_pods_ready
 

--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -22,12 +22,12 @@ function wait_pods_ready {
 }
 
 function deploy_sriov_operator {
-  OPERATOR_PATH=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/sriov-network-operator-${OPERATOR_GIT_HASH}
-  if [[ ! -d $OPERATOR_PATH ]]; then
+  operator_path=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/sriov-network-operator-${OPERATOR_GIT_HASH}
+  if [ ! -d $operator_path ]; then
     curl -L https://github.com/openshift/sriov-network-operator/archive/${OPERATOR_GIT_HASH}/sriov-network-operator.tar.gz | tar xz -C ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/
   fi
 
-  pushd $OPERATOR_PATH
+  pushd $operator_path
     # TODO: right now in CI we need to use upstream sriov cni in order to have this
     # https://github.com/intel/sriov-cni/pull/88 available. This can be removed once the feature will
     # be merged in openshift sriov operator. We need latest since that feature was not tagged yet


### PR DESCRIPTION
The resources injector is a mutating webhook that adds resource requests based on
the needed resources declared on the network attachment definition.
It's going to be deployed together with the sr-iov operator so we want to be sure it's compatible with kubevirt.
