### PR TITLE
Fix call to provision.sh in local testing docs

### DIFF
--- a/KUBEVIRT_LOCAL_TESTING.md
+++ b/KUBEVIRT_LOCAL_TESTING.md
@@ -9,7 +9,7 @@ Steps:
 ```bash
 cd .../kubevirtci
 cd cluster-provision/k8s/1.17.0
-./provision.sh      # this also calls cluster-up to check whether the cluster will really start and have the pods ready
+../provision.sh      # this also calls cluster-up to check whether the cluster will really start and have the pods ready
 ```
 
 ### kubevirt: prepare for tests
@@ -17,7 +17,7 @@ cd cluster-provision/k8s/1.17.0
 ```bash
 # set local provision test flag
 export KUBEVIRTCI_PROVISION_CHECK=1
-# sync changes to kubevirt cluster-up
+# sync changes to kubevirt cluster-up, notably cluster/images.sh
 rsync -av .../kubevirtci/cluster-up .../kubevirt/cluster-up                               
 ```                                                                                       
                                                                                           


### PR DESCRIPTION
./provision.sh happens to be a valid command, but it's the script from
the parent directory that should actually be called to build the image