### PR TITLE
[1] k8s1.18: Modify hard coded values in hugepage checks

### DIFF
--- a/cluster-provision/k8s/1.18/node01.sh
+++ b/cluster-provision/k8s/1.18/node01.sh
@@ -3,7 +3,15 @@
 set -ex
 
 # Ensure that hugepages are there
-cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
+# Hugetlb holds total huge page size in kB including both 2M or 1G hugepages
+HUGETLB=`cat /proc/meminfo | sed -e "s/ //g" | grep "Hugetlb:"`
+HUGEPAGE=(${HUGETLB//:/ })
+HUGEPAGE_PARTS=(${HUGEPAGE[-1]//kB/ })
+HUGEPAGE_TOTAL=${HUGEPAGE_PARTS[0]}
+if [[ $HUGEPAGE_TOTAL -lt $((64 * 2048)) ]]; then
+    echo "Minimum of 64 2M Hugepages is required"
+    exit 1
+fi
 
 timeout=30
 interval=5

--- a/cluster-provision/k8s/1.18/nodes.sh
+++ b/cluster-provision/k8s/1.18/nodes.sh
@@ -3,7 +3,15 @@
 set -ex
 
 # Ensure that hugepages are there
-cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
+# Hugetlb holds total huge page size in kB including both 2M or 1G hugepages
+HUGETLB=`cat /proc/meminfo | sed -e "s/ //g" | grep "Hugetlb:"`
+HUGEPAGE=(${HUGETLB//:/ })
+HUGEPAGE_PARTS=(${HUGEPAGE[-1]//kB/ })
+HUGEPAGE_TOTAL=${HUGEPAGE_PARTS[0]}
+if [[ $HUGEPAGE_TOTAL -lt $((64 * 2048)) ]]; then
+    echo "Minimum of 64 2M Hugepages is required"
+    exit 1
+fi
 
 timeout=30
 interval=5


### PR DESCRIPTION
Using vhostuser based VMs required additional hugepages than the
existing configuration of 64 2M pages. Modify the condition check
of == 64, to allow the huagepages to be a minimum of 64 2M
size. This change is already [merged](https://github.com/kubevirt/kubevirtci/pull/367) in 1.17, apply the same with
1.18 too.

Related #365

Signed-off-by: Saravanan KR <skramaja@redhat.com>