### PR TITLE
Label k8s nodes as workers

### DIFF
--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -20,9 +20,20 @@ function up() {
     # Make sure that local config is correct
     prepare_config
 
+
+    kubectl="${_cli} --prefix $provider_prefix ssh node01 -- sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf"
+
+    # For multinode cluster Label all the non master nodes as workers,
+    # for one node cluster label master with 'master,worker' roles
+    if [ "$KUBEVIRT_NUM_NODES" -gt 1 ]; then
+        label="!node-role.kubernetes.io/master"
+    else
+        label="node-role.kubernetes.io/master"
+    fi
+    $kubectl label node -l $label node-role.kubernetes.io/worker=''
+
     # Activate cluster-network-addons-operator if flag is passed
     if [ "$KUBEVIRT_WITH_CNAO" == "true" ]; then
-        kubectl="${_cli} --prefix $provider_prefix ssh node01 -- sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf"
 
         $kubectl create -f /opt/cnao/namespace.yaml
         $kubectl create -f /opt/cnao/network-addons-config.crd.yaml


### PR DESCRIPTION
At multi node cluster non master nodes were missing the node-role label at all
, also mono node cluster has only master node-role, all this prevent some testing
that depends on those labels.
