### PR TITLE
Fail faster when k8s-fedora-1.17.0 is used with cnao

### DIFF
--- a/cluster-up/cluster/k8s-fedora-1.17.0/provider.sh
+++ b/cluster-up/cluster/k8s-fedora-1.17.0/provider.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 set -e
+
+if [ "$KUBEVIRT_WITH_CNAO" == "true" ]; then
+    echo "ERROR: KUBEVIRT_WITH_CNAO=true is not supported with $KUBEVIRT_PROVIDER"
+    exit 1
+fi
 source ${KUBEVIRTCI_PATH}/cluster/k8s-provider-common.sh


### PR DESCRIPTION
Provider k8s-fedora-1.17.0 does not support CNAO operator.
But if it is enabled, it will fail in the middle of run
operation with file not found error. Add a check to ensure
that cluster-up fails faster if un-supported config is used.

Fixes: #351 

