### PR TITLE
Fix check-cluster-up.sh missing Var init

### DIFF
--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -3,6 +3,7 @@
 
 set -exuo pipefail
 
+CI=${CI:-"false"}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 provision_dir="$1"
 


### PR DESCRIPTION
Since the script runs with -u,
variables must be set also when running locally.

When running locally, the error was:
`./check-cluster-up.sh: line 31: CI: unbound variable`

Signed-off-by: Or Shoval <oshoval@redhat.com>