### PR TITLE
[5] Create OvS-DPDK operator when enabled

### DIFF
--- a/cluster-provision/k8s/1.17/provision.sh
+++ b/cluster-provision/k8s/1.17/provision.sh
@@ -354,6 +354,9 @@ for i in $(grep -A 2 "IMAGE" /opt/cnao/operator.yaml | grep value | awk '{print 
 # Pre pull local-volume-provisioner
 for i in $(grep -A 2 "IMAGE" /var/provision/local-volume.yaml | grep value | awk -F\" '{print $2}'); do docker_pull_retry $i; done
 
+# Pre pull ovsdpdk operator image
+docker_pull_retry quay.io/krsacme/ovsdpdk-network-operator:v0.0.1
+
 # Create a properly labelled tmp directory for testing
 mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests

--- a/cluster-up/cluster/k8s-1.17/manifests/ovsdpdk/allinone.yaml
+++ b/cluster-up/cluster/k8s-1.17/manifests/ovsdpdk/allinone.yaml
@@ -1,0 +1,310 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovsdpdk-network-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ovsdpdk-network-operator
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: [namespaces, serviceaccounts]
+  verbs: ["*"]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources: ["network-attachment-definitions"]
+  verbs: ["*"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: [clusterroles, clusterrolebindings]
+  verbs: ["*"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["*"]
+- apiGroups: ["ovsdpdknetwork.openshift.io"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ovsdpdk-network-prepare
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovsdpdk-network-operator
+roleRef:
+  kind: ClusterRole
+  name: ovsdpdk-network-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: default
+  name: ovsdpdk-network-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovsdpdk-network-prepare
+roleRef:
+  kind: ClusterRole
+  name: ovsdpdk-network-prepare
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: default 
+  name: ovsdpdk-network-prepare
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ovsdpdk-network-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - ovsdpdk-network-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - ovsdpdknetwork.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ovsdpdk-network-operator
+subjects:
+- kind: ServiceAccount
+  name: ovsdpdk-network-operator
+roleRef:
+  kind: Role
+  name: ovsdpdk-network-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ovsdpdk-network-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: ovsdpdk-network-operator
+  template:
+    metadata:
+      labels:
+        name: ovsdpdk-network-operator
+    spec:
+      serviceAccountName: ovsdpdk-network-operator
+      containers:
+        - name: ovsdpdk-network-operator
+          image: quay.io/krsacme/ovsdpdk-network-operator:latest
+          command:
+          - ovsdpdk-network-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "ovsdpdk-network-operator"
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ovsdpdkconfigs.ovsdpdknetwork.openshift.io
+spec:
+  group: ovsdpdknetwork.openshift.io
+  names:
+    kind: OvsDpdkConfig
+    listKind: OvsDpdkConfigList
+    plural: ovsdpdkconfigs
+    singular: ovsdpdkconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: OvsDpdkConfig is the Schema for the ovsdpdkconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OvsDpdkConfigSpec defines the desired state of OvsDpdkConfig
+            properties:
+              interfaceConfig:
+                description: Interfaces to be used for OvS-DPDK configuration
+                items:
+                  properties:
+                    bond:
+                      type: boolean
+                    bondMonde:
+                      type: string
+                    bridge:
+                      type: string
+                    driver:
+                      type: string
+                    mtu:
+                      format: int32
+                      type: integer
+                    nicSelector:
+                      properties:
+                        devices:
+                          items:
+                            type: string
+                          type: array
+                        ifNames:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    queues:
+                      format: int32
+                      type: integer
+                  required:
+                  - bridge
+                  - nicSelector
+                  type: object
+                type: array
+              nodeConfig:
+                description: Node specific configuration
+                properties:
+                  hugepage1g:
+                    type: string
+                  memoryChannel:
+                    format: int32
+                    type: integer
+                  pmdCount:
+                    format: int32
+                    type: integer
+                type: object
+              nodeSelectorLabels:
+                additionalProperties:
+                  type: string
+                description: Nodes on which OvS-DPDK should run
+                type: object
+            required:
+            - interfaceConfig
+            - nodeSelectorLabels
+            type: object
+          status:
+            description: OvsDpdkConfigStatus defines the observed state of OvsDpdkConfig
+            properties:
+              nodes:
+                description: List of nodes on which OvS-DPDK is enabled (is it useful?)
+                items:
+                  type: string
+                type: array
+            required:
+            - nodes
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-up/cluster/k8s-1.17/manifests/ovsdpdk/allinone.yaml
+++ b/cluster-up/cluster/k8s-1.17/manifests/ovsdpdk/allinone.yaml
@@ -188,7 +188,7 @@ spec:
       serviceAccountName: ovsdpdk-network-operator
       containers:
         - name: ovsdpdk-network-operator
-          image: quay.io/krsacme/ovsdpdk-network-operator:latest
+          image: quay.io/krsacme/ovsdpdk-network-operator:v0.0.1
           command:
           - ovsdpdk-network-operator
           imagePullPolicy: Always

--- a/cluster-up/cluster/k8s-1.17/manifests/ovsdpdk/ovsdpdkconfig.yaml
+++ b/cluster-up/cluster/k8s-1.17/manifests/ovsdpdk/ovsdpdkconfig.yaml
@@ -1,0 +1,16 @@
+apiVersion: ovsdpdknetwork.openshift.io/v1
+kind: OvsDpdkConfig
+metadata:
+  name: ovsdpdk-group-1
+spec:
+  nodeSelectorLabels:
+    network.operator.openshift.io/external-openvswitch: ""
+  nodeConfig:
+    pmdCount: 1
+  interfaceConfig:
+    - bridge: "br-dpdk0"
+      bond: false
+      driver: igb_uio
+      nicSelector:
+        ifNames:
+          - eth1

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -43,4 +43,14 @@ function up() {
         $kubectl create -f /opt/cnao/network-addons-config-example.cr.yaml
         $kubectl wait networkaddonsconfig cluster --for condition=Available --timeout=200s
     fi
+
+    if [ "$KUBEVIRT_OVS_DPDK" == "true" ]; then
+        OVSDPDK_MANIFESTS_DIR="${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/manifests/ovsdpdk"
+        if [ -f $OVSDPDK_MANIFESTS_DIR/allinone.yaml ]; then
+            echo "Create OvS-DPDK operator.."
+            _kubectl label node node02 network.operator.openshift.io/external-openvswitch=
+            _kubectl create -f $OVSDPDK_MANIFESTS_DIR/allinone.yaml
+            _kubectl create -f $OVSDPDK_MANIFESTS_DIR/ovsdpdkconfig.yaml
+        fi
+    fi
 }


### PR DESCRIPTION
In order to create a VM with vhostuser interface, OvS-DPDK should
be enabled and relevant parameter should be configured.
ovsdpdk-network-operator does the configuration based on the
provided interface configuration. In order to use vhostuser
interface on VMs as additional interface, a secondary
interface should be added to the deployed nodes. And
operator config will specify the additional interface eth1
to configure it for vhostuser socket. Relevant manifests
are added to the provider to perform this operation.

Fixes: #365 

Signed-off-by: Saravanan KR <skramaja@redhat.com>