### PR TITLE
Label 1 node cluster with 'master,worker' roles

### DIFF
--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 


### PR DESCRIPTION
In case KUBEVIRT_NUM_NODES=1 is used only a master node is stareted
but it's missing worker node-role so it may be an issue with deploys or test
that depends on worker node-role.

Signed-off-by: Quique Llorente <ellorent@redhat.com>