### PR TITLE
Don't mess with system's caching settings

### DIFF
--- a/cluster-provision/okd/scripts/provision.sh
+++ b/cluster-provision/okd/scripts/provision.sh
@@ -171,9 +171,6 @@ cp "${CLUSTER_DIR}/openshift/99-worker-registries.yaml" ./
 # Generate ignition configs
 /openshift-install --dir "${CLUSTER_DIR}" create ignition-configs
 
-# Clean up memory cache so we have all resources available
-sync; echo 3 > /proc/sys/vm/drop_caches
-
 # Excecute installer
 export TF_VAR_libvirt_master_memory=$MASTER_MEMORY
 export TF_VAR_libvirt_master_vcpu=$MASTER_CPU

--- a/cluster-up/cluster/ocp-4.3/provider.sh
+++ b/cluster-up/cluster/ocp-4.3/provider.sh
@@ -52,9 +52,6 @@ function up() {
         params=" --container-registry= $params"
     fi
 
-    # Free some cached/buffered mem
-    sync; echo 3 > /proc/sys/vm/drop_caches
-
     ${_cli} run okd ${params} --container-registry-user $user --container-registry-password $password
 
     # Copy k8s config and kubectl

--- a/cluster-up/cluster/ocp-4.4/provider.sh
+++ b/cluster-up/cluster/ocp-4.4/provider.sh
@@ -52,9 +52,6 @@ function up() {
         params=" --container-registry= $params"
     fi
 
-    # Free some cached/buffered mem
-    sync; echo 3 > /proc/sys/vm/drop_caches
-
     ${_cli} run okd ${params} --container-registry-user $user --container-registry-password $password
 
     # Copy k8s config and kubectl


### PR DESCRIPTION
We shouldn't mess with this setting implicitly from kubevirtci for
several resaons:
1. It requires the user to run the tool with root permissions.
2. It changes the behaviour of the system permanently.

Since this is not a strict requirement to make kubevirtci work, we
can drop this code.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>