### PR TITLE
Improve Sriov provider

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -207,8 +207,8 @@ function deploy_sriov_operator {
 
   echo 'Generating webhook certificates for the SR-IOV operator webhooks'
   pushd "${CSRCREATORPATH}"
-    go run . -namespace sriov-network-operator -secret operator-webhook-service -hook operator-webhook -kubeconfig $KUBECONFIG_PATH
-    go run . -namespace sriov-network-operator -secret network-resources-injector-secret -hook network-resources-injector -kubeconfig $KUBECONFIG_PATH
+    go run . -namespace sriov-network-operator -secret operator-webhook-service -hook operator-webhook -kubeconfig $KUBECONFIG_PATH || return 1
+    go run . -namespace sriov-network-operator -secret network-resources-injector-secret -hook network-resources-injector -kubeconfig $KUBECONFIG_PATH || return 1
   popd
 
   echo 'Setting caBundle for SR-IOV webhooks'

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -225,8 +225,9 @@ function deploy_sriov_operator {
   # 'operator-webhook' and 'network-resources-injector' webhooks certificates are
   # configured, in order to check if caBundle reconcile is finished it is necessary
   # to wait for the "NoSchedule" taint to present and then absent.
-  wait_for_taint "NoSchedule" || true
-  wait_for_taint_absence "NoSchedule" || return 1
+  taint="NoSchedule"
+  wait_for_taint "$taint" || echo "Taint $taint did not present on nodes after setting caBundle for sriov webhooks"
+  wait_for_taint_absence "$taint" || return 1
 
   return 0
 }
@@ -259,8 +260,9 @@ function apply_sriov_node_policy {
   # Since SriovNodeNetworkPolicy doesnt have Status to indicate if its
   # configured successfully, it is necessary to wait for the "NoSchedule"
   # taint to present and then absent.
-  wait_for_taint "NoSchedule" || true
-  wait_for_taint_absence "NoSchedule" || return  1
+  taint="NoSchedule"
+  wait_for_taint "$taint" || echo "Taint $taint did not present on nodes after creating SriovNodeNetworkPolicy"
+  wait_for_taint_absence "$taint" || return  1
 
   return 0
 }


### PR DESCRIPTION
This PR is part of stabilizing sriov-lane effort:
1. Stop cluster-up when  sriov operator webhooks certificate generation fails 
2. Print informative error message where wait_for_taint return code 1

