### PR TITLE
cluster: add support for different runtimes

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -3,8 +3,11 @@
 set -e
 
 _cli_container="kubevirtci/gocli@sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a"
-_cli_with_tty="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
-_cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
+if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
+	_cli="pack8s"
+else
+	_cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
+fi
 
 function _main_ip() {
     echo 127.0.0.1

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-_cli_container="kubevirtci/gocli@sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a"
 if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
 	_cli="pack8s"
 else
+	_cli_container="kubevirtci/gocli@sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a"
 	_cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 fi
 


### PR DESCRIPTION
with this patch, we open the road for different helper tools in addition
to the standard `gocli`, which is still the default choice.
We want to make room for the future podman support, which is currently
experimented with in `github.com/fromanirh/pack8s`, and this seems
the safest and less invasive way.

Signed-off-by: Francesco Romani <fromani@redhat.com>