### PR TITLE
Make base image ipv6 ready and use it for centos8

### DIFF
--- a/cluster-provision/gocli/cmd/ports.go
+++ b/cluster-provision/gocli/cmd/ports.go
@@ -93,7 +93,7 @@ func ports(cmd *cobra.Command, args []string) error {
 		case utils.PortNameOCPConsole:
 			err = utils.PrintPublicPort(utils.PortOCPConsole, containers[0].Ports)
 		case utils.PortNameVNC:
-			err = utils.PrintPublicPort(utils.PortVNC, containers[0].Ports)
+			err = utils.PrintPublicPort(utils.VNCPortStartRange, containers[0].Ports)
 		}
 
 		if err != nil {

--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -69,7 +69,7 @@ func provision(cmd *cobra.Command, args []string) error {
 	portMap := nat.PortMap{}
 
 	utils.AppendIfExplicit(portMap, utils.PortSSH, cmd.Flags(), "ssh-port")
-	utils.AppendIfExplicit(portMap, utils.PortVNC, cmd.Flags(), "vnc-port")
+	utils.AppendIfExplicit(portMap, utils.VNCPortStartRange+1, cmd.Flags(), "vnc-port")
 
 	qemuArgs, err := cmd.Flags().GetString("qemu-args")
 	if err != nil {
@@ -118,8 +118,8 @@ func provision(cmd *cobra.Command, args []string) error {
 		},
 		Cmd: []string{"/bin/bash", "-c", "/dnsmasq.sh"},
 		ExposedPorts: nat.PortSet{
-			utils.TCPPortOrDie(utils.PortSSH): {},
-			utils.TCPPortOrDie(utils.PortVNC): {},
+			utils.TCPPortOrDie(utils.PortSSH):               {},
+			utils.TCPPortOrDie(utils.VNCPortStartRange + 1): {},
 		},
 	}, &container.HostConfig{
 		Privileged:      true,

--- a/cluster-provision/gocli/cmd/utils/ports.go
+++ b/cluster-provision/gocli/cmd/utils/ports.go
@@ -19,8 +19,8 @@ const (
 	PortOCP = 8443
 	// PortAPI contains API server port
 	PortAPI = 6443
-	// PortVNC contains first VM VNC port
-	PortVNC = 5901
+	// VNCPortStartRange contains first VM VNC port
+	VNCPortStartRange = 5900
 	//PortOCPConsole contains OCP console port
 	PortOCPConsole = 443
 

--- a/cluster-provision/gocli/cmd/utils/utils.go
+++ b/cluster-provision/gocli/cmd/utils/utils.go
@@ -25,3 +25,13 @@ func AppendIfExplicit(ports nat.PortMap, exposedPort int, flagSet *pflag.FlagSet
 	}
 	return nil
 }
+
+func AppendPort(ports nat.PortMap, publicPort int, exposedPort int) {
+	port := TCPPortOrDie(exposedPort)
+	ports[port] = []nat.PortBinding{
+		{
+			HostIP:   "127.0.0.1",
+			HostPort: strconv.Itoa(int(publicPort)),
+		},
+	}
+}

--- a/cluster-provision/gocli/go.mod
+++ b/cluster-provision/gocli/go.mod
@@ -21,3 +21,5 @@ require (
 )
 
 replace github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.4.1
+
+go 1.13

--- a/cluster-provision/k8s/1.17/provision.sh
+++ b/cluster-provision/k8s/1.17/provision.sh
@@ -2,6 +2,13 @@
 
 set -ex
 
+# Configure IPv6 DHCP
+nmcli connection modify "System eth0" ipv6.method dhcp
+nmcli connection modify "System eth0" ipv6.may-fail no
+nmcli connection modify "System eth0" connection.autoconnect yes
+nmcli connection modify "System eth0" ipv6.addr-gen-mode eui64
+nmcli connection down "System eth0" && sudo nmcli connection up "System eth0"
+
 # Resize root partition
 dnf install -y cloud-utils-growpart
 if growpart /dev/vda 1; then


### PR DESCRIPTION
Let dnsmasq advertise ipv6 addresses which can reach each other over the
internal br0 bridge in addition to the ipv4 addresses.

The k8s 1.17 cluster which is based on centos8, is configured to automatically ask for an ipv6 address. The IPv6 addresses will be assigned as follows: `node01: fd00::101`, `node02: fd00::101`, and so forth.