### PR TITLE
Label k8s non master nodes as workers

### DIFF
--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -20,9 +20,14 @@ function up() {
     # Make sure that local config is correct
     prepare_config
 
+    kubectl=${KUBEVIRTCI_PATH}/kubectl.sh
+
+    # Label all the non master nodes as workers, we have to do here since, after k8s 1.16 is not possible to do
+    # at kubelet [1]
+    # [1] https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/book/src/user/troubleshooting.md
+    $kubectl label node -l '!node-role.kubernetes.io/master' node-role.kubernetes.io/worker=''
     # Activate cluster-network-addons-operator if flag is passed
     if [ "$KUBEVIRT_WITH_CNAO" == "true" ]; then
-        kubectl="${_cli} --prefix $provider_prefix ssh node01 -- sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf"
 
         $kubectl create -f /opt/cnao/namespace.yaml
         $kubectl create -f /opt/cnao/network-addons-config.crd.yaml


### PR DESCRIPTION
They were missing the node-role label at all and this prevent some
testing to work propertly.

Signed-off-by: Quique Llorente <ellorent@redhat.com>