### PR TITLE
Revert CNI to kindnet, due to kind not fully support ipv6.

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -111,8 +111,10 @@ function kind_up() {
         echo "no ipv6, safe to install flannel"
         _kubectl create -f $KIND_MANIFESTS_DIR/kube-flannel.yaml
     else
-        echo "ipv6 enabled, using calico"
-        _kubectl create -f $KIND_MANIFESTS_DIR/kube-calico.yaml
+        echo "ipv6 enabled, using kindnet"
+        # currently kind does not fully support ipv6 or ipv6-DualStack,
+        # when using diffrent CNI's.
+        #_kubectl create -f $KIND_MANIFESTS_DIR/kube-calico.yaml
     fi
 
     _wait_kind_up


### PR DESCRIPTION
This PR reverting calico cni plugin installation.
According to kind documentation, due to kind not fully support ipv6 and ipv6-dual stack with different CNI plugins then kindnet.
https://kind.sigs.k8s.io/docs/user/configuration/#ip-family


Signed-off-by: Or Mergi <ormergi@redhat.com>