### PR TITLE
add local registry mirror to kind base

### DIFF
--- a/cluster-up/cluster/kind/manifests/kind.yaml
+++ b/cluster-up/cluster/kind/manifests/kind.yaml
@@ -1,5 +1,9 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry:5000"]
+    endpoint = ["http://registry:5000"]
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"


### PR DESCRIPTION
In order for kind provider to work with make cluster-sync, we need to add
registry mirrors.

Signed-off-by: Petr Horacek <phoracek@redhat.com>