### PR TITLE
Add a container_file_t tmpfs to every k8s lane for tests

### DIFF
--- a/cluster-provision/k8s/1.14/provision.sh
+++ b/cluster-provision/k8s/1.14/provision.sh
@@ -220,3 +220,8 @@ docker pull quay.io/k8scsi/csi-provisioner:v1.0.1
 docker pull quay.io/k8scsi/csi-snapshotter:v1.0.1
 docker pull quay.io/cephcsi/rbdplugin:v1.0.0
 docker pull quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+
+# Create a properly labelled tmp directory for testing
+mkdir -p /tmp/kubevirt.io/tests
+chcon -t container_file_t /tmp/kubevirt.io/tests
+echo "tmpfs /tmp/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab

--- a/cluster-provision/k8s/1.15/provision.sh
+++ b/cluster-provision/k8s/1.15/provision.sh
@@ -220,3 +220,8 @@ docker pull quay.io/k8scsi/csi-provisioner:v1.0.1
 docker pull quay.io/k8scsi/csi-snapshotter:v1.0.1
 docker pull quay.io/cephcsi/rbdplugin:v1.0.0
 docker pull quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+
+# Create a properly labelled tmp directory for testing
+mkdir -p /tmp/kubevirt.io/tests
+chcon -t container_file_t /tmp/kubevirt.io/tests
+echo "tmpfs /tmp/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab

--- a/cluster-provision/k8s/1.16/provision.sh
+++ b/cluster-provision/k8s/1.16/provision.sh
@@ -219,3 +219,8 @@ docker pull quay.io/k8scsi/csi-provisioner:v1.0.1
 docker pull quay.io/k8scsi/csi-snapshotter:v1.0.1
 docker pull quay.io/cephcsi/rbdplugin:v1.0.0
 docker pull quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+
+# Create a properly labelled tmp directory for testing
+mkdir -p /tmp/kubevirt.io/tests
+chcon -t container_file_t /tmp/kubevirt.io/tests
+echo "tmpfs /tmp/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab

--- a/cluster-provision/k8s/1.17/provision.sh
+++ b/cluster-provision/k8s/1.17/provision.sh
@@ -304,3 +304,8 @@ docker pull quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
 # so we can use them at cluster-up
 cp -rf /tmp/cnao/ /opt/
 for i in $(grep -A 2 "IMAGE" /opt/cnao/operator.yaml |grep value | awk '{print $2}'); do docker pull $i; done
+
+# Create a properly labelled tmp directory for testing
+mkdir -p /tmp/kubevirt.io/tests
+chcon -t container_file_t /tmp/kubevirt.io/tests
+echo "tmpfs /tmp/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab


### PR DESCRIPTION
Some tests need a tmp directory with the container_file_t SELinux label.
One test also needs that tmp directory to *not* support direct I/O (1681).
Creating a tmpfs that meets both requirements.