### PR TITLE
Connect to the right cluster container

### DIFF
--- a/cluster-up/container.sh
+++ b/cluster-up/container.sh
@@ -3,7 +3,8 @@
 set -e
 
 if [[ $KUBEVIRT_PROVIDER =~ (ocp|okd).* ]]; then
-    CONTAINER=$(docker ps | grep kubevirt | grep $KUBEVIRT_PROVIDER | awk '{print $1}')
+    POSTFIX="cluster"
+    CONTAINER=$(docker ps | grep kubevirt | grep "${KUBEVIRT_PROVIDER}-${POSTFIX}" | awk '{print $1}')
     if [ -z $CONTAINER ]; then
         echo "container was not found"
         exit 0


### PR DESCRIPTION
When connecting to the cluster container with "make connect",
the grep command returns more then one container id and raises an error.

Adding extra post-fix to the search pattern making the result more
accurate and returning the right container id.

Signed-off-by: Or Mergi <omergi@redhat.com>