### PR TITLE
Update CNAO to 0.30.0

### DIFF
--- a/cluster-provision/k8s/1.17/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.17/manifests/cnao/operator.yaml
@@ -121,7 +121,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.27.4
+    networkaddonsoperator.network.kubevirt.io/version: 0.30.0
   name: cluster-network-addons-operator
   namespace: cluster-network-addons
 spec:
@@ -145,7 +145,7 @@ spec:
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker:0.2.0
         - name: NMSTATE_HANDLER_IMAGE
-          value: quay.io/nmstate/kubernetes-nmstate-handler:v0.15.3
+          value: quay.io/nmstate/kubernetes-nmstate-handler:v0.14.0
         - name: OVS_CNI_IMAGE
           value: quay.io/kubevirt/ovs-cni-plugin:v0.10.0
         - name: OVS_MARKER_IMAGE
@@ -153,11 +153,11 @@ spec:
         - name: KUBEMACPOOL_IMAGE
           value: quay.io/kubevirt/kubemacpool:v0.8.2
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:0.27.4
+          value: quay.io/kubevirt/cluster-network-addons-operator:0.30.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.27.4
+          value: 0.30.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -171,7 +171,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WATCH_NAMESPACE
-        image: quay.io/kubevirt/cluster-network-addons-operator:0.27.4
+        image: quay.io/kubevirt/cluster-network-addons-operator:0.30.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources: {}


### PR DESCRIPTION
It include a fix for multus missing cniVersion

Manifests are taken from https://github.com/kubevirt/cluster-network-addons-operator/releases/tag/0.30.0

Signed-off-by: Quique Llorente <ellorent@redhat.com>