### PR TITLE
Enable local registry in containerd when using kind-ipv6

### DIFF
--- a/cluster-up/cluster/kind/manifests/kind-ipv6.yaml
+++ b/cluster-up/cluster/kind/manifests/kind-ipv6.yaml
@@ -1,8 +1,11 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry:5000"]
+    endpoint = ["http://registry:5000"]
 networking:
   ipFamily: ipv6
   apiServerAddress: "::1"
 nodes:
 - role: control-plane
-


### PR DESCRIPTION
This change is required for running ```make sync``` from KubeVirt on a cluster with IPv6.
Currently the make fail to deploy kubevirt containers since the cluster doesn't have access to the local registry.

Reference for the configuration: https://kind.sigs.k8s.io/docs/user/local-registry/