### PR TITLE
Explain how to reach the outer IPv6 world with the kind-ipv6 provider

### DIFF
--- a/cluster-up/cluster/kind-k8s-1.17.0-ipv6/README.md
+++ b/cluster-up/cluster/kind-k8s-1.17.0-ipv6/README.md
@@ -20,6 +20,19 @@ cluster is brought up with ipv6 support but without flannel or multi nic support
     if needed, docker can be tested with:
     `docker run --rm busybox ip a`  
     and make sure you get an ipv6 address  
+1. With an IPv6-connected host, you may want the pods to be able to reach the rest of the IPv6 world, too:  
+    Enable IPv6 NAT:
+    ```console
+    # ip6tables -t nat -A POSTROUTING -s 2001:db8:1::/64 -j MASQUERADE
+    ```
+    (Note that the address 2001:db8:1::/64 has to match fixed-cidr-v6 in /etc/docker/daemon.json)
+
+    You will also need the host to be configured with an IPv6-reachable DNS server.  
+    If you don't have one, you can use OpenDNS:
+    ```console
+    # echo "DNS=2620:119:35::35" >> /etc/systemd/resolved.conf
+    # systemctl restart systemd-resolved
+    ```
 
 ## Bringing the cluster up
 


### PR DESCRIPTION
CoreDNS runs as a pod on the ipv6-only cluster, so it can only reach DNS server over IPv6, so explain this part and give an example of IPv6-reachable DNS.
It would probably be preferable to configure IPv6 docker without NAT, but I haven't been able to get it to work, and these instructions match the previous (pre-existing) step of adding: "fixed-cidr-v6": "2001:db8:1::/64"