### PR TITLE
kind: deploy local volume provisioner

### DIFF
--- a/cluster-up/cluster/kind-k8s-1.17.0-ipv6/provider.sh
+++ b/cluster-up/cluster/kind-k8s-1.17.0-ipv6/provider.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+DOCKER="${CONTAINER_RUNTIME:-docker}"
+
 export IPV6_CNI="yes"
 export CLUSTER_NAME="kind-1.17.0"
 export KIND_NODE_IMAGE="kindest/node:v1.17.0"
@@ -11,4 +13,27 @@ source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
 function up() {
     cp $KIND_MANIFESTS_DIR/kind-ipv6.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
     kind_up
+    # remove the rancher.io kind default storageClass
+    _kubectl delete sc standard
+
+    nodes=$(_kubectl get nodes -o=custom-columns=:.metadata.name | awk NF)
+    for node in $nodes; do
+        # Create local-volume directories, which, on other providers, are pre-provisioned.
+        # For more info, check https://github.com/kubevirt/kubevirtci/blob/master/cluster-provision/STORAGE.md
+        for i in {1..10}; do
+            mount_disk $node $i
+        done
+        $DOCKER exec -it $node bash -c "chmod -R 777 /var/local/kubevirt-storage/local-volume"
+    done
+
+    # create the `local` storage class - which functional tests assume to exist
+    _kubectl apply -f $KIND_MANIFESTS_DIR/local-volume.yaml
+}
+
+function mount_disk() {
+    local node=$1
+    local idx=$2
+    $DOCKER exec -it $node bash -c "mkdir -p /var/local/kubevirt-storage/local-volume/disk${idx}"
+    $DOCKER exec -it $node bash -c "mkdir -p /mnt/local-storage/local/disk${idx}"
+    $DOCKER exec -it $node bash -c "mount -o bind /var/local/kubevirt-storage/local-volume/disk${idx} /mnt/local-storage/local/disk${idx}"
 }

--- a/cluster-up/cluster/kind/manifests/local-volume.yaml
+++ b/cluster-up/cluster/kind/manifests/local-volume.yaml
@@ -1,0 +1,130 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+ name: local
+ annotations:
+  storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-storage-config
+data:
+  storageClassMap: |
+    local:
+       hostDir: /mnt/local-storage/local
+       mountDir: /mnt/local-storage/local
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-storage-provisioner-jobs-role
+rules:
+- apiGroups:
+    - 'batch'
+  resources:
+    - jobs
+  verbs:
+    - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-storage-provisioner-jobs-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+roleRef:
+  kind: Role
+  name: local-storage-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.3.4"
+          name: provisioner
+          securityContext:
+            privileged: true
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: "quay.io/external_storage/local-volume-provisioner:v2.3.4"
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /mnt/local-storage
+              name: local-storage
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-storage-config
+        - name: local-storage
+          hostPath:
+            path: /mnt/local-storage


### PR DESCRIPTION
Kind default StorageClass is named 'standard', while kubevirt
func tests assume it to be called 'local' - as is for all the
other providers.
    
To enable the kind-k8s-1.17-ipv6 provider to work out of the box,
the `local-volume-provisioner` daemonset must be deployed. It will
take care of:
  - create the 'local' storage class
  - discover all mount points in its configuration path (via config
    map) and expose those mount points as PersistentVolumes.
    
For more information, check the local static provisioner repo,
located at [0].
    
This will enable the functional_tests labeled as 'PVC' to be
executed.
    
[0] - https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner


Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>