### PR TITLE
Add a note with another reason to use upstream sriov cni image

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -30,6 +30,7 @@ function deploy_sriov_operator {
     # TODO: right now in CI we need to use upstream sriov cni in order to have this
     # https://github.com/intel/sriov-cni/pull/88 available. This can be removed once the feature will
     # be merged in openshift sriov operator. We need latest since that feature was not tagged yet
+    # We also need it for link_state feature used in CI: https://github.com/intel/sriov-cni/pull/102
     sed -i '/SRIOV_CNI_IMAGE/!b;n;c\              value: nfvpe\/sriov-cni' ./deploy/operator.yaml
 
     # on prow nodes the default shell is dash and some commands are not working


### PR DESCRIPTION
```release-note
NONE
```