### PR TITLE
allow setting hugepages via gocli

### DIFF
--- a/cluster-provision/k8s/1.17/hugepages-setup.sh
+++ b/cluster-provision/k8s/1.17/hugepages-setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+
+HUGEPAGES_2M=0
+HUGEPAGES_1G=0
+
+while true; do
+  case "$1" in
+    ----hugepages2M ) HUGEPAGES_2M="$2"; shift 2 ;;
+    ----hugepages1G ) HUGEPAGES_1G="$2"; shift 2 ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+if [ $HUGEPAGES_2M -ne 0 ]; then
+  sudo sh -c "echo $(HUGEPAGES_2M) > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages"
+fi
+
+if [ $HUGEPAGES_1G -ne 0 ]; then
+  sudo sh -c "echo $(HUGEPAGES_1G) > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages"
+fi
+
+service kubelet restart
+kubelet_rc=$?
+if [[ $kubelet_rc -ne 0 ]]; then
+    rm -rf /var/lib/kubelet/cpu_manager_state
+    service kubelet restart
+fi

--- a/cluster-provision/k8s/1.18/hugepages-setup.sh
+++ b/cluster-provision/k8s/1.18/hugepages-setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+
+HUGEPAGES_2M=0
+HUGEPAGES_1G=0
+
+while true; do
+  case "$1" in
+    ----hugepages2M ) HUGEPAGES_2M="$2"; shift 2 ;;
+    ----hugepages1G ) HUGEPAGES_1G="$2"; shift 2 ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+if [ $HUGEPAGES_2M -ne 0 ]; then
+  sudo sh -c "echo $(HUGEPAGES_2M) > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages"
+fi
+
+if [ $HUGEPAGES_1G -ne 0 ]; then
+  sudo sh -c "echo $(HUGEPAGES_1G) > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages"
+fi
+
+service kubelet restart
+kubelet_rc=$?
+if [[ $kubelet_rc -ne 0 ]]; then
+    rm -rf /var/lib/kubelet/cpu_manager_state
+    service kubelet restart
+fi


### PR DESCRIPTION
Some KubeVirt features such as VirtioFS (https://github.com/kubevirt/kubevirt/pull/3493) or VhostUser with DPDK will require more hugepages to be allocated on the nodes.
This PR will allow allocating hugepages on nodes using gocli.
It which will accept the number of pages using  `--hugepages2M-nr` | `--hugepages1G-nr` parameters

Signed-off-by: Vladik Romanovsky <vromanso@redhat.com>