### PR TITLE
Enable SELinux for Docker in provision.sh for k8s 1.17

### DIFF
--- a/cluster-provision/k8s/1.17/provision.sh
+++ b/cluster-provision/k8s/1.17/provision.sh
@@ -50,7 +50,8 @@ cat << EOF > /etc/docker/daemon.json
   "log-driver": "json-file",
   "exec-opts": ["native.cgroupdriver=systemd"],
   "ipv6": true,
-  "fixed-cidr-v6": "2001:db8:1::/64"
+  "fixed-cidr-v6": "2001:db8:1::/64",
+  "selinux-enabled": true
 }
 EOF
 


### PR DESCRIPTION
Docker does not come with SELinux by default.
Setting "selinux-enabled" to true in daemon.json to fix that.