### PR TITLE
Activate serial pty qemu on new images

### DIFF
--- a/cluster-provision/base/scripts/vm.sh
+++ b/cluster-provision/base/scripts/vm.sh
@@ -87,4 +87,5 @@ exec qemu-system-x86_64 -enable-kvm -drive format=qcow2,file=${next},if=virtio,c
   -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n} \
   -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
   -device virtio-rng-pci \
-  -vnc :${n} -cpu host -m ${MEMORY} -smp ${CPU} ${QEMU_ARGS}
+  -vnc :${n} -cpu host -m ${MEMORY} -smp ${CPU} ${QEMU_ARGS} \
+  -serial pty


### PR DESCRIPTION
This commit is applying the change from #152 PR to new images and providers.

Adding this change also to the vm.sh script which is copied to the base image,
making this functionality available on new providers and images.

In vm.sh file, add extra arg to the qemu exec command (creating qemu vm) '-serial pty'.
In case we loose connectivity to the vm we could still connect via 'socat - /dev/pts/0'
from the host as explained in [README.md](https://github.com/kubevirt/kubevirtci/blob/master/README.md)

Signed-off-by: Or Mergi <omergi@redhat.com>