### PR TITLE
providers: okd: add podman support

### DIFF
--- a/cluster-up/cluster/okd-4.1/provider.sh
+++ b/cluster-up/cluster/okd-4.1/provider.sh
@@ -12,11 +12,18 @@ function _install_from_cluster() {
     local src_cid="$1"
     local src_file="$2"
     local dst_perms="$3"
+    local dst_name="$4"
     local dst_file="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/$4"
+    local pack8s_path="$5"
 
-    touch $dst_file
+    if [ "$KUBEVIRTCI_RUNTIME" = "podman" ]; then
+        pack8s exec $src_cid cp $src_file /tmp/$dst_name
+        cp $pack8s_path/$dst_name $dst_file
+    else
+        touch $dst_file
+        docker exec $src_cid cat $src_file > $dst_file
+    fi
     chmod $dst_perms $dst_file
-    docker exec $src_cid cat $src_file > $dst_file
 }
 
 function up() {
@@ -38,13 +45,23 @@ function up() {
         params=" --installer-pull-secret-file ${INSTALLER_PULL_SECRET} ${params}"
     fi
 
+    if [ "$KUBEVIRTCI_RUNTIME" = "podman" ]; then
+        pack8s_path=$(mktemp -d /tmp/pack8sXXX)
+        params=" --volume $pack8s_path:/tmp ${params}"
+    fi
+
     ${_cli} run okd ${params}
 
-    # Copy k8s config and kubectl
-    cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
 
-    _install_from_cluster $cluster_container_id /usr/local/bin/oc 0755 .kubectl
-    _install_from_cluster $cluster_container_id /root/install/auth/kubeconfig 0644 .kubeconfig
+    if [ "$KUBEVIRTCI_RUNTIME" = "podman" ]; then
+        cluster_container_id=$(pack8s -p "$provider_prefix-cluster" show -i)
+    else
+        cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
+    fi
+    # Copy k8s config and kubectl
+
+    _install_from_cluster $cluster_container_id /usr/local/bin/oc 0755 .kubectl $pack8s_path
+    _install_from_cluster $cluster_container_id /root/install/auth/kubeconfig 0644 .kubeconfig $pack8s_path
 
     # Set server and disable tls check
     export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig

--- a/cluster-up/cluster/okd-4.3/provider.sh
+++ b/cluster-up/cluster/okd-4.3/provider.sh
@@ -12,11 +12,18 @@ function _install_from_cluster() {
     local src_cid="$1"
     local src_file="$2"
     local dst_perms="$3"
+    local dst_name="$4"
     local dst_file="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/$4"
+    local pack8s_path="$5"
 
-    touch $dst_file
+    if [ "$KUBEVIRTCI_RUNTIME" = "podman" ]; then
+        pack8s exec $src_cid cp $src_file /tmp/$dst_name
+        cp $pack8s_path/$dst_name $dst_file
+    else
+        touch $dst_file
+        docker exec $src_cid cat $src_file > $dst_file
+    fi
     chmod $dst_perms $dst_file
-    docker exec $src_cid cat $src_file > $dst_file
 }
 
 function up() {
@@ -38,13 +45,22 @@ function up() {
         params=" --installer-pull-secret-file ${INSTALLER_PULL_SECRET} ${params}"
     fi
 
+    if [ "$KUBEVIRTCI_RUNTIME" = "podman" ]; then
+        pack8s_path=$(mktemp -d /tmp/pack8sXXX)
+        params=" --volume $pack8s_path:/tmp ${params}"
+    fi
+
     ${_cli} run okd ${params}
 
     # Copy k8s config and kubectl
-    cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
+    if [ "$KUBEVIRTCI_RUNTIME" = "podman" ]; then
+        cluster_container_id=$(pack8s -p "$provider_prefix-cluster" show -i)
+    else
+        cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
+    fi
 
-    _install_from_cluster $cluster_container_id /usr/local/bin/oc 0755 .kubectl
-    _install_from_cluster $cluster_container_id /root/install/auth/kubeconfig 0644 .kubeconfig
+    _install_from_cluster $cluster_container_id /usr/local/bin/oc 0755 .kubectl $pack8s_path
+    _install_from_cluster $cluster_container_id /root/install/auth/kubeconfig 0644 .kubeconfig $pack8s_path
 
     # Set server and disable tls check
     export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig


### PR DESCRIPTION
We need special treatment to make OKD clusters working with
the `pack8s` helper.
Differently from docker, we can't just call podman, because
we can be running with an user != root. In that case, the
copy step will fail. Hence, we use a exec command co copy files to mounted folder (between conteiner and host)
//cc @fromanirh 
This PR is upgrade of https://github.com/kubevirt/kubevirtci/pull/183
Signed-off-by: Karel Šimon <ksimon@redhat.com>