### PR TITLE
Configure br_netfilter to fix DNS

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -84,7 +84,7 @@ function _configure_network() {
     # environment running this script, so load the module from inside kind
     ${NODE_CMD} $1 modprobe br_netfilter
     for knob in arp ip ip6; do
-        echo 1 > /proc/sys/net/bridge/bridge-nf-call-${knob}tables
+        ${NODE_CMD} $1 sysctl -w sys.net.bridge.bridge-nf-call-${knob}tables=1
     done
 }
 

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -79,8 +79,16 @@ manifest_docker_prefix=registry:5000/kubevirt
 EOF
 }
 
+function _configure_network() {
+    for knob in arp ip ip6; do
+        echo 1 > /proc/sys/net/bridge/bridge-nf-call-${knob}tables
+    done
+}
+
 function kind_up() {
     _fetch_kind
+
+    _configure_network
   
     # appending eventual workers to the yaml
     for ((n=0;n<$(($KUBEVIRT_NUM_NODES-1));n++)); do 


### PR DESCRIPTION
This is needed by SR-IOV tests that may need to resolve DNS (specifically, to fetch agent binary into Fedora VMIs).