### PR TITLE
Update openshift installer patches so they apply cleanly.

### DIFF
--- a/cluster-provision/okd/hacks/release-4.3
+++ b/cluster-provision/okd/hacks/release-4.3
@@ -1,8 +1,8 @@
 diff --git a/cmd/openshift-install/create.go b/cmd/openshift-install/create.go
-index f9ae4c6bb..dea45f0d7 100644
+index c5c035e72..e44a4d03e 100644
 --- a/cmd/openshift-install/create.go
 +++ b/cmd/openshift-install/create.go
-@@ -244,7 +244,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
+@@ -252,7 +252,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
  
  	discovery := client.Discovery()
  
@@ -11,7 +11,7 @@ index f9ae4c6bb..dea45f0d7 100644
  	logrus.Infof("Waiting up to %v for the Kubernetes API at %s...", apiTimeout, config.Host)
  	apiContext, cancel := context.WithTimeout(ctx, apiTimeout)
  	defer cancel()
-@@ -285,7 +285,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
+@@ -293,7 +293,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
  // and waits for the bootstrap configmap to report that bootstrapping has
  // completed.
  func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset) error {
@@ -20,15 +20,15 @@ index f9ae4c6bb..dea45f0d7 100644
  	logrus.Infof("Waiting up to %v for bootstrapping to complete...", timeout)
  
  	waitCtx, cancel := context.WithTimeout(ctx, timeout)
-@@ -323,7 +323,7 @@ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset
+@@ -331,7 +331,7 @@ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset
  // waitForInitializedCluster watches the ClusterVersion waiting for confirmation
  // that the cluster has been initialized.
  func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
 -	timeout := 30 * time.Minute
 +	timeout := 120 * time.Minute
- 	logrus.Infof("Waiting up to %v for the cluster at %s to initialize...", timeout, config.Host)
- 	cc, err := configclient.NewForConfig(config)
- 	if err != nil {
+ 
+ 	// Wait longer for baremetal, due to length of time it takes to boot
+ 	if assetStore, err := assetstore.NewStore(rootOpts.dir); err == nil {
 diff --git a/data/data/libvirt/main.tf b/data/data/libvirt/main.tf
 index 9ba88c9cf..09f6500bf 100644
 --- a/data/data/libvirt/main.tf
@@ -189,10 +189,10 @@ index 01264e898..32cc8059d 100644
  
  	return a.SignedCertKey.Generate(cfg, ca, "kubelet-client", DoNotAppendParent)
 diff --git a/pkg/tfvars/libvirt/libvirt.go b/pkg/tfvars/libvirt/libvirt.go
-index a51fbfba1..7542dc278 100644
+index e4e5e4927..43bcdc8a2 100644
 --- a/pkg/tfvars/libvirt/libvirt.go
 +++ b/pkg/tfvars/libvirt/libvirt.go
-@@ -20,6 +20,7 @@ type config struct {
+@@ -21,6 +21,7 @@ type config struct {
  	BootstrapIP  string   `json:"libvirt_bootstrap_ip,omitempty"`
  	MasterMemory string   `json:"libvirt_master_memory,omitempty"`
  	MasterVcpu   string   `json:"libvirt_master_vcpu,omitempty"`
@@ -200,7 +200,7 @@ index a51fbfba1..7542dc278 100644
  }
  
  // TFVars generates libvirt-specific Terraform variables.
-@@ -45,6 +46,7 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string,
+@@ -46,6 +47,7 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string,
  		IfName:       bridge,
  		BootstrapIP:  bootstrapIP.String(),
  		MasterIPs:    masterIPs,

--- a/cluster-provision/okd/hacks/release-4.4
+++ b/cluster-provision/okd/hacks/release-4.4
@@ -1,34 +1,3 @@
-diff --git a/cmd/openshift-install/create.go b/cmd/openshift-install/create.go
-index f9ae4c6bb..dea45f0d7 100644
---- a/cmd/openshift-install/create.go
-+++ b/cmd/openshift-install/create.go
-@@ -244,7 +244,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
- 
- 	discovery := client.Discovery()
- 
--	apiTimeout := 30 * time.Minute
-+	apiTimeout := 120 * time.Minute
- 	logrus.Infof("Waiting up to %v for the Kubernetes API at %s...", apiTimeout, config.Host)
- 	apiContext, cancel := context.WithTimeout(ctx, apiTimeout)
- 	defer cancel()
-@@ -285,7 +285,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
- // and waits for the bootstrap configmap to report that bootstrapping has
- // completed.
- func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset) error {
--	timeout := 30 * time.Minute
-+	timeout := 120 * time.Minute
- 	logrus.Infof("Waiting up to %v for bootstrapping to complete...", timeout)
- 
- 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
-@@ -323,7 +323,7 @@ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset
- // waitForInitializedCluster watches the ClusterVersion waiting for confirmation
- // that the cluster has been initialized.
- func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
--	timeout := 30 * time.Minute
-+	timeout := 120 * time.Minute
- 	logrus.Infof("Waiting up to %v for the cluster at %s to initialize...", timeout, config.Host)
- 	cc, err := configclient.NewForConfig(config)
- 	if err != nil {
 diff --git a/data/data/libvirt/main.tf b/data/data/libvirt/main.tf
 index 9ba88c9cf..09f6500bf 100644
 --- a/data/data/libvirt/main.tf
@@ -167,7 +136,7 @@ index a50bee836..cd63ff13c 100644
  			internalAPIAddress(installConfig.Config),
  		},
 diff --git a/pkg/asset/tls/kubelet.go b/pkg/asset/tls/kubelet.go
-index 01264e898..32cc8059d 100644
+index 34049cba3..53178675c 100644
 --- a/pkg/asset/tls/kubelet.go
 +++ b/pkg/asset/tls/kubelet.go
 @@ -24,7 +24,7 @@ func (c *KubeletCSRSignerCertKey) Generate(parents asset.Parents) error {
@@ -179,20 +148,11 @@ index 01264e898..32cc8059d 100644
  		IsCA:      true,
  	}
  
-@@ -181,7 +181,7 @@ func (a *KubeletClientCertKey) Generate(dependencies asset.Parents) error {
- 		Subject:      pkix.Name{CommonName: "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper", Organization: []string{"system:serviceaccounts:openshift-machine-config-operator"}},
- 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
- 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
--		Validity:     ValidityOneDay,
-+		Validity:     ValidityOneYear,
- 	}
- 
- 	return a.SignedCertKey.Generate(cfg, ca, "kubelet-client", DoNotAppendParent)
 diff --git a/pkg/tfvars/libvirt/libvirt.go b/pkg/tfvars/libvirt/libvirt.go
-index a51fbfba1..7542dc278 100644
+index e4e5e4927..43bcdc8a2 100644
 --- a/pkg/tfvars/libvirt/libvirt.go
 +++ b/pkg/tfvars/libvirt/libvirt.go
-@@ -20,6 +20,7 @@ type config struct {
+@@ -21,6 +21,7 @@ type config struct {
  	BootstrapIP  string   `json:"libvirt_bootstrap_ip,omitempty"`
  	MasterMemory string   `json:"libvirt_master_memory,omitempty"`
  	MasterVcpu   string   `json:"libvirt_master_vcpu,omitempty"`
@@ -200,7 +160,7 @@ index a51fbfba1..7542dc278 100644
  }
  
  // TFVars generates libvirt-specific Terraform variables.
-@@ -45,6 +46,7 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string,
+@@ -46,6 +47,7 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string,
  		IfName:       bridge,
  		BootstrapIP:  bootstrapIP.String(),
  		MasterIPs:    masterIPs,


### PR DESCRIPTION
The following patches were committed to upstream, causing
conflicts. They are similar to our patches, so drop the
conflicting changes.

commit 3d877660c8471df0c2011189acce93e5212fa1cf (origin/pr/2979)
Author: Stephen Benjamin <stephen@redhat.com>
Date:   Fri Jan 24 10:08:45 2020 -0500

    cmd/openshift-install/create: wait 60 minutes for baremetal

commit e4715781303eab45f6e01e022b97257fe0868e38 (origin/pr/3116)
Author: Stephen Benjamin <stephen@redhat.com>
Date:   Fri Jan 24 10:08:45 2020 -0500

    cmd/openshift-install/create: wait 60 minutes for baremetal

commit 462ba89b1b8ca7f005680b406cd253a833abf322 (origin/pr/3038)
Author: David Eads <deads@redhat.com>
Date:   Fri Jan 31 15:39:35 2020 -0500

    tls: extended lifetime of master kubelet bootstrap credentials