### PR TITLE
Refactor okd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.img
 cli
 .idea
-/gocli/bazel**
+/cluster-provision/gocli/bazel**
 log.txt
 _ci-configs/*

--- a/cluster-provision/README.md
+++ b/cluster-provision/README.md
@@ -58,7 +58,7 @@ gocli help
 
 First you will need to create installer pull token file with the content:
 ```
-pullSecret: <pull secret>
+{"auths":{...}}
 ```
 
 and after you should run `gocli` command:
@@ -68,14 +68,14 @@ gocli provision okd \
 --dir-scripts <scripts_folder>/scripts \
 --dir-hacks <hacks_folder>/hacks \
 --master-memory 10240 \
---installer-pull-secret-file <installer_secret_token> \
+--installer-pull-secret-file <installer_pull_secret_file> \
 --installer-repo-tag release-4.1 \
 --installer-release-image quay.io/openshift-release-dev/ocp-release:4.1 \
 kubevirtci/okd-base@sha256:73ede51ce464546a82b81956b7f58cf98662a4c5fded9c659b57746bc131e047
 ```
 
 ***
-NOTE: you can get the pull secret [here](https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/auth?client_id=uhc&redirect_uri=https%3A%2F%2Fcloud.openshift.com%2Fclusters%2Finstall%23pull-secret&state=109aa48e-1779-45d6-9bdc-c156b1e699b4&response_mode=fragment&response_type=code&scope=openid&nonce=b9fe0085-f2c9-4fd7-bd17-e8629f01bbaf).
+NOTE: you can get the pull secret [here](https://cloud.redhat.com/openshift).
 ***
 
 ***
@@ -86,7 +86,7 @@ NOTE: OpenShift cluster consumes a lot of resources, you should have at least 18
 
 You should run `gocli` command:
 ```bash
-gocli run okd --prefix okd-4.1 --ocp-console-port 443 --background kubevirtci/okd-4.1@sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8
+gocli run okd --prefix okd-4.1 --ocp-console-port 443 --installer-pull-secret-file <installer_pull_secret_file> --background kubevirtci/okd-4.1@sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8
 ```
 
 ### How to connect to the OKD console

--- a/cluster-provision/README.md
+++ b/cluster-provision/README.md
@@ -15,7 +15,7 @@
 ## Versions to use
 
 * `kubevirtci/cli`: `sha256:1dd015dea4f12e6dcb8e31be3eeb677fed96f290ef4a4892a33c43d666053536`
-* `kubevirtci/gocli`: `sha256:5ab9913a535227766f814b3a497d0eb1eede1a86a289d3e8bfb6bbd91836f11c`
+* `kubevirtci/gocli`: `sha256:f032efbd59718d48381ae2544799b44adfefa17bcd029ee6bbefdf82f53c35bc`
 * `kubevirtci/base`: `sha256:850ac2e2828610b5f35f004f2a8a1ab23609a4c7891c8a1b68cbb7eef5f5dda0`
 * `kubevirtci/centos:1905_01`: `sha256:4b292b646f382d986c75a2be8ec49119a03467fe26dccc3a0886eb9e6e38c911`
 * `kubevirtci/os-3.11.0-multus`: `sha256:0c8be10799490a1f86740eaa490063f51eab78b920540f0a2946abc5e0bf30fe`
@@ -38,8 +38,9 @@
 
 ## Versions to use
 
-* `kubevirtci/okd-base`: `sha256:259e776998da3a503a30fdf935b29102443b24ca4ea095c9478c37e994e242bb`
-* `kubevirtci/okd-4.1`: `sha256:b26decaf0454cc1f99b39b9bc991f715a8d6d8e97499db5a2d40f778430972f7`
+* `kubevirtci/okd-base`: `sha256:73ede51ce464546a82b81956b7f58cf98662a4c5fded9c659b57746bc131e047`
+* `kubevirtci/okd-4.1`: `sha256:67fe42feea8256f07069d776d4c4cecff6294ff8a5af67d719eca6c08548b45d`
+* `kubevirtci/okd-4.2`: `sha256:998f79c90c635dbd8d752752c1ee1a731e40b36bbc089b00f9cdf332e6cdb72e`
 * `kubevirtci/okd-4.3`: `sha256:63abc3884002a615712dfac5f42785be864ea62006892bf8a086ccdbca8b3d38`
 
 ## Using gocli
@@ -67,10 +68,10 @@ gocli provision okd \
 --dir-scripts <scripts_folder>/scripts \
 --dir-hacks <hacks_folder>/hacks \
 --master-memory 10240 \
---installer-pull-token-file <installer_pull_token_file> \
+--installer-pull-secret-file <installer_secret_token> \
 --installer-repo-tag release-4.1 \
 --installer-release-image quay.io/openshift-release-dev/ocp-release:4.1 \
-kubevirtci/okd-base@sha256:259e776998da3a503a30fdf935b29102443b24ca4ea095c9478c37e994e242bb
+kubevirtci/okd-base@sha256:73ede51ce464546a82b81956b7f58cf98662a4c5fded9c659b57746bc131e047
 ```
 
 ***

--- a/cluster-provision/gocli/BUILD
+++ b/cluster-provision/gocli/BUILD
@@ -39,13 +39,13 @@ load(
 
 gazelle(
     name = "gazelle",
-    prefix = "kubevirt.io/kubevirtci/gocli",
+    prefix = "kubevirt.io/kubevirtci/cluster-provision/gocli",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
-    importpath = "kubevirt.io/kubevirtci/gocli",
+    importpath = "kubevirt.io/kubevirtci/cluster-provision/gocli",
     deps = ["//cmd:go_default_library"],
 )
 

--- a/cluster-provision/gocli/cmd/BUILD.bazel
+++ b/cluster-provision/gocli/cmd/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "scp.go",
         "ssh.go",
     ],
-    importpath = "kubevirt.io/kubevirtci/gocli/cmd",
+    importpath = "kubevirt.io/kubevirtci/cluster-provision/gocli/cmd",
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/okd:go_default_library",

--- a/cluster-provision/gocli/cmd/okd/BUILD.bazel
+++ b/cluster-provision/gocli/cmd/okd/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "provision.go",
         "run.go",
     ],
-    importpath = "kubevirt.io/kubevirtci/gocli/cmd/okd",
+    importpath = "kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/okd",
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/utils:go_default_library",

--- a/cluster-provision/gocli/cmd/ports.go
+++ b/cluster-provision/gocli/cmd/ports.go
@@ -6,8 +6,8 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 
-	"kubevirt.io/kubevirtci/gocli/cmd/utils"
-	"kubevirt.io/kubevirtci/gocli/docker"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/utils"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/docker"
 )
 
 // NewPortCommand returns new command to expose public ports for the cluster

--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -15,9 +15,9 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 
-	"kubevirt.io/kubevirtci/gocli/cmd/okd"
-	"kubevirt.io/kubevirtci/gocli/cmd/utils"
-	"kubevirt.io/kubevirtci/gocli/docker"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/okd"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/utils"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/docker"
 )
 
 // NewProvisionCommand provision given cluster

--- a/cluster-provision/gocli/cmd/rm.go
+++ b/cluster-provision/gocli/cmd/rm.go
@@ -5,7 +5,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
-	"kubevirt.io/kubevirtci/gocli/docker"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/docker"
 )
 
 // NewRemoveCommand returns command to remove the cluster

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -20,9 +20,9 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 
-	"kubevirt.io/kubevirtci/gocli/cmd/okd"
-	"kubevirt.io/kubevirtci/gocli/cmd/utils"
-	"kubevirt.io/kubevirtci/gocli/docker"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/okd"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/utils"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/docker"
 )
 
 const proxySettings = `

--- a/cluster-provision/gocli/cmd/scp.go
+++ b/cluster-provision/gocli/cmd/scp.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
-	"kubevirt.io/kubevirtci/gocli/cmd/utils"
-	"kubevirt.io/kubevirtci/gocli/docker"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/utils"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/docker"
 
 	"bytes"
 	"fmt"

--- a/cluster-provision/gocli/cmd/ssh.go
+++ b/cluster-provision/gocli/cmd/ssh.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
-	"kubevirt.io/kubevirtci/gocli/docker"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/docker"
 )
 
 // NewSSHCommand returns command to SSH to the cluster node

--- a/cluster-provision/gocli/cmd/utils/BUILD.bazel
+++ b/cluster-provision/gocli/cmd/utils/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "ports.go",
         "utils.go",
     ],
-    importpath = "kubevirt.io/kubevirtci/gocli/cmd/utils",
+    importpath = "kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/utils",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/docker/docker/api/types:go_default_library",

--- a/cluster-provision/gocli/docker/BUILD.bazel
+++ b/cluster-provision/gocli/docker/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["docker.go"],
-    importpath = "kubevirt.io/kubevirtci/gocli/docker",
+    importpath = "kubevirt.io/kubevirtci/cluster-provision/gocli/docker",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/docker/docker/api/types:go_default_library",

--- a/cluster-provision/gocli/main.go
+++ b/cluster-provision/gocli/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"kubevirt.io/kubevirtci/gocli/cmd"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd"
 )
 
 func main() {

--- a/cluster-provision/gocli/vendor/github.com/Microsoft/go-winio/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/Microsoft/go-winio/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "syscall.go",
         "zsyscall_windows.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/Microsoft/go-winio",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/Microsoft/go-winio",
     importpath = "github.com/Microsoft/go-winio",
     visibility = ["//visibility:public"],
     deps = select({

--- a/cluster-provision/gocli/vendor/github.com/Sirupsen/logrus/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/Sirupsen/logrus/BUILD.bazel
@@ -21,7 +21,7 @@ go_library(
         "text_formatter.go",
         "writer.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/Sirupsen/logrus",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/Sirupsen/logrus",
     importpath = "github.com/Sirupsen/logrus",
     visibility = ["//visibility:public"],
     deps = select({

--- a/cluster-provision/gocli/vendor/github.com/docker/distribution/digest/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/distribution/digest/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "set.go",
         "verifiers.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/distribution/digest",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/distribution/digest",
     importpath = "github.com/docker/distribution/digest",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/distribution/reference/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/distribution/reference/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "reference.go",
         "regexp.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/distribution/reference",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/distribution/reference",
     importpath = "github.com/docker/distribution/reference",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/docker/distribution/digest:go_default_library"],

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
         "types.go",
         "volume.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types",
     importpath = "github.com/docker/docker/api/types",
     visibility = ["//visibility:public"],
     deps = [

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/blkiodev/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/blkiodev/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["blkio.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/blkiodev",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/blkiodev",
     importpath = "github.com/docker/docker/api/types/blkiodev",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/container/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/container/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "hostconfig_unix.go",
         "hostconfig_windows.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/container",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/container",
     importpath = "github.com/docker/docker/api/types/container",
     visibility = ["//visibility:public"],
     deps = [

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/events/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/events/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["events.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/events",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/events",
     importpath = "github.com/docker/docker/api/types/events",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/filters/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/filters/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["parse.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/filters",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/filters",
     importpath = "github.com/docker/docker/api/types/filters",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/docker/docker/api/types/versions:go_default_library"],

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/mount/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/mount/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["mount.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/mount",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/mount",
     importpath = "github.com/docker/docker/api/types/mount",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/network/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/network/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["network.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/network",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/network",
     importpath = "github.com/docker/docker/api/types/network",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/reference/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/reference/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["image_reference.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/reference",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/reference",
     importpath = "github.com/docker/docker/api/types/reference",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/docker/distribution/reference:go_default_library"],

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/registry/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/registry/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "authenticate.go",
         "registry.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/registry",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/registry",
     importpath = "github.com/docker/docker/api/types/registry",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/strslice/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/strslice/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["strslice.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/strslice",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/strslice",
     importpath = "github.com/docker/docker/api/types/strslice",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/swarm/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/swarm/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "swarm.go",
         "task.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/swarm",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/swarm",
     importpath = "github.com/docker/docker/api/types/swarm",
     visibility = ["//visibility:public"],
     deps = [

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/time/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/time/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "duration_convert.go",
         "timestamp.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/time",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/time",
     importpath = "github.com/docker/docker/api/types/time",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/versions/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/versions/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["compare.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/versions",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/versions",
     importpath = "github.com/docker/docker/api/types/versions",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/volume/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/volume/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "volumes_create.go",
         "volumes_list.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/api/types/volume",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/api/types/volume",
     importpath = "github.com/docker/docker/api/types/volume",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/docker/docker/api/types:go_default_library"],

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/client/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/client/BUILD.bazel
@@ -108,7 +108,7 @@ go_library(
         "volume_prune.go",
         "volume_remove.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/client",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/client",
     importpath = "github.com/docker/docker/client",
     visibility = ["//visibility:public"],
     deps = [

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/archive/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/archive/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
         "whiteouts.go",
         "wrap.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/pkg/archive",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/archive",
     importpath = "github.com/docker/docker/pkg/archive",
     visibility = ["//visibility:public"],
     deps = [

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/fileutils/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/fileutils/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "fileutils_unix.go",
         "fileutils_windows.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/pkg/fileutils",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/fileutils",
     importpath = "github.com/docker/docker/pkg/fileutils",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/Sirupsen/logrus:go_default_library"],

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/idtools/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/idtools/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "usergroupadd_unsupported.go",
         "utils_unix.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/pkg/idtools",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/idtools",
     importpath = "github.com/docker/docker/pkg/idtools",
     visibility = ["//visibility:public"],
     deps = select({

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/ioutils/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/ioutils/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "writeflusher.go",
         "writers.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/pkg/ioutils",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/ioutils",
     importpath = "github.com/docker/docker/pkg/ioutils",
     visibility = ["//visibility:public"],
     deps = [

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/longpath/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/longpath/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["longpath.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/pkg/longpath",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/longpath",
     importpath = "github.com/docker/docker/pkg/longpath",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/pools/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/pools/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["pools.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/pkg/pools",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/pools",
     importpath = "github.com/docker/docker/pkg/pools",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/docker/docker/pkg/ioutils:go_default_library"],

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/promise/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/promise/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["promise.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/pkg/promise",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/promise",
     importpath = "github.com/docker/docker/pkg/promise",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/system/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/system/BUILD.bazel
@@ -47,7 +47,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/pkg/system",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/system",
     importpath = "github.com/docker/docker/pkg/system",
     visibility = ["//visibility:public"],
     deps = select({

--- a/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/tlsconfig/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/tlsconfig/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "tlsconfig_clone_go16.go",
         "tlsconfig_clone_go17.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/docker/pkg/tlsconfig",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/docker/pkg/tlsconfig",
     importpath = "github.com/docker/docker/pkg/tlsconfig",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/go-connections/nat/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/go-connections/nat/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "parse.go",
         "sort.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/go-connections/nat",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/go-connections/nat",
     importpath = "github.com/docker/go-connections/nat",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/docker/go-connections/sockets/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/go-connections/sockets/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "tcp_socket.go",
         "unix_socket.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/go-connections/sockets",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/go-connections/sockets",
     importpath = "github.com/docker/go-connections/sockets",
     visibility = ["//visibility:public"],
     deps = [

--- a/cluster-provision/gocli/vendor/github.com/docker/go-connections/tlsconfig/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/go-connections/tlsconfig/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "config_client_ciphers.go",
         "config_legacy_client_ciphers.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/go-connections/tlsconfig",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/go-connections/tlsconfig",
     importpath = "github.com/docker/go-connections/tlsconfig",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/pkg/errors:go_default_library"],

--- a/cluster-provision/gocli/vendor/github.com/docker/go-units/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/docker/go-units/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "size.go",
         "ulimit.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/docker/go-units",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/docker/go-units",
     importpath = "github.com/docker/go-units",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/inconshreveable/mousetrap/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/inconshreveable/mousetrap/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "trap_windows.go",
         "trap_windows_1.4.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/inconshreveable/mousetrap",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/inconshreveable/mousetrap",
     importpath = "github.com/inconshreveable/mousetrap",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/konsorten/go-windows-terminal-sequences/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/konsorten/go-windows-terminal-sequences/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "sequences.go",
         "sequences_dummy.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/konsorten/go-windows-terminal-sequences",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/konsorten/go-windows-terminal-sequences",
     importpath = "github.com/konsorten/go-windows-terminal-sequences",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/opencontainers/runc/libcontainer/system/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/opencontainers/runc/libcontainer/system/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
         "xattrs_linux.go",
     ],
     cgo = True,
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/opencontainers/runc/libcontainer/system",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/opencontainers/runc/libcontainer/system",
     importpath = "github.com/opencontainers/runc/libcontainer/system",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/opencontainers/runc/libcontainer/user/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/opencontainers/runc/libcontainer/user/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "lookup_unsupported.go",
         "user.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/opencontainers/runc/libcontainer/user",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/opencontainers/runc/libcontainer/user",
     importpath = "github.com/opencontainers/runc/libcontainer/user",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/pkg/errors/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/pkg/errors/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "errors.go",
         "stack.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/pkg/errors",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/pkg/errors",
     importpath = "github.com/pkg/errors",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/github.com/spf13/cobra/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/spf13/cobra/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "command_win.go",
         "zsh_completions.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/spf13/cobra",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/spf13/cobra",
     importpath = "github.com/spf13/cobra",
     visibility = ["//visibility:public"],
     deps = [

--- a/cluster-provision/gocli/vendor/github.com/spf13/pflag/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/github.com/spf13/pflag/BUILD.bazel
@@ -30,7 +30,7 @@ go_library(
         "uint8.go",
         "uint_slice.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/github.com/spf13/pflag",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/github.com/spf13/pflag",
     importpath = "github.com/spf13/pflag",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/golang.org/x/crypto/curve25519/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/crypto/curve25519/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "mul_amd64.s",
         "square_amd64.s",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/crypto/curve25519",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/crypto/curve25519",
     importpath = "golang.org/x/crypto/curve25519",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/golang.org/x/crypto/ed25519/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/crypto/ed25519/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["ed25519.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/crypto/ed25519",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/crypto/ed25519",
     importpath = "golang.org/x/crypto/ed25519",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/crypto/ed25519/internal/edwards25519:go_default_library"],

--- a/cluster-provision/gocli/vendor/golang.org/x/crypto/ed25519/internal/edwards25519/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/crypto/ed25519/internal/edwards25519/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "const.go",
         "edwards25519.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/crypto/ed25519/internal/edwards25519",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/crypto/ed25519/internal/edwards25519",
     importpath = "golang.org/x/crypto/ed25519/internal/edwards25519",
     visibility = ["//vendor/golang.org/x/crypto/ed25519:__subpackages__"],
 )

--- a/cluster-provision/gocli/vendor/golang.org/x/crypto/internal/chacha20/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/crypto/internal/chacha20/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["chacha_generic.go"],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/crypto/internal/chacha20",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/crypto/internal/chacha20",
     importpath = "golang.org/x/crypto/internal/chacha20",
     visibility = ["//vendor/golang.org/x/crypto:__subpackages__"],
 )

--- a/cluster-provision/gocli/vendor/golang.org/x/crypto/poly1305/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/crypto/poly1305/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "sum_arm.s",
         "sum_ref.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/crypto/poly1305",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/crypto/poly1305",
     importpath = "golang.org/x/crypto/poly1305",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/golang.org/x/crypto/ssh/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/crypto/ssh/BUILD.bazel
@@ -24,7 +24,7 @@ go_library(
         "tcpip.go",
         "transport.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/crypto/ssh",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/crypto/ssh",
     importpath = "golang.org/x/crypto/ssh",
     visibility = ["//visibility:public"],
     deps = [

--- a/cluster-provision/gocli/vendor/golang.org/x/crypto/ssh/terminal/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/crypto/ssh/terminal/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "util_solaris.go",
         "util_windows.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/crypto/ssh/terminal",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/crypto/ssh/terminal",
     importpath = "golang.org/x/crypto/ssh/terminal",
     visibility = ["//visibility:public"],
     deps = select({

--- a/cluster-provision/gocli/vendor/golang.org/x/net/context/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/net/context/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "pre_go17.go",
         "pre_go19.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/net/context",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/net/context",
     importpath = "golang.org/x/net/context",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/golang.org/x/net/context/ctxhttp/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/net/context/ctxhttp/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "ctxhttp.go",
         "ctxhttp_pre17.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/net/context/ctxhttp",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/net/context/ctxhttp",
     importpath = "golang.org/x/net/context/ctxhttp",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/net/context:go_default_library"],

--- a/cluster-provision/gocli/vendor/golang.org/x/net/internal/socks/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/net/internal/socks/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "client.go",
         "socks.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/net/internal/socks",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/net/internal/socks",
     importpath = "golang.org/x/net/internal/socks",
     visibility = ["//vendor/golang.org/x/net:__subpackages__"],
 )

--- a/cluster-provision/gocli/vendor/golang.org/x/net/proxy/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/net/proxy/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "proxy.go",
         "socks5.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/net/proxy",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/net/proxy",
     importpath = "golang.org/x/net/proxy",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/net/internal/socks:go_default_library"],

--- a/cluster-provision/gocli/vendor/golang.org/x/sys/unix/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/sys/unix/BUILD.bazel
@@ -201,7 +201,7 @@ go_library(
         "ztypes_solaris_amd64.go",
     ],
     cgo = True,
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/sys/unix",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/sys/unix",
     importpath = "golang.org/x/sys/unix",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/gocli/vendor/golang.org/x/sys/windows/BUILD.bazel
+++ b/cluster-provision/gocli/vendor/golang.org/x/sys/windows/BUILD.bazel
@@ -23,7 +23,7 @@ go_library(
         "types_windows_amd64.go",
         "zsyscall_windows.go",
     ],
-    importmap = "kubevirt.io/kubevirtci/gocli/vendor/golang.org/x/sys/windows",
+    importmap = "kubevirt.io/kubevirtci/cluster-provision/gocli/vendor/golang.org/x/sys/windows",
     importpath = "golang.org/x/sys/windows",
     visibility = ["//visibility:public"],
 )

--- a/cluster-provision/manifests/cna/namespace.yaml
+++ b/cluster-provision/manifests/cna/namespace.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cluster-network-addons-operator
+  name: cluster-network-addons
   labels:
-    name: cluster-network-addons-operator
+    name: cluster-network-addons

--- a/cluster-provision/manifests/cna/network-addons-config-example.cr.yaml
+++ b/cluster-provision/manifests/cna/network-addons-config-example.cr.yaml
@@ -4,7 +4,9 @@ kind: NetworkAddonsConfig
 metadata:
   name: cluster
 spec:
-  imagePullPolicy: Always
+  imagePullPolicy: IfNotPresent
   kubeMacPool: {}
   linuxBridge: {}
   multus: {}
+  nmstate: {}
+  ovs: {}

--- a/cluster-provision/manifests/cna/operator.yaml
+++ b/cluster-provision/manifests/cna/operator.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     kubevirt.io: ""
   name: cluster-network-addons-operator
-  namespace: cluster-network-addons-operator
+  namespace: cluster-network-addons
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -21,6 +21,14 @@ rules:
   - privileged
   resources:
   - securitycontextconstraints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - networks
   verbs:
   - get
   - list
@@ -54,7 +62,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cluster-network-addons-operator
-    namespace: cluster-network-addons-operator
+    namespace: cluster-network-addons
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -63,7 +71,7 @@ metadata:
   labels:
     name: cluster-network-addons-operator
   name: cluster-network-addons-operator
-  namespace: cluster-network-addons-operator
+  namespace: cluster-network-addons
 rules:
 - apiGroups:
   - ""
@@ -99,7 +107,7 @@ metadata:
   labels:
     kubevirt.io: ""
   name: cluster-network-addons-operator
-  namespace: cluster-network-addons-operator
+  namespace: cluster-network-addons
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -112,14 +120,17 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    networkaddonsoperator.network.kubevirt.io/version: 0.20.0
   name: cluster-network-addons-operator
-  namespace: cluster-network-addons-operator
+  namespace: cluster-network-addons
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: cluster-network-addons-operator
-  strategy: {}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -130,25 +141,28 @@ spec:
         - name: MULTUS_IMAGE
           value: quay.io/kubevirt/cluster-network-addon-multus:v3.2.0-1.gitbf61002
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins:v0.8.0
+          value: quay.io/kubevirt/cni-default-plugins:v0.8.1
         - name: LINUX_BRIDGE_MARKER_IMAGE
-          value: quay.io/kubevirt/bridge-marker:0.1.0
-        - name: SRIOV_DP_IMAGE
-          value: quay.io/kubevirt/cluster-network-addon-sriov-device-plugin:v2.0.0-1.git9a20829
-        - name: SRIOV_CNI_IMAGE
-          value: quay.io/kubevirt/cluster-network-addon-sriov-cni:v1.1.0-1.git9e4c973
-        - name: SRIOV_ROOT_DEVICES
-        - name: SRIOV_NETWORK_NAME
-          value: sriov-network
-        - name: SRIOV_NETWORK_TYPE
-          value: sriov
+          value: quay.io/kubevirt/bridge-marker:0.2.0
+        - name: NMSTATE_HANDLER_IMAGE
+          value: quay.io/nmstate/kubernetes-nmstate-handler:v0.12.0
+        - name: OVS_CNI_IMAGE
+          value: quay.io/kubevirt/ovs-cni-plugin:v0.7.0
+        - name: OVS_MARKER_IMAGE
+          value: quay.io/kubevirt/ovs-cni-marker:v0.7.0
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool:v0.3.0
+          value: quay.io/kubevirt/kubemacpool:v0.8.0
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:0.8.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:0.20.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
+        - name: OPERATOR_VERSION
+          value: 0.20.0
         - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPERAND_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -157,7 +171,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WATCH_NAMESPACE
-        image: quay.io/kubevirt/cluster-network-addons-operator:0.8.0
+        image: quay.io/kubevirt/cluster-network-addons-operator:0.20.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources: {}

--- a/cluster-provision/manifests/okd/install-config.yaml
+++ b/cluster-provision/manifests/okd/install-config.yaml
@@ -3,7 +3,7 @@ baseDomain: tt.testing
 compute:
 - name: worker
   platform: {}
-  replicas: 1
+  replicas: 2
 controlPlane:
   name: master
   platform: {}
@@ -22,3 +22,5 @@ platform:
     URI: qemu+tcp://192.168.122.1/system
     network:
       if: tt0
+pullSecret: '${PULL_SECRET}'
+sshKey: '${SSH_PUBLIC_KEY}'

--- a/cluster-provision/manifests/okd/registries.conf
+++ b/cluster-provision/manifests/okd/registries.conf
@@ -1,0 +1,7 @@
+[registries]
+  [registries.search]
+    registries = ["registry.access.redhat.com", "docker.io"]
+  [registries.insecure]
+    registries = ["brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888", "registry:5000"]
+  [registries.block]
+    registries = []

--- a/cluster-provision/manifests/okd/registries.yaml
+++ b/cluster-provision/manifests/okd/registries.yaml
@@ -1,0 +1,32 @@
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 2.2.0
+    networkd: {}
+    passwd: {}
+    storage: {
+            "files": [
+                {
+                    "path": "/etc/containers/registries.conf",
+                    "filesystem": "root",
+                    "mode": 420,
+                    "contents": {
+                    "source": "data:;base64,${REGISTRIES_CONF}"
+                    }
+                }
+            ]
+        }
+    systemd: {
+        "units": [
+            {
+                "contents": "[Unit]\nDescription=Update system CA\nAfter=syslog.target network.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/update-ca-trust\nRemainAfterExit=true\n\n[Install]\nWantedBy=multi-user.target\n",
+                "enabled": true,
+                "name": "update-ca.service"
+            }
+        ]
+    }
+  osImageURL: ""

--- a/cluster-provision/okd/4.1/provision.sh
+++ b/cluster-provision/okd/4.1/provision.sh
@@ -4,8 +4,8 @@ set -x
 
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )"
 
-okd_base_hash="sha256:259e776998da3a503a30fdf935b29102443b24ca4ea095c9478c37e994e242bb"
-gocli_image_hash="sha256:5ab9913a535227766f814b3a497d0eb1eede1a86a289d3e8bfb6bbd91836f11c"
+okd_base_hash="sha256:73ede51ce464546a82b81956b7f58cf98662a4c5fded9c659b57746bc131e047"
+gocli_image_hash="sha256:f032efbd59718d48381ae2544799b44adfefa17bcd029ee6bbefdf82f53c35bc"
 
 gocli="docker run \
 --privileged \
@@ -21,7 +21,9 @@ ${gocli} provision okd \
 --dir-manifests ${PARENT_DIR}/manifests \
 --dir-hacks ${PARENT_DIR}/okd/hacks \
 --master-memory 10240 \
---installer-pull-token-file ${INSTALLER_PULL_SECRET} \
+--workers-cpu 4 \
+--workers-memory 6144 \
+--installer-pull-secret-file ${INSTALLER_PULL_SECRET} \
 --installer-repo-tag release-4.1 \
---installer-release-image docker.io/kubevirtci/ocp-release:4.1.18 \
+--installer-release-image docker.io/kubevirtci/ocp-release:4.1.24 \
 "kubevirtci/okd-base@${okd_base_hash}"

--- a/cluster-provision/okd/4.1/run.sh
+++ b/cluster-provision/okd/4.1/run.sh
@@ -2,9 +2,15 @@
 
 set -x
 
-okd_image_hash="sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8"
-gocli_image_hash="sha256:5ab9913a535227766f814b3a497d0eb1eede1a86a289d3e8bfb6bbd91836f11c"
+okd_image_hash="sha256:67fe42feea8256f07069d776d4c4cecff6294ff8a5af67d719eca6c08548b45d"
+gocli_image_hash="sha256:f032efbd59718d48381ae2544799b44adfefa17bcd029ee6bbefdf82f53c35bc"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"
 
-${gocli} run okd --random-ports --background --prefix okd-4.1 --registry-volume okd-4.1-registry "kubevirtci/okd-4.1@${okd_image_hash}"
+${gocli} run okd \
+--random-ports \
+--background \
+--prefix okd-4.1 \
+--registry-volume okd-4.1-registry \
+--installer-pull-secret-file ${INSTALLER_PULL_SECRET} \
+"kubevirtci/okd-4.1@${okd_image_hash}"

--- a/cluster-provision/okd/4.2/provision.sh
+++ b/cluster-provision/okd/4.2/provision.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -x
+
+PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )"
+
+okd_base_hash="sha256:73ede51ce464546a82b81956b7f58cf98662a4c5fded9c659b57746bc131e047"
+gocli_image_hash="sha256:dd2ece308936bb13ffa040c663e30488f0130c92c0d84a7fc4f209052239747c"
+
+gocli="docker run \
+--privileged \
+--net=host \
+--rm -t \
+-v /var/run/docker.sock:/var/run/docker.sock \
+-v ${PARENT_DIR}:${PARENT_DIR} \
+docker.io/kubevirtci/gocli@${gocli_image_hash}"
+
+${gocli} provision okd \
+--prefix okd-4.2-provision \
+--dir-scripts ${PARENT_DIR}/okd/scripts \
+--dir-manifests ${PARENT_DIR}/manifests \
+--dir-hacks ${PARENT_DIR}/okd/hacks \
+--master-memory 10240 \
+--installer-secret-token ${INSTALLER_PULL_SECRET} \
+--installer-repo-tag release-4.2 \
+--installer-release-image docker.io/kubevirtci/ocp-release:4.2.5 \
+"kubevirtci/okd-base@${okd_base_hash}"

--- a/cluster-provision/okd/4.2/provision.sh
+++ b/cluster-provision/okd/4.2/provision.sh
@@ -5,7 +5,7 @@ set -x
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )"
 
 okd_base_hash="sha256:73ede51ce464546a82b81956b7f58cf98662a4c5fded9c659b57746bc131e047"
-gocli_image_hash="sha256:dd2ece308936bb13ffa040c663e30488f0130c92c0d84a7fc4f209052239747c"
+gocli_image_hash="sha256:f032efbd59718d48381ae2544799b44adfefa17bcd029ee6bbefdf82f53c35bc"
 
 gocli="docker run \
 --privileged \
@@ -21,7 +21,9 @@ ${gocli} provision okd \
 --dir-manifests ${PARENT_DIR}/manifests \
 --dir-hacks ${PARENT_DIR}/okd/hacks \
 --master-memory 10240 \
---installer-secret-token ${INSTALLER_PULL_SECRET} \
+--workers-cpu 4 \
+--workers-memory 6144 \
+--installer-pull-secret-file ${INSTALLER_PULL_SECRET} \
 --installer-repo-tag release-4.2 \
 --installer-release-image docker.io/kubevirtci/ocp-release:4.2.5 \
 "kubevirtci/okd-base@${okd_base_hash}"

--- a/cluster-provision/okd/4.2/publish.sh
+++ b/cluster-provision/okd/4.2/publish.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker tag kubevirtci/okd-4.2-provision:latest docker.io/kubevirtci/okd-4.2:latest
+docker push docker.io/kubevirtci/okd-4.2:latest

--- a/cluster-provision/okd/4.2/run.sh
+++ b/cluster-provision/okd/4.2/run.sh
@@ -2,8 +2,8 @@
 
 set -x
 
-okd_image_hash="sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8"
-gocli_image_hash="sha256:dd2ece308936bb13ffa040c663e30488f0130c92c0d84a7fc4f209052239747c"
+okd_image_hash="sha256:998f79c90c635dbd8d752752c1ee1a731e40b36bbc089b00f9cdf332e6cdb72e"
+gocli_image_hash="sha256:f032efbd59718d48381ae2544799b44adfefa17bcd029ee6bbefdf82f53c35bc"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"
 
@@ -12,5 +12,5 @@ ${gocli} run okd \
 --background \
 --prefix okd-4.2 \
 --registry-volume okd-4.2-registry \
---installer-secret-token ${INSTALLER_PULL_SECRET} \
+--installer-pull-secret-file ${INSTALLER_PULL_SECRET} \
 "kubevirtci/okd-4.2@${okd_image_hash}"

--- a/cluster-provision/okd/4.2/run.sh
+++ b/cluster-provision/okd/4.2/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -x
+
+okd_image_hash="sha256:2b7b5e09b9bdf2ca40b8e153a111702584e2a3e802643e3e7df1f2d97eca0ce8"
+gocli_image_hash="sha256:dd2ece308936bb13ffa040c663e30488f0130c92c0d84a7fc4f209052239747c"
+
+gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"
+
+${gocli} run okd \
+--random-ports \
+--background \
+--prefix okd-4.2 \
+--registry-volume okd-4.2-registry \
+--installer-secret-token ${INSTALLER_PULL_SECRET} \
+"kubevirtci/okd-4.2@${okd_image_hash}"

--- a/cluster-provision/okd/4.3/provision.sh
+++ b/cluster-provision/okd/4.3/provision.sh
@@ -4,8 +4,8 @@ set -x
 
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )"
 
-okd_base_hash="sha256:259e776998da3a503a30fdf935b29102443b24ca4ea095c9478c37e994e242bb"
-gocli_image_hash="sha256:5ab9913a535227766f814b3a497d0eb1eede1a86a289d3e8bfb6bbd91836f11c"
+okd_base_hash="sha256:73ede51ce464546a82b81956b7f58cf98662a4c5fded9c659b57746bc131e047"
+gocli_image_hash="sha256:f032efbd59718d48381ae2544799b44adfefa17bcd029ee6bbefdf82f53c35bc"
 
 gocli="docker run \
 --privileged \
@@ -26,8 +26,8 @@ ${gocli} provision okd \
 --dir-hacks ${PARENT_DIR}/okd/hacks \
 --workers-memory 8192 \
 --workers-cpu 4 \
---installer-pull-token-file ${INSTALLER_PULL_SECRET} \
+--workers-memory 6144 \
+--installer-pull-secret-file ${INSTALLER_PULL_SECRET} \
 --installer-repo-tag release-4.3 \
---installer-release-image registry.svc.ci.openshift.org/origin/release:4.3 \
 "kubevirtci/okd-base@${okd_base_hash}"
 exit $?

--- a/cluster-provision/okd/4.3/run.sh
+++ b/cluster-provision/okd/4.3/run.sh
@@ -3,8 +3,14 @@
 set -x
 
 okd_image_hash="sha256:63abc3884002a615712dfac5f42785be864ea62006892bf8a086ccdbca8b3d38"
-gocli_image_hash="sha256:5ab9913a535227766f814b3a497d0eb1eede1a86a289d3e8bfb6bbd91836f11c"
+gocli_image_hash="sha256:f032efbd59718d48381ae2544799b44adfefa17bcd029ee6bbefdf82f53c35bc"
 
 gocli="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock docker.io/kubevirtci/gocli@${gocli_image_hash}"
 
-${gocli} run okd --random-ports --background --prefix okd-4.3 --registry-volume okd-4.3-registry "kubevirtci/okd-4.3@${okd_image_hash}"
+${gocli} run okd \
+--random-ports \
+--background \
+--prefix okd-4.3 \
+--registry-volume okd-4.3-registry \
+--installer-pull-secret-file ${INSTALLER_PULL_SECRET} \
+"kubevirtci/okd-4.3@${okd_image_hash}"

--- a/cluster-provision/okd/base/Dockerfile
+++ b/cluster-provision/okd/base/Dockerfile
@@ -1,10 +1,6 @@
 FROM fedora@sha256:a66c6fa97957087176fede47846e503aeffc0441050dd7d6d2ed9e2fae50ea8e
 
-# oc binary without SSL dependency
-ENV OC_PKG https://artifacts-openshift-master.svc.ci.openshift.org/repo/openshift-clients-4.0.0-0.alpha.0.1969.af45cda.x86_64.rpm
-
 RUN dnf install -y \
-${OC_PKG} \
 libvirt \
 libvirt-devel \
 libvirt-daemon-kvm \
@@ -12,12 +8,28 @@ libvirt-client \
 qemu-kvm \
 openssh-clients \
 haproxy \
+jq \
 virt-install \
 socat \
 selinux-policy \
 selinux-policy-targeted \
-httpd-tools && \
+httpd-tools \
+python2-pip && \
 dnf clean all
+
+RUN pip2 install yq
+
+# install golang
+ENV GO_VERSION 1.12.12
+RUN curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -o go.tar.gz && \
+tar -xvzf go.tar.gz -C /usr/local/ && \
+rm -rf go.tar.gz
+
+# Install oc client
+ENV OC_VERSION 4.3
+RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz -o oc.tar.gz && \
+tar -xvzf oc.tar.gz -C /usr/local/bin/ && \
+rm -rf oc.tar.gz
 
 # configure libvirt
 RUN echo 'listen_tls = 0' >> /etc/libvirt/libvirtd.conf; \
@@ -30,7 +42,6 @@ COPY vagrant.key /
 RUN chmod 600 /vagrant.key
 
 COPY haproxy.cfg /etc/haproxy
-COPY install-config.yaml /
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/cluster-provision/okd/base/entrypoint.sh
+++ b/cluster-provision/okd/base/entrypoint.sh
@@ -15,6 +15,11 @@ iptables \
     -m comment \
     --comment "Allow insecure libvirt clients"
 
+# add go ENV variables
+echo 'export GOROOT=/usr/local/go' >> /root/.bashrc
+echo 'export GOPATH=/root/go/' >> /root/.bashrc
+echo 'export PATH=$GOPATH/bin:$GOROOT/bin:$PATH' >> /root/.bashrc
+
 # start libvirt
 /usr/sbin/virtlogd --daemon
 /usr/sbin/libvirtd --listen

--- a/cluster-provision/okd/hacks/release-4.1
+++ b/cluster-provision/okd/hacks/release-4.1
@@ -1,13 +1,31 @@
 diff --git a/cmd/openshift-install/create.go b/cmd/openshift-install/create.go
-index 2e3d442c6..898204f00 100644
+index 2e3d442c6..f7c52a3a5 100644
 --- a/cmd/openshift-install/create.go
 +++ b/cmd/openshift-install/create.go
+@@ -238,7 +238,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
+ 
+ 	discovery := client.Discovery()
+ 
+-	apiTimeout := 30 * time.Minute
++	apiTimeout := 120 * time.Minute
+ 	logrus.Infof("Waiting up to %v for the Kubernetes API at %s...", apiTimeout, config.Host)
+ 	apiContext, cancel := context.WithTimeout(ctx, apiTimeout)
+ 	defer cancel()
+@@ -279,7 +279,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
+ // and waits for the bootstrap configmap to report that bootstrapping has
+ // completed.
+ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset) error {
+-	timeout := 30 * time.Minute
++	timeout := 120 * time.Minute
+ 	logrus.Infof("Waiting up to %v for bootstrapping to complete...", timeout)
+ 
+ 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 @@ -317,7 +317,7 @@ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset
  // waitForInitializedCluster watches the ClusterVersion waiting for confirmation
  // that the cluster has been initialized.
  func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
 -	timeout := 30 * time.Minute
-+	timeout := 60 * time.Minute
++	timeout := 120 * time.Minute
  	logrus.Infof("Waiting up to %v for the cluster at %s to initialize...", timeout, config.Host)
  	cc, err := configclient.NewForConfig(config)
  	if err != nil {

--- a/cluster-provision/okd/hacks/release-4.2
+++ b/cluster-provision/okd/hacks/release-4.2
@@ -1,0 +1,209 @@
+diff --git a/cmd/openshift-install/create.go b/cmd/openshift-install/create.go
+index 9021025b6..a88d973ed 100644
+--- a/cmd/openshift-install/create.go
++++ b/cmd/openshift-install/create.go
+@@ -238,7 +238,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
+ 
+ 	discovery := client.Discovery()
+ 
+-	apiTimeout := 30 * time.Minute
++	apiTimeout := 120 * time.Minute
+ 	logrus.Infof("Waiting up to %v for the Kubernetes API at %s...", apiTimeout, config.Host)
+ 	apiContext, cancel := context.WithTimeout(ctx, apiTimeout)
+ 	defer cancel()
+@@ -279,7 +279,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
+ // and waits for the bootstrap configmap to report that bootstrapping has
+ // completed.
+ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset) error {
+-	timeout := 30 * time.Minute
++	timeout := 120 * time.Minute
+ 	logrus.Infof("Waiting up to %v for bootstrapping to complete...", timeout)
+ 
+ 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+@@ -317,7 +317,7 @@ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset
+ // waitForInitializedCluster watches the ClusterVersion waiting for confirmation
+ // that the cluster has been initialized.
+ func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
+-	timeout := 30 * time.Minute
++	timeout := 120 * time.Minute
+ 	logrus.Infof("Waiting up to %v for the cluster at %s to initialize...", timeout, config.Host)
+ 	cc, err := configclient.NewForConfig(config)
+ 	if err != nil {
+diff --git a/data/data/libvirt/main.tf b/data/data/libvirt/main.tf
+index 9ba88c9cf..0b899734d 100644
+--- a/data/data/libvirt/main.tf
++++ b/data/data/libvirt/main.tf
+@@ -33,6 +33,7 @@ resource "libvirt_volume" "master" {
+   name           = "${var.cluster_id}-master-${count.index}"
+   base_volume_id = module.volume.coreos_base_volume_id
+   pool           = libvirt_pool.storage_pool.name
++  size           = 32212254720
+ }
+ 
+ resource "libvirt_ignition" "master" {
+@@ -73,6 +74,8 @@ resource "libvirt_network" "net" {
+         data.libvirt_network_dns_host_template.masters.*.rendered,
+         data.libvirt_network_dns_host_template.masters_int.*.rendered,
+         data.libvirt_network_dns_host_template.etcds.*.rendered,
++        data.libvirt_network_dns_host_template.console.*.rendered,
++        data.libvirt_network_dns_host_template.auth.*.rendered,
+       )
+       content {
+         hostname = hosts.value.hostname
+@@ -114,6 +117,18 @@ resource "libvirt_domain" "master" {
+   }
+ }
+ 
++data "libvirt_network_dns_host_template" "auth" {
++  count    = "${var.master_count}"
++  ip       = "${var.libvirt_auth_ip}"
++  hostname = "oauth-openshift.apps.${var.cluster_domain}"
++}
++
++data "libvirt_network_dns_host_template" "console" {
++  count    = "${var.master_count}"
++  ip       = "${var.libvirt_auth_ip}"
++  hostname = "console-openshift-console.apps.${var.cluster_domain}"
++}
++
+ data "libvirt_network_dns_host_template" "bootstrap" {
+   count    = var.bootstrap_dns ? 1 : 0
+   ip       = var.libvirt_bootstrap_ip
+diff --git a/data/data/libvirt/variables-libvirt.tf b/data/data/libvirt/variables-libvirt.tf
+index 53cf68bae..3c5f7f905 100644
+--- a/data/data/libvirt/variables-libvirt.tf
++++ b/data/data/libvirt/variables-libvirt.tf
+@@ -28,6 +28,11 @@ variable "libvirt_master_ips" {
+   description = "the list of desired master ips. Must match master_count"
+ }
+ 
++variable "libvirt_auth_ip" {
++  type        = "string"
++  description = "node with authentication server ip"
++}
++
+ # It's definitely recommended to bump this if you can.
+ variable "libvirt_master_memory" {
+   type        = string
+diff --git a/pkg/asset/tls/aggregator.go b/pkg/asset/tls/aggregator.go
+index 9ec6432da..6dac0b736 100644
+--- a/pkg/asset/tls/aggregator.go
++++ b/pkg/asset/tls/aggregator.go
+@@ -27,7 +27,7 @@ func (a *AggregatorCA) Generate(dependencies asset.Parents) error {
+ 	cfg := &CertCfg{
+ 		Subject:   pkix.Name{CommonName: "aggregator", OrganizationalUnit: []string{"bootkube"}},
+ 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+-		Validity:  ValidityOneDay,
++		Validity:  ValidityOneYear,
+ 		IsCA:      true,
+ 	}
+ 
+@@ -65,7 +65,7 @@ func (a *APIServerProxyCertKey) Generate(dependencies asset.Parents) error {
+ 		Subject:      pkix.Name{CommonName: "system:kube-apiserver-proxy", Organization: []string{"kube-master"}},
+ 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+ 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+-		Validity:     ValidityOneDay,
++		Validity:     ValidityOneYear,
+ 	}
+ 
+ 	return a.SignedCertKey.Generate(cfg, aggregatorCA, "apiserver-proxy", DoNotAppendParent)
+@@ -93,7 +93,7 @@ func (c *AggregatorSignerCertKey) Generate(parents asset.Parents) error {
+ 	cfg := &CertCfg{
+ 		Subject:   pkix.Name{CommonName: "aggregator-signer", OrganizationalUnit: []string{"openshift"}},
+ 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+-		Validity:  ValidityOneDay,
++		Validity:  ValidityOneYear,
+ 		IsCA:      true,
+ 	}
+ 
+@@ -158,7 +158,7 @@ func (a *AggregatorClientCertKey) Generate(dependencies asset.Parents) error {
+ 		Subject:      pkix.Name{CommonName: "system:kube-apiserver-proxy", Organization: []string{"kube-master"}},
+ 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+ 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+-		Validity:     ValidityOneDay,
++		Validity:     ValidityOneYear,
+ 	}
+ 
+ 	return a.SignedCertKey.Generate(cfg, ca, "aggregator-client", DoNotAppendParent)
+diff --git a/pkg/asset/tls/apiserver.go b/pkg/asset/tls/apiserver.go
+index a50bee836..cd63ff13c 100644
+--- a/pkg/asset/tls/apiserver.go
++++ b/pkg/asset/tls/apiserver.go
+@@ -185,7 +185,7 @@ func (a *KubeAPIServerLocalhostServerCertKey) Generate(dependencies asset.Parent
+ 		Subject:      pkix.Name{CommonName: "system:kube-apiserver", Organization: []string{"kube-master"}},
+ 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+ 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+-		Validity:     ValidityOneDay,
++		Validity:     ValidityOneYear,
+ 		DNSNames: []string{
+ 			"localhost",
+ 		},
+@@ -288,7 +288,7 @@ func (a *KubeAPIServerServiceNetworkServerCertKey) Generate(dependencies asset.P
+ 		Subject:      pkix.Name{CommonName: "system:kube-apiserver", Organization: []string{"kube-master"}},
+ 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+ 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+-		Validity:     ValidityOneDay,
++		Validity:     ValidityOneYear,
+ 		DNSNames: []string{
+ 			"kubernetes", "kubernetes.default",
+ 			"kubernetes.default.svc",
+@@ -392,7 +392,7 @@ func (a *KubeAPIServerExternalLBServerCertKey) Generate(dependencies asset.Paren
+ 		Subject:      pkix.Name{CommonName: "system:kube-apiserver", Organization: []string{"kube-master"}},
+ 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+ 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+-		Validity:     ValidityOneDay,
++		Validity:     ValidityOneYear,
+ 		DNSNames: []string{
+ 			apiAddress(installConfig.Config),
+ 		},
+@@ -431,7 +431,7 @@ func (a *KubeAPIServerInternalLBServerCertKey) Generate(dependencies asset.Paren
+ 		Subject:      pkix.Name{CommonName: "system:kube-apiserver", Organization: []string{"kube-master"}},
+ 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+ 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+-		Validity:     ValidityOneDay,
++		Validity:     ValidityOneYear,
+ 		DNSNames: []string{
+ 			internalAPIAddress(installConfig.Config),
+ 		},
+diff --git a/pkg/asset/tls/kubelet.go b/pkg/asset/tls/kubelet.go
+index 01264e898..32cc8059d 100644
+--- a/pkg/asset/tls/kubelet.go
++++ b/pkg/asset/tls/kubelet.go
+@@ -24,7 +24,7 @@ func (c *KubeletCSRSignerCertKey) Generate(parents asset.Parents) error {
+ 	cfg := &CertCfg{
+ 		Subject:   pkix.Name{CommonName: "kubelet-signer", OrganizationalUnit: []string{"openshift"}},
+ 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+-		Validity:  ValidityOneDay,
++		Validity:  ValidityOneYear,
+ 		IsCA:      true,
+ 	}
+ 
+@@ -181,7 +181,7 @@ func (a *KubeletClientCertKey) Generate(dependencies asset.Parents) error {
+ 		Subject:      pkix.Name{CommonName: "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper", Organization: []string{"system:serviceaccounts:openshift-machine-config-operator"}},
+ 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+ 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+-		Validity:     ValidityOneDay,
++		Validity:     ValidityOneYear,
+ 	}
+ 
+ 	return a.SignedCertKey.Generate(cfg, ca, "kubelet-client", DoNotAppendParent)
+diff --git a/pkg/tfvars/libvirt/libvirt.go b/pkg/tfvars/libvirt/libvirt.go
+index 4b7b7f50b..056bc2de1 100644
+--- a/pkg/tfvars/libvirt/libvirt.go
++++ b/pkg/tfvars/libvirt/libvirt.go
+@@ -17,6 +17,7 @@ type config struct {
+ 	IfName      string   `json:"libvirt_network_if"`
+ 	MasterIPs   []string `json:"libvirt_master_ips,omitempty"`
+ 	BootstrapIP string   `json:"libvirt_bootstrap_ip,omitempty"`
++	AuthNodeIP  string   `json:"libvirt_auth_ip,omitempty"`
+ }
+ 
+ // TFVars generates libvirt-specific Terraform variables.
+@@ -42,6 +43,7 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string,
+ 		IfName:      bridge,
+ 		BootstrapIP: bootstrapIP.String(),
+ 		MasterIPs:   masterIPs,
++		AuthNodeIP:  "192.168.126.51",
+ 	}
+ 
+ 	return json.MarshalIndent(cfg, "", "  ")

--- a/cluster-provision/okd/hacks/release-4.3
+++ b/cluster-provision/okd/hacks/release-4.3
@@ -16,7 +16,7 @@ index f9ae4c6bb..dea45f0d7 100644
  // completed.
  func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset) error {
 -	timeout := 30 * time.Minute
-+	timeout := 10 * time.Minute
++	timeout := 120 * time.Minute
  	logrus.Infof("Waiting up to %v for bootstrapping to complete...", timeout)
  
  	waitCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/cluster-provision/okd/hacks/release-4.3
+++ b/cluster-provision/okd/hacks/release-4.3
@@ -1,13 +1,31 @@
 diff --git a/cmd/openshift-install/create.go b/cmd/openshift-install/create.go
-index f9ae4c6bb..99b670c51 100644
+index f9ae4c6bb..dea45f0d7 100644
 --- a/cmd/openshift-install/create.go
 +++ b/cmd/openshift-install/create.go
+@@ -244,7 +244,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
+ 
+ 	discovery := client.Discovery()
+ 
+-	apiTimeout := 30 * time.Minute
++	apiTimeout := 120 * time.Minute
+ 	logrus.Infof("Waiting up to %v for the Kubernetes API at %s...", apiTimeout, config.Host)
+ 	apiContext, cancel := context.WithTimeout(ctx, apiTimeout)
+ 	defer cancel()
+@@ -285,7 +285,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
+ // and waits for the bootstrap configmap to report that bootstrapping has
+ // completed.
+ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset) error {
+-	timeout := 30 * time.Minute
++	timeout := 10 * time.Minute
+ 	logrus.Infof("Waiting up to %v for bootstrapping to complete...", timeout)
+ 
+ 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 @@ -323,7 +323,7 @@ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset
  // waitForInitializedCluster watches the ClusterVersion waiting for confirmation
  // that the cluster has been initialized.
  func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
 -	timeout := 30 * time.Minute
-+	timeout := 60 * time.Minute
++	timeout := 120 * time.Minute
  	logrus.Infof("Waiting up to %v for the cluster at %s to initialize...", timeout, config.Host)
  	cc, err := configclient.NewForConfig(config)
  	if err != nil {

--- a/cluster-provision/okd/scripts/provision.sh
+++ b/cluster-provision/okd/scripts/provision.sh
@@ -2,8 +2,13 @@
 
 set -xe
 
+if [ ! -f "/etc/installer/token" ]; then
+    echo "You need to provide installer pull secret file to the container"
+    exit 1
+fi
+
 if [ ! -z $INSTALLER_RELEASE_IMAGE ]; then
-    until  export INSTALLER_COMMIT=$(oc adm release info $INSTALLER_RELEASE_IMAGE --commits | grep installer | awk '{print $3}' | head -n 1); do
+    until  export INSTALLER_COMMIT=$(oc adm release info -a /etc/installer/token $INSTALLER_RELEASE_IMAGE --commits | grep installer | awk '{print $3}' | head -n 1); do
         sleep 1
     done
 fi
@@ -114,11 +119,6 @@ export REGISTRIES_CONF=$(base64 -w0 /manifests/okd/registries.conf)
 envsubst < /manifests/okd/registries.yaml > /registries.yaml
 
 # inject PULL_SECRET and SSH_PUBLIC_KEY into install-config
-if [ ! -f "/etc/installer/token" ]; then	
-    echo "You need to provide installer pull secret file to the container"	
-    exit 1	
-fi
-
 set +x
 export PULL_SECRET=$(cat /etc/installer/token)
 export SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"

--- a/cluster-provision/okd/scripts/run.sh
+++ b/cluster-provision/okd/scripts/run.sh
@@ -70,16 +70,41 @@ done
 # wait half minute, just to be sure that we do not get old cluster state
 sleep 30
 
+# wait for the router pod to start on the worker
+until [[ $(oc -n openshift-ingress get pods -o custom-columns=NAME:.metadata.name,HOST_IP:.status.hostIP,PHASE:.status.phase | grep route | grep Running | head -n 1 | awk '{print $2}') != "" ]]; do
+    sleep 5
+done
+
+# update hostnames for services to point to the node with the route pod
+worker_node_ip=$(oc -n openshift-ingress get pods -o custom-columns=NAME:.metadata.name,HOST_IP:.status.hostIP,PHASE:.status.phase | grep route | grep Running | head -n 1 | awk '{print $2}')
+if [[ ${worker_node_ip} != "192.168.126.51" ]]; then
+    virsh net-update $cluster_network delete dns-host \
+"<host ip='192.168.126.51'>
+  <hostname>console-openshift-console.apps.test-1.tt.testing</hostname>
+  <hostname>oauth-openshift.apps.test-1.tt.testing</hostname>
+</host>" --live --config
+
+    virsh net-update $cluster_network add dns-host \
+"<host ip='${worker_node_ip}'>
+  <hostname>console-openshift-console.apps.test-1.tt.testing</hostname>
+  <hostname>oauth-openshift.apps.test-1.tt.testing</hostname>
+</host>" --live --config
+fi
+
 until [[ $(oc get pods --all-namespaces --no-headers | grep -v revision-pruner | grep -v Running | grep -v Completed | wc -l) -le 3 ]]; do
     echo "waiting for pods to come online"
     sleep 10
 done
 
-# update the pull-secret from the ENV variable
-pull_secret=$(echo ${PULL_SECRET} | base64)
-until oc -n openshift-config patch secret pull-secret --type merge --patch "{\"data\": {\".dockerconfigjson\": \"${pull_secret}\"}}"; do
-    sleep 5
-done
+# update the pull-secret from the file
+if [ -s "/etc/installer/token" ]; then
+    set +x
+    pull_secret=$(cat /etc/installer/token | base64 -w0)
+    until oc -n openshift-config patch secret pull-secret --type merge --patch "{\"data\": {\".dockerconfigjson\": \"${pull_secret}\"}}"; do
+        sleep 5
+    done
+    set -x
+fi
 
 # update worker machine set with desired number of CPU and memory
 worker_machine_set=$(oc -n openshift-machine-api get machineset --no-headers | grep worker | awk '{print $1}')

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -5,7 +5,7 @@ set -e
 if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
 	_cli="pack8s"
 else
-	_cli_container="kubevirtci/gocli@sha256:dd2ece308936bb13ffa040c663e30488f0130c92c0d84a7fc4f209052239747c"
+	_cli_container="kubevirtci/gocli@sha256:f032efbd59718d48381ae2544799b44adfefa17bcd029ee6bbefdf82f53c35bc"
 	_cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 fi
 

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -5,7 +5,7 @@ set -e
 if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
 	_cli="pack8s"
 else
-	_cli_container="kubevirtci/gocli@sha256:5ab9913a535227766f814b3a497d0eb1eede1a86a289d3e8bfb6bbd91836f11c"
+	_cli_container="kubevirtci/gocli@sha256:dd2ece308936bb13ffa040c663e30488f0130c92c0d84a7fc4f209052239747c"
 	_cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 fi
 

--- a/cluster-up/cluster/okd-4.1/provider.sh
+++ b/cluster-up/cluster/okd-4.1/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="okd-4.1@sha256:b26decaf0454cc1f99b39b9bc991f715a8d6d8e97499db5a2d40f778430972f7"
+image="okd-4.1@sha256:67fe42feea8256f07069d776d4c4cecff6294ff8a5af67d719eca6c08548b45d"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 
@@ -41,7 +41,7 @@ function up() {
     # Copy k8s config and kubectl
     cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
 
-    _install_from_cluster $cluster_container_id /bin/oc 0755 .kubectl
+    _install_from_cluster $cluster_container_id /usr/local/bin/oc 0755 .kubectl
     _install_from_cluster $cluster_container_id /root/install/auth/kubeconfig 0644 .kubeconfig
 
     # Set server and disable tls check

--- a/cluster-up/cluster/okd-4.2/README.md
+++ b/cluster-up/cluster/okd-4.2/README.md
@@ -1,0 +1,44 @@
+# OKD 4.2 in ephemeral containers
+
+Provides a pre-deployed OKD with version 4.2 purely in docker
+containers with libvirt. The provided VMs are completely ephemeral and are
+recreated on every cluster restart. The KubeVirt containers are built on the
+local machine and are then pushed to a registry which is exposed at
+`localhost:5000`.
+
+## Bringing the cluster up
+
+```bash
+export KUBEVIRT_PROVIDER=okd-4.2
+make cluster-up
+```
+
+The cluster can be accessed as usual:
+
+```bash
+$ cluster/kubectl.sh get nodes
+NAME                          STATUS   ROLES    AGE   VERSION
+test-1-82xp6-master-0         Ready    master   62m   v1.14.4+509916ce1
+test-1-82xp6-worker-0-wxf27   Ready    worker   57m   v1.14.4+509916ce1
+```
+
+## Bringing the cluster down
+
+```bash
+export KUBEVIRT_PROVIDER=okd-4.2
+make cluster-down
+```
+
+This destroys the whole cluster. Recreating the cluster is fast, since OKD is
+already pre-deployed. The only state which is kept is the state of the local
+docker registry.
+
+## Destroying the docker registry state
+
+The docker registry survives a `make cluster-down`. It's state is stored in a
+docker volume called `kubevirt_registry`. If the volume gets too big or the
+volume contains corrupt data, it can be deleted with
+
+```bash
+docker volume rm kubevirt_registry
+```

--- a/cluster-up/cluster/okd-4.2/provider.sh
+++ b/cluster-up/cluster/okd-4.2/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="okd-4.2@sha256:595bb3565cf4c03a27cc3b0d280d0da97ef27fb6923463e94a4501b01b05c31d"
+image="okd-4.2@sha256:998f79c90c635dbd8d752752c1ee1a731e40b36bbc089b00f9cdf332e6cdb72e"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 
@@ -41,7 +41,7 @@ function up() {
     # Copy k8s config and kubectl
     cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
 
-    _install_from_cluster $cluster_container_id /bin/oc 0755 .kubectl
+    _install_from_cluster $cluster_container_id /usr/local/bin/oc 0755 .kubectl
     _install_from_cluster $cluster_container_id /root/install/auth/kubeconfig 0644 .kubeconfig
 
     # Set server and disable tls check

--- a/cluster-up/cluster/okd-4.2/provider.sh
+++ b/cluster-up/cluster/okd-4.2/provider.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+
+image="okd-4.2@sha256:595bb3565cf4c03a27cc3b0d280d0da97ef27fb6923463e94a4501b01b05c31d"
+
+source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
+
+function _port() {
+    ${_cli} ports --prefix $provider_prefix --container-name cluster "$@"
+}
+
+function _install_from_cluster() {
+    local src_cid="$1"
+    local src_file="$2"
+    local dst_perms="$3"
+    local dst_file="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/$4"
+
+    touch $dst_file
+    chmod $dst_perms $dst_file
+    docker exec $src_cid cat $src_file > $dst_file
+}
+
+function up() {
+    workers=$(($KUBEVIRT_NUM_NODES-1))
+    if [[ ( $workers < 1 ) ]]; then
+        workers=1
+    fi
+    echo "Number of workers: $workers"
+    params="--random-ports --background --prefix $provider_prefix --master-cpu 6 --workers-cpu 6 --workers-memory 8192 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --registry-volume $(_registry_volume) --workers $workers kubevirtci/${image}"
+    if [[ ! -z "${RHEL_NFS_DIR}" ]]; then
+        params=" --nfs-data $RHEL_NFS_DIR ${params}"
+    fi
+
+    if [[ ! -z "${OKD_CONSOLE_PORT}" ]]; then
+        params=" --ocp-console-port $OKD_CONSOLE_PORT ${params}"
+    fi
+
+    ${_cli} run okd ${params}
+
+    # Copy k8s config and kubectl
+    cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
+
+    _install_from_cluster $cluster_container_id /bin/oc 0755 .kubectl
+    _install_from_cluster $cluster_container_id /root/install/auth/kubeconfig 0644 .kubeconfig
+
+    # Set server and disable tls check
+    export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster test-1 --server=https://$(_main_ip):$(_port k8s)
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster test-1 --insecure-skip-tls-verify=true
+
+    # Make sure that local config is correct
+    prepare_config
+}

--- a/cluster-up/cluster/okd-4.3/provider.sh
+++ b/cluster-up/cluster/okd-4.3/provider.sh
@@ -41,7 +41,7 @@ function up() {
     # Copy k8s config and kubectl
     cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
 
-    _install_from_cluster $cluster_container_id /bin/oc 0755 .kubectl
+    _install_from_cluster $cluster_container_id /usr/local/bin/oc 0755 .kubectl
     _install_from_cluster $cluster_container_id /root/install/auth/kubeconfig 0644 .kubeconfig
 
     # Set server and disable tls check


### PR DESCRIPTION
Refactor OKD provision and run scripts
    
- move registry yaml configuration to the manifests directory
- move install-config.yaml from base container to manifests directory
- remove pull-token after provision
- ask for pull-token on run time
- remove if condition, what works for 4.3 also works for 4.1
- add the `--installer-pull-secret-file` parameter to the run CLI
- change the gocli package prefix