### PR TITLE
Bump the version of the kubevirt-testing image to fc32

### DIFF
--- a/cluster-provision/images/kubevirt-testing/Dockerfile
+++ b/cluster-provision/images/kubevirt-testing/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:28
+FROM fedora:32
 
 LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 ENV container docker


### PR DESCRIPTION
The current version of the kubevirt-testing image is fc28; other
containers - like cdi-importer - are based on this image, as per the
[testing images README](https://github.com/kubevirt/kubevirt/tree/master/images).

The cdi-importer [exposes a set of binaries](https://github.com/kubevirt/kubevirt/blob/fb7711c72f9b509186eb1e80a0dbb319086d609e/images/cdi-http-import-server/entrypoint.sh#L61) to the KubeVirt
functest VMs (qemu-ga, stress, etc); the issue here is that the
exposed binaries are simply installed via `dnf`. This means that
the version of the qemu-guest-agent being used on the functests
is a fc28 version.

The current fedora version used in the tests is fc32; this PR tries
to align the images of both the cdi-importer and the test VMs.

**For reviewers**: we'll need to push a new image with this, but I wasn't able to verify 
this locally; how can I use an image built locally on bazel's WORKSPACE ? (I've tried replacing the [registry](https://github.com/kubevirt/kubevirt/blob/e8d6534a8e205b9c715dc0cfd2ffe070aa1ea0b2/WORKSPACE#L345) to `localhost:5000` to no avail .
