### PR TITLE
Expose a VNC port for every VM

### DIFF
--- a/cluster-provision/gocli/cmd/ports.go
+++ b/cluster-provision/gocli/cmd/ports.go
@@ -93,7 +93,7 @@ func ports(cmd *cobra.Command, args []string) error {
 		case utils.PortNameOCPConsole:
 			err = utils.PrintPublicPort(utils.PortOCPConsole, containers[0].Ports)
 		case utils.PortNameVNC:
-			err = utils.PrintPublicPort(utils.PortVNC, containers[0].Ports)
+			err = utils.PrintPublicPort(utils.VNCPortStartRange, containers[0].Ports)
 		}
 
 		if err != nil {

--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -69,7 +69,7 @@ func provision(cmd *cobra.Command, args []string) error {
 	portMap := nat.PortMap{}
 
 	utils.AppendIfExplicit(portMap, utils.PortSSH, cmd.Flags(), "ssh-port")
-	utils.AppendIfExplicit(portMap, utils.PortVNC, cmd.Flags(), "vnc-port")
+	utils.AppendIfExplicit(portMap, utils.VNCPortStartRange+1, cmd.Flags(), "vnc-port")
 
 	qemuArgs, err := cmd.Flags().GetString("qemu-args")
 	if err != nil {
@@ -118,8 +118,8 @@ func provision(cmd *cobra.Command, args []string) error {
 		},
 		Cmd: []string{"/bin/bash", "-c", "/dnsmasq.sh"},
 		ExposedPorts: nat.PortSet{
-			utils.TCPPortOrDie(utils.PortSSH): {},
-			utils.TCPPortOrDie(utils.PortVNC): {},
+			utils.TCPPortOrDie(utils.PortSSH):               {},
+			utils.TCPPortOrDie(utils.VNCPortStartRange + 1): {},
 		},
 	}, &container.HostConfig{
 		Privileged:      true,

--- a/cluster-provision/gocli/cmd/utils/ports.go
+++ b/cluster-provision/gocli/cmd/utils/ports.go
@@ -19,8 +19,8 @@ const (
 	PortOCP = 8443
 	// PortAPI contains API server port
 	PortAPI = 6443
-	// PortVNC contains first VM VNC port
-	PortVNC = 5901
+	// VNCPortStartRange contains first VM VNC port
+	VNCPortStartRange = 5900
 	//PortOCPConsole contains OCP console port
 	PortOCPConsole = 443
 

--- a/cluster-provision/gocli/cmd/utils/utils.go
+++ b/cluster-provision/gocli/cmd/utils/utils.go
@@ -25,3 +25,13 @@ func AppendIfExplicit(ports nat.PortMap, exposedPort int, flagSet *pflag.FlagSet
 	}
 	return nil
 }
+
+func AppendPort(ports nat.PortMap, publicPort int, exposedPort int) {
+	port := TCPPortOrDie(exposedPort)
+	ports[port] = []nat.PortBinding{
+		{
+			HostIP:   "127.0.0.1",
+			HostPort: strconv.Itoa(int(publicPort)),
+		},
+	}
+}

--- a/cluster-provision/gocli/go.mod
+++ b/cluster-provision/gocli/go.mod
@@ -21,3 +21,5 @@ require (
 )
 
 replace github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.4.1
+
+go 1.13

--- a/cluster-up/cluster/images.sh
+++ b/cluster-up/cluster/images.sh
@@ -3,7 +3,7 @@
 set -e
 
 declare -A IMAGES
-IMAGES[gocli]="gocli@sha256:220f55f6b1bcb3975d535948d335bd0e6b6297149a3eba1a4c14cad9ac80f80d"
+IMAGES[gocli]="gocli@sha256:c9abd3eb50abc339214a95db6e48828c562db8b3801854b8b4ed9fddbf87b7f3"
 if [ -z $KUBEVIRTCI_PROVISION_CHECK ]; then
     IMAGES[k8s-fedora-1.17.0]="k8s-fedora-1.17.0@sha256:aebf67b8b1b499c721f4d98a7ab9542c680553a14cbc144d1fa701fe611f3c0d"
     IMAGES[k8s-1.17]="k8s-1.17@sha256:c3a307b55d60578d8aa99aca09d92728810d0ee6480887f8015ba21dd71d25b3"


### PR DESCRIPTION
Ease debugging by exposing a VNC port not just for the first VM. This
makes it easier to see what is going on in VMs if networking does not
work as expected.

Thanks Roman.