### PR TITLE
Support time based tags in k8s publish

### DIFF
--- a/cluster-provision/k8s/publish.sh
+++ b/cluster-provision/k8s/publish.sh
@@ -4,7 +4,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 major_minor="$(basename $(pwd))"
+tag=$(git log -1 --pretty=%h)-$(date +%s)
+destination="docker.io/kubevirtci/k8s-${major_minor}:$tag"
 
-version="$(cat version | tr -d '\n')"
-docker tag kubevirtci/k8s-${major_minor}:latest docker.io/kubevirtci/k8s-${major_minor}:latest
-docker push docker.io/kubevirtci/k8s-${major_minor}:latest
+docker tag kubevirtci/k8s-${major_minor}:latest $destination
+docker push $destination


### PR DESCRIPTION
In order to keep previous images as well,
at least during development and provisioing of new images,
support time based image tag, instead of using latest,
which will cause previous image to be untagged and deleted.
(as was done on ocp providers)

Signed-off-by: Or Shoval <oshoval@redhat.com>