### PR TITLE
kind: minor fixes to down()

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -201,9 +201,9 @@ function _kubectl() {
 
 function down() {
     _fetch_kind
-    if [ -z $($KIND get clusters | grep ${CLUSTER_NAME}) ]; then
+    if [ -z "$($KIND get clusters | grep ${CLUSTER_NAME})" ]; then
         return
     fi
     $KIND delete cluster --name=${CLUSTER_NAME}
-    rm ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+    rm -f ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
 }


### PR DESCRIPTION
Fixes the following when taking down a multi-node cluster:
```
cluster/kind/common.sh: line 204: [: kind-1.17: binary operator expected
```
and this when calling `make cluster-down` on an already down cluster:
```
rm: cannot remove '/home/build/kubevirt/_ci-configs/kind-k8s-1.17/kind.yaml': No such file or directory
```