### PR TITLE
[2] Add provision script to update kernel args for Vhostuser

### DIFF
--- a/cluster-provision/k8s/1.17/kargs.sh
+++ b/cluster-provision/k8s/1.17/kargs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -ex
+
+# OvS-DPDK requires latest kernel
+yum update -y --nobest kernel
+
+# Increase the Hugepages count so that DPDK can be enabled in OvS which requires 1GB of hugepages
+# Add iommu support to enable PMD drivers
+GRUB_FILE=/etc/default/grub
+MODIFIED=0
+if ! grep -q iommu $GRUB_FILE; then
+    sed -i 's/${GRUB_CMDLINE_LINUX}/${GRUB_CMDLINE_LINUX} iommu=pt intel_iommu=on/g' $GRUB_FILE
+    MODIFIED=1
+fi
+
+if grep -q 'hugepagesz=2M' $GRUB_FILE && ! grep -q 'hugepages=2048' $GRUB_FILE; then
+    sed -i 's/ hugepages=[0-9]*/ hugepages=2048/g' $GRUB_FILE
+    MODIFIED=1
+fi
+
+if [[ $MODIFIED == "1" ]]; then
+    grub2-mkconfig -o /boot/grub2/grub.cfg
+fi


### PR DESCRIPTION
The default kernel args as part of the provision.sh script has
64 2M hugepages. DPDK requires 1GB of hugepage to enable the
support and additionally VM also needs huagepages. And iommu
should be abled in order to used the PMD driver.

Kernel should be updated to the latest version for enabling DPDK.

All the above operations involes reboot of the node, so it is
grouped together for the DPDK requirement. This script can be
run as part of the provision itself, and it can be common to all
other nodes, but it causes memory overhead. Insted it is better
to invoke this script runing run gocli command which can be
followed up by a reboot, managed in the gocli itself.

This patch adds the script only, the invocation of this script
will be done in the follow-up patches.

Related: #365 

Signed-off-by: Saravanan KR <skramaja@redhat.com>