### PR TITLE
Use RHCOS 4.3 based on RHEL 8.1 for okd 4.1

### DIFF
--- a/cluster-provision/okd/4.1/provision.sh
+++ b/cluster-provision/okd/4.1/provision.sh
@@ -23,5 +23,5 @@ ${gocli} provision okd \
 --master-memory 10240 \
 --installer-pull-token-file ${INSTALLER_PULL_SECRET} \
 --installer-repo-tag release-4.1 \
---installer-release-image docker.io/kubevirtci/ocp-release:4.1.18 \
+--installer-release-image registry.svc.ci.openshift.org/rhcos-devel/vrutkovs-ocp-release:43vrutkovs.81.20191023.1 \
 "kubevirtci/okd-base@${okd_base_hash}"


### PR DESCRIPTION
For kubernetes-nmstate we need a NetworkManager >= 1.20, that's
only present at RHEL >= 8.1, this upgrade the base image to it.

Signed-off-by: Quique Llorente <ellorent@redhat.com>