### PR TITLE
Fix ssh.sh for ocp-4.3 provider

### DIFF
--- a/cluster-provision/okd/scripts/run.sh
+++ b/cluster-provision/okd/scripts/run.sh
@@ -89,6 +89,10 @@ if [[ ${worker_node_ip} != "192.168.126.51" ]]; then
   <hostname>console-openshift-console.apps.test-1.tt.testing</hostname>
   <hostname>oauth-openshift.apps.test-1.tt.testing</hostname>
 </host>" --live --config
+
+    sed -i "s/192.168.126.51/${worker_node_ip}/" /etc/haproxy/haproxy.cfg
+    pkill haproxy
+    haproxy -f /etc/haproxy/haproxy.cfg
 fi
 
 until [[ $(oc get pods --all-namespaces --no-headers | grep -v revision-pruner | grep -v Running | grep -v Completed | wc -l) -le 3 ]]; do

--- a/cluster-up/cluster/images.sh
+++ b/cluster-up/cluster/images.sh
@@ -16,7 +16,7 @@ if [ -z $KUBEVIRTCI_PROVISION_CHECK ]; then
     IMAGES[okd-4.1]="okd-4.1@sha256:e7e3a03bb144eb8c0be4dcd700592934856fb623d51a2b53871d69267ca51c86"
     IMAGES[okd-4.2]="okd-4.2@sha256:a830064ca7bf5c5c2f15df180f816534e669a9a038fef4919116d61eb33e84c5"
     IMAGES[okd-4.3]="okd-4.3@sha256:63abc3884002a615712dfac5f42785be864ea62006892bf8a086ccdbca8b3d38"
-    IMAGES[ocp-4.3]="ocp-4.3@sha256:4f537cbf6cf068eec9eadf2e340a642f2fda97d1b59b0aeebd615c19ce8e4ca6"
+    IMAGES[ocp-4.3]="ocp-4.3@sha256:8f59d625852ef285d6ce3ddd6ebd3662707d2c0fab19772b61dd0aa0f6b41e5f"
 fi
 export IMAGES
 


### PR DESCRIPTION
Since the worker ip might end in 51 or 52, haproxy need to be updated
accordingly in order to allow using ssh.sh to connect to the worker

Signed-off-by: Or Shoval <oshoval@redhat.com>