### PR TITLE
Implement _port for kind providers

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -71,6 +71,10 @@ function _configure_registry_on_node() {
     ${NODE_CMD} $1  sh -c "echo $(docker inspect --format '{{.NetworkSettings.IPAddress }}' $REGISTRY_NAME)'\t'registry >> /etc/hosts"
 }
 
+function _port() {
+	docker inspect "${CLUSTER_NAME}"-"$@" --format='{{range $p, $conf := .NetworkSettings.Ports}}{{(index $conf 0).HostPort}}{{end}}'
+}
+
 function prepare_config() {
     BASE_PATH=${KUBEVIRTCI_CONFIG_PATH:-$PWD}
     cat >$BASE_PATH/$KUBEVIRT_PROVIDER/config-provider-$KUBEVIRT_PROVIDER.sh <<EOF


### PR DESCRIPTION
This is used by [CDI's cluster-sync](https://github.com/kubevirt/containerized-data-importer/blob/master/cluster-sync/sync.sh#L32) so we'll have to have an implementation in order to make cluster-sync.

I have some doubts about whether this implementation matches the intention so cc @awels