### PR TITLE
add kind v0.7.0 with ipv6 support

### DIFF
--- a/cluster-up/cluster/kind-k8s-1.17.0-ipv6/README.md
+++ b/cluster-up/cluster/kind-k8s-1.17.0-ipv6/README.md
@@ -1,0 +1,34 @@
+# K8S 1.14.2 in a Kind cluster
+
+Provides a pre-deployed k8s cluster with version 1.17.0 that runs using [kind](https://github.com/kubernetes-sigs/kind) The cluster is completely ephemeral and is recreated on every cluster restart. 
+The KubeVirt containers are built on the local machine and are then pushed to a registry which is exposed at
+`localhost:5000`.
+
+cluster is brought up with ipv6 support but without flannel or multi nic support
+
+## Bringing the cluster up
+
+```bash
+export KUBEVIRT_PROVIDER=kind-k8s-1.17.0
+export KUBEVIRT_NUM_NODES=2 # master + one node
+make cluster-up
+```
+
+The cluster can be accessed as usual:
+
+```bash
+$ cluster-up/kubectl.sh get nodes
+NAME                        STATUS   ROLES    AGE    VERSION
+kind-1.17.0-control-plane   Ready    master   105s   v1.14.2
+kind-1.17.0-worker          Ready    <none>   71s    v1.14.2
+```
+
+## Bringing the cluster down
+
+```bash
+export KUBEVIRT_PROVIDER=kind-k8s-1.17.0
+make cluster-down
+```
+
+This destroys the whole cluster. 
+

--- a/cluster-up/cluster/kind-k8s-1.17.0-ipv6/provider.sh
+++ b/cluster-up/cluster/kind-k8s-1.17.0-ipv6/provider.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+export IPV6_CNI="yes"
+export CLUSTER_NAME="kind-1.17.0"
+export KIND_NODE_IMAGE="kindest/node:v1.17.0"
+
+source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
+
+function up() {
+    cp $KIND_MANIFESTS_DIR/kind-ipv6.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+    kind_up
+}

--- a/cluster-up/cluster/kind/manifests/kind-ipv6.yaml
+++ b/cluster-up/cluster/kind/manifests/kind-ipv6.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: ipv6
+  apiServerAddress: "::1"
+nodes:
+- role: control-plane
+


### PR DESCRIPTION
for ipv6 to actually work you'll need to:
1. use kubectl >= 1.16
2. docker network with ipv6. now, to get that you'll have to add this to /etc/docker/daemon.json:
{
  "ipv6": true,
  "fixed-cidr-v6": "2001:db8:1::/64"
}
and to fully restart docker (systemctl restart docker)
if needed, docker can be tested with
docker run --rm busybox ip a

this currently without disabling the default CNI or adding flannel, as it seems that flannel doesnt support ipv6 yet

Signed-off by: Yuval Kashtan <yuval@redhat.com>