### PR TITLE
Correct the username for oscollabus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,7 +8,7 @@ filters:
       - vladikr
       - dhiller
       - qinqon
-      - oscollabus
+      - oshoval
       - phoracek
       - ormergi
       - danielBelenky


### PR DESCRIPTION
There is no user `oscollabus` but there is `oshoval` that is part of the kubevirt org with `oscollabus` as their name