### PR TITLE
replace PF ID selector with vendor and device ID

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -84,6 +84,8 @@ for ifs in "${sriov_pfs[@]}"; do
   # the sriov operator will trigger a node reboot to update the firmware
   export NODE_PF="$ifs_name"
   export NODE_PF_NUM_VFS=$(cat /sys/class/net/"$NODE_PF"/device/sriov_totalvfs)
+  export NODE_PF_VENDOR=$(cat /sys/class/net/"$NODE_PF"/device/vendor)
+  export NODE_PF_DEVICEID=$(cat /sys/class/net/"$NODE_PF"/device/device)
   break
 done
 

--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/manifests/network_config_policy.yaml
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/manifests/network_config_policy.yaml
@@ -10,7 +10,7 @@ spec:
     sriov: "true"
   numVfs: $NODE_PF_NUM_VFS
   nicSelector:
-    pfNames:
-      - $NODE_PF
+    vendor: "$NODE_PF_VENDOR"
+    deviceID: "$NODE_PF_DEVICEID"
   priority: 90
   resourceName: sriov_net


### PR DESCRIPTION
Since the pfNames selector seems to be broken, we replace it with vendor
and deviceID. Due to this change, we may be moving more PFs to the pod than
needed. However, it should not be an issue.

Signed-off-by: Petr Horacek <phoracek@redhat.com>