### PR TITLE
Fix kubelet config for nodes

### DIFF
--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -1,26 +1,53 @@
 #!/bin/bash
-# DO NOT RUN THIS SCRIPT, USE SCRIPTS UNDER VERSIONS DIRECTORIES
 
 set -exuo pipefail
+
+function usage {
+    cat <<EOF
+"${BASH_SOURCE[0]} [-c|--no-cleanup]" - spin up kubevirtci cluster and check for readiness
+
+    env vars required:
+        \${version}: version of kubevirtci cluster to spin up
+
+    --no-cleanup: do not spin down cluster after testing
+
+EOF
+}
+
+cleanup=1
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -c|--no-cleanup)
+            cleanup=0
+            shift
+            ;;
+        *)
+            usage
+            return 1
+            ;;
+    esac
+done
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function cleanup {
-  cd "$DIR" && cd ../..
-  make cluster-down
+    cd "$DIR" && cd ../..
+    make cluster-down
 }
 
 # check cluster-up
 (
-  ksh="./cluster-up/kubectl.sh"
-  cd "$DIR" && cd ../..
-  export KUBEVIRTCI_PROVISION_CHECK=1
-  export KUBEVIRT_PROVIDER="k8s-${version}"
-  export KUBEVIRT_NUM_NODES=2
-  trap cleanup EXIT ERR SIGINT SIGTERM SIGQUIT
-  bash -x ./cluster-up/up.sh
-  ${ksh} wait --for=condition=Ready pod --all
-  ${ksh} wait --for=condition=Ready pod -n kube-system --all
-  ${ksh} get nodes
-  ${ksh} get pods -A
+    ksh="./cluster-up/kubectl.sh"
+    cd "$DIR" && cd ../..
+    export KUBEVIRTCI_PROVISION_CHECK=1
+    export KUBEVIRT_PROVIDER="k8s-${version}"
+    export KUBEVIRT_NUM_NODES=2
+    if [ "$cleanup" -ne 0 ]; then
+        trap cleanup EXIT ERR SIGINT SIGTERM SIGQUIT
+    fi
+    bash -x ./cluster-up/up.sh
+    ${ksh} wait --for=condition=Ready pod --all
+    ${ksh} wait --for=condition=Ready pod -n kube-system --all
+    ${ksh} get nodes
+    ${ksh} get pods -A
 )

--- a/cluster-provision/k8s/scripts/nodes.sh
+++ b/cluster-provision/k8s/scripts/nodes.sh
@@ -10,14 +10,12 @@ done
 
 if [ -f /etc/sysconfig/kubelet ]; then
     # TODO use config file! this is deprecated
-    cat <<EOT >>/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=${KUBELET_EXTRA_ARGS} --feature-gates=CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
-EOT
+    sed -E -i 's/^(KUBELET_EXTRA_ARGS=.*)$/\1 --feature-gates=CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m/' /etc/sysconfig/kubelet
 else
     cat <<EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf
 Environment="KUBELET_CPUMANAGER_ARGS=--feature-gates=CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m"
 EOT
-sed -i 's/$KUBELET_EXTRA_ARGS/$KUBELET_EXTRA_ARGS $KUBELET_CPUMANAGER_ARGS/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+    sed -i 's/$KUBELET_EXTRA_ARGS/$KUBELET_EXTRA_ARGS $KUBELET_CPUMANAGER_ARGS/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 fi
 
 systemctl daemon-reload


### PR DESCRIPTION
On nodes the kubelet config is meant to be extended so that
it contains specific configuration. However the approach in
extending it lead to a corrupt configuration file that overwrote
required parameters.

Side note: Add -c parameter for skipping cluster-down to
check-cluster-up.sh .