### PR TITLE
kind: fix kubeadmConfigPatches and local registry

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -98,18 +98,7 @@ function _configure_network() {
 function prepare_workers() {
     # appending eventual workers to the yaml
     for ((n=0;n<$(($KUBEVIRT_NUM_NODES-1));n++)); do
-        cat << EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
-- role: worker
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        "feature-gates": "CPUManager=true"
-        "cpu-manager-policy": "static"
-        "kube-reserved": "cpu=500m"
-        "system-reserved": "cpu=500m"
-EOF
+        echo '- role: worker' >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
     done
 }
 

--- a/cluster-up/cluster/kind/manifests/kind-ipv6.yaml
+++ b/cluster-up/cluster/kind/manifests/kind-ipv6.yaml
@@ -4,6 +4,15 @@ containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry:5000"]
     endpoint = ["http://registry:5000"]
+kubeadmConfigPatches:
+- |
+  kind: JoinConfiguration
+  nodeRegistration:
+    kubeletExtraArgs:
+      "feature-gates": "CPUManager=true"
+      "cpu-manager-policy": "static"
+      "kube-reserved": "cpu=500m"
+      "system-reserved": "cpu=500m"
 networking:
   ipFamily: ipv6
   apiServerAddress: "::1"

--- a/cluster-up/cluster/kind/manifests/kind.yaml
+++ b/cluster-up/cluster/kind/manifests/kind.yaml
@@ -3,6 +3,10 @@ apiVersion: kind.sigs.k8s.io/v1alpha3
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry:5000"]
+    endpoint = ["http://registry:5000"]
 kubeadmConfigPatches:
 - |
   kind: JoinConfiguration

--- a/cluster-up/cluster/kind/manifests/kind.yaml
+++ b/cluster-up/cluster/kind/manifests/kind.yaml
@@ -3,5 +3,14 @@ apiVersion: kind.sigs.k8s.io/v1alpha3
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"
+kubeadmConfigPatches:
+- |
+  kind: JoinConfiguration
+  nodeRegistration:
+    kubeletExtraArgs:
+      "feature-gates": "CPUManager=true"
+      "cpu-manager-policy": "static"
+      "kube-reserved": "cpu=500m"
+      "system-reserved": "cpu=500m"
 nodes:
 - role: control-plane

--- a/cluster-up/cluster/kind/manifests/kind.yaml
+++ b/cluster-up/cluster/kind/manifests/kind.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"


### PR DESCRIPTION
Kind API moved kubeadmConfigPatches attribute to Cluster. With this PR we move
it from Node config to Cluster to follow the API and avoid following error:

ERROR: failed to create cluster: unable to decode config: yaml: unmarshal errors:
  line 9: field kubeadmConfigPatches not found in type v1alpha3.Node

We also forgot to add local registry patch to kind.yaml used for SR-IOV.