### PR TITLE
kind, automation: detach all loopbacks on provider startup

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -152,6 +152,11 @@ function setup_kind() {
         docker exec $node /bin/sh -c "curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar xz -C /opt/cni/bin"
     done
 
+    # detach all the loopback devices from previous executions - useful only
+    # for CI.
+    # TODO: Once this is properly fixed, remove the next condition.
+    losetup -D
+
     echo "ipv6 cni: $IPV6_CNI"
     if [ -z ${IPV6_CNI+x} ]; then
         echo "no ipv6, safe to install calico"


### PR DESCRIPTION
When running docker in docker (which is how kind does it's thing)
, the `losetup` command ends up looking for the next available
device in the host's namespace, instead of using the k8s node
namespace.

Eventually, it will grow past the number of statically allocated
loopback devices by the `loopdev` container. When that happens,
the `disks-images-provider` pod enters the crash loop.

By detaching all loopback devices from the host at provider
startup we assure the next available device will be on range.

Fixes: https://github.com/kubevirt/kubevirt/issues/3569