### PR TITLE
Parameterize cluster container url preffix

### DIFF
--- a/cluster-provision/README.md
+++ b/cluster-provision/README.md
@@ -15,7 +15,7 @@
 ## Versions to use
 
 * `kubevirtci/cli`: `sha256:1dd015dea4f12e6dcb8e31be3eeb677fed96f290ef4a4892a33c43d666053536`
-* `kubevirtci/gocli`: `sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a`
+* `kubevirtci/gocli`: `sha256:483733ad03e7ac5e81df5ff90042ca92bb7c5f0b998cca89bd4c1a2bf17ea337`
 * `kubevirtci/base`: `sha256:850ac2e2828610b5f35f004f2a8a1ab23609a4c7891c8a1b68cbb7eef5f5dda0`
 * `kubevirtci/centos:1905_01`: `sha256:4b292b646f382d986c75a2be8ec49119a03467fe26dccc3a0886eb9e6e38c911`
 * `kubevirtci/os-3.11.0-multus`: `sha256:0c8be10799490a1f86740eaa490063f51eab78b920540f0a2946abc5e0bf30fe`

--- a/cluster-provision/gocli/cmd/okd/run.go
+++ b/cluster-provision/gocli/cmd/okd/run.go
@@ -42,6 +42,7 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().Uint("ssh-worker-port", 0, "port on localhost to ssh to worker node")
 	run.Flags().Bool("background", false, "go to background after nodes are up")
 	run.Flags().Bool("random-ports", true, "expose all ports on random localhost ports")
+	run.Flags().String("container-suffix", "docker.io/", "the suffix for pull url")
 	return run
 }
 
@@ -96,6 +97,11 @@ func run(cmd *cobra.Command, args []string) (err error) {
 
 	portMap := nat.PortMap{}
 
+	containerSuffix, err := cmd.Flags().GetString("container-suffix")
+	if err != nil {
+		return err
+	}
+
 	utils.AppendIfExplicit(portMap, utils.PortSSH, cmd.Flags(), "ssh-master-port")
 	utils.AppendIfExplicit(portMap, utils.PortSSHWorker, cmd.Flags(), "ssh-worker-port")
 	utils.AppendIfExplicit(portMap, utils.PortAPI, cmd.Flags(), "k8s-port")
@@ -142,8 +148,8 @@ func run(cmd *cobra.Command, args []string) (err error) {
 	}()
 
 	// Pull the cluster image
-	fmt.Printf("Download the image %s\n", "docker.io/"+cluster)
-	err = docker.ImagePull(cli, ctx, "docker.io/"+cluster, types.ImagePullOptions{})
+	fmt.Printf("Download the image %s\n", containerSuffix+cluster)
+	err = docker.ImagePull(cli, ctx, containerSuffix+cluster, types.ImagePullOptions{})
 	if err != nil {
 		panic(err)
 	}

--- a/cluster-provision/okd/4.1/provision.sh
+++ b/cluster-provision/okd/4.1/provision.sh
@@ -5,7 +5,7 @@ set -x
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )"
 
 okd_base_hash="sha256:259e776998da3a503a30fdf935b29102443b24ca4ea095c9478c37e994e242bb"
-gocli_image_hash="sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a"
+gocli_image_hash="sha256:483733ad03e7ac5e81df5ff90042ca92bb7c5f0b998cca89bd4c1a2bf17ea337"
 
 gocli="docker run \
 --privileged \

--- a/cluster-provision/okd/4.1/run.sh
+++ b/cluster-provision/okd/4.1/run.sh
@@ -3,7 +3,7 @@
 set -x
 
 okd_image_hash="sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8"
-gocli_image_hash="sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a"
+gocli_image_hash="sha256:483733ad03e7ac5e81df5ff90042ca92bb7c5f0b998cca89bd4c1a2bf17ea337"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"
 

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -5,7 +5,7 @@ set -e
 if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
 	_cli="pack8s"
 else
-	_cli_container="kubevirtci/gocli@sha256:f6145018927094a6b62ac89fdb26f5901cb8030d9120f620b2490c9c9c25655a"
+	_cli_container="kubevirtci/gocli@sha256:483733ad03e7ac5e81df5ff90042ca92bb7c5f0b998cca89bd4c1a2bf17ea337"
 	_cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 fi
 


### PR DESCRIPTION
When creating new providers is save time if you can run
the local ones, passing empty string here will allow that
so you don't have to push to a repository.

Signed-off-by: Quique Llorente <ellorent@redhat.com>