### PR TITLE
Tamper the sriov-network-operator image with a fixed tag

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -32,6 +32,7 @@ function deploy_sriov_operator {
     # https://github.com/intel/sriov-cni/pull/88 available. This can be removed once the feature will
     # be merged in openshift sriov operator. We need latest since that feature was not tagged yet
     sed -i '/SRIOV_CNI_IMAGE/!b;n;c\              value: nfvpe\/sriov-cni' ./deploy/operator.yaml
+    sed -i 's#image: quay.io/openshift/origin-sriov-network-operator$#image: quay.io/openshift/origin-sriov-network-operator:4.2#' ./deploy/operator.yaml
 
     # on prow nodes the default shell is dash and some commands are not working
     make deploy-setup-k8s SHELL=/bin/bash OPERATOR_EXEC="${KUBECTL}"


### PR DESCRIPTION
Despite downloading a commit sha, the operator manifest we use refers to `latest` when downloading the sr-iov operator image.

With this PR we tamper the manifest in order to stick with the version we were using before.
