### PR TITLE
vm-image-builder: Automate creating customized Kubevirt VM's images

### DIFF
--- a/cluster-provision/images/vm-image-builder/Dockerfile.containerdisk
+++ b/cluster-provision/images/vm-image-builder/Dockerfile.containerdisk
@@ -1,0 +1,2 @@
+FROM kubevirt/container-disk-v1alpha
+ADD image /disk

--- a/cluster-provision/images/vm-image-builder/OWNERS
+++ b/cluster-provision/images/vm-image-builder/OWNERS
@@ -1,0 +1,6 @@
+filters:
+  ".*":
+    reviewers:
+      - ormergi
+    approvers:
+      - ormergi

--- a/cluster-provision/images/vm-image-builder/README.md
+++ b/cluster-provision/images/vm-image-builder/README.md
@@ -1,0 +1,162 @@
+# Customize ephemeral container-disk images for KubeVirt VM's
+
+This tool is targeted for KubeVirt developers, users or anyone who
+would like to create KubeVirt VM's with customized container-disk,
+without the hassle of installing and customizing the OS manually.
+
+Use cases:
+- VM's for Demos
+- Pre-configured Kubevirt VM image for tests, for example:
+    - Image with qemu-guest-agent installed and configured.
+    - Image with sriov drivers for sriov-lane images.
+    - Image with DPDK package for testing DPDK applications on KubeVirt.
+
+## Create customized container-disk
+
+In order to create customized  container-disk for KubeVirt VM,
+use `create-containderdisk.sh` script.
+
+This script automates the process of customizing VM image and build Kubevirt VM container-disk-image.
+Soon there will be used for creating and image automatically using CI.
+
+What this script does:
+- Download VM image from given URL
+
+- Customize VM image using `customize-image.sh` script, according to given cloud-config file.
+  Keeping customizing image method loosely-coupled, so it will be easy to maintain.
+  You can use any image customizing script by exporting `CUSTOMIZE_IMAGE_SCRIPT=<script path>`.
+
+- Building container-disk image using `build-containerdisk.sh`
+  according to the doc:
+  https://github.com/kubevirt/kubevirt/blob/master/docs/container-register-disks.md
+
+- Store the image in local registry and exports the container image to .tar file, so it will be easier to store or send.
+
+This script expected variables:  
+- `VM_IMAGE_URL` - URL to download the image
+- `CLOUD_CONFIG_PATH` - cloud-conifg file path used  for customizing the image with cloud-init
+- `IMAGE_NAME`, `TAG` - container-disk image tag that will be created tag details `IMAGE_NAME:TAG`
+- `OS_VARIANT`- required by customize-image.sh
+
+Notes:
+- If no variables passed, the script will create container-disk image according to the files at `example/`.
+- Currently, image customization process done by spinning up live VM with cloud-init disk to provision the image with the changes described by the cloud-config file.
+- It is necessary to add `sudo shutdown` at the end of the cloud-config`runcmd` block, so the script will not wait for user input.
+- You can use your own image customizing script by exporting the path to `CUSTOMIZE_IMAGE_SCRIPT`.
+
+This script requires the following packages:
+- cloud-utils
+- docker-ce
+- libvirt
+- libguestfs
+- qemu-img
+
+## How to use:
+```bash
+cd cluster-provision/images/container-disk-images/
+# Export image name and tag
+$ export IMAGE_NAME="example-fedora"
+$ export TAG="32"
+
+# Export VM image URL:
+$ export IMAGE_URL=$(cat example/image-url)
+$ export OS_VARIANT=fedora31
+
+# Export cloud-config file
+$ export CLOUD_CONFIG_PATH="example/cloud-config"
+
+# Run script
+$ ./create-containerdisk.sh
+...
+Successfully tagged example-fedora:32
+...
+Container image saved as tar file at: example-fedora_build/example-fedora-32.tar
+...
+
+# You can send / store the image .tar file:
+$ ls example-fedora_build/example-fedora-32.tar
+example-fedora_build/example-fedora-32.tar
+```
+
+## Publish customized container-disk image
+
+Push the new container-disk image to a registry with `publish-containerdisk.sh` script.
+
+This script exports:
+REGISTRY - the registry the image will be stored at.
+REPOSITORY - image repository.
+
+This script expects:
+IMAGE_NAME - container disk image name.
+TAG - container disk image tag.
+
+### Example:
+```bash
+$ export IMAGE_NAME=example-fedora
+$ export TAG=32
+
+$ ./publish-containerdisk.sh
+```
+
+### Push the new image to local cluster registry:
+```bash
+$ export IMAGE_NAME=example-fedora
+$ export TAG=32
+
+# From kubevirtci / kubevirt directory
+$ export REGISTRY="localhost:$(./cluster-up/cli.sh ports registry | tr -d '\r')"$
+
+$ ./publish-containerdisk.sh
+```
+
+### Create Kubevirt VM's with the new image
+
+In the VMI / VM yaml file, change `spec.volumes[].containerDisk.image` to the new image path.
+
+It is possible to use an image from local cluster registry.
+
+```bash
+$ kubectl apply -f <VMI yaml file>
+$ kubectl wait --for=condition=AgentConnected vmi $VMI_NAME --timeout 5m
+$ virtctl console testvm1
+```
+
+
+## Build container-disk image
+
+To build container-disk image form qcow2 image file, use `build-containerdisk.sh` script.
+
+This script converts `qcow2` image to container-disk image that can be consumed by KubeVirt VM's.
+
+What this script does:
+- Creates temp directory with a copy of the source VM image.
+
+- Build container image with kubevirt/container-disk-v1alpha layer, 
+  using `Dokcerfile.template` according to:
+  https://github.com/kubevirt/kubevirt/blob/master/docs/container-register-disks.md  
+  The image is stored in the local registry.
+  
+- Exports container image as .tar file
+
+Arguments:
+- IMAGE_NAME - container-disk image name
+- TAG - container-disk image tag
+- VM_IMAGE_FILE - source VM image path to convert
+
+### Example:
+```bash
+$ image_name='example-fedora'
+$ tag='32'
+$ vm_image='customized-image.qcow2'
+
+$ ./build-containerdisk.sh $image_name $tag $vm_image
+...
+Successfully tagged example-fedora:32
+...
+Container image saved as tar file at: example-fedora_build/example-fedora-32.tar
+...
+
+# Generated image .tar file
+$ ls example-fedora_build/example-fedora-32.tar
+example-fedora_build/example-fedora-32.tar
+```

--- a/cluster-provision/images/vm-image-builder/build-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/build-containerdisk.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+SCRIPT_PATH=$(dirname "$(realpath "$0")")
+
+function cleanup() {
+  if [ $? -ne 0 ]; then
+    rm -f "${tar_file}"
+    docker image rm -f "${full_image_tag}"
+  fi
+
+  rm -rf "${temp_dir}"
+}
+
+IMAGE_NAME=$1
+TAG=$2
+VM_IMAGE_FILE=$3
+
+template_dockerfile="${SCRIPT_PATH}/Dockerfile.containerdisk"
+
+parent_dir=$(dirname "$VM_IMAGE_FILE")
+tar_file="${parent_dir}/${IMAGE_NAME}-${TAG}.tar"
+full_image_tag="${IMAGE_NAME}:${TAG}"
+
+trap 'cleanup' EXIT SIGINT
+
+temp_dir=$(mktemp -d -p /tmp -t build.container-disk.XXXX)
+cp "${template_dockerfile}" "${temp_dir}/Dockerfile"
+cp "${VM_IMAGE_FILE}" "${temp_dir}/image"
+
+pushd "${temp_dir}"
+  docker build -t "${full_image_tag}" .
+popd
+
+docker save --output "${tar_file}" "${full_image_tag}"
+
+echo "Container image saved as tar file at: ${tar_file}"

--- a/cluster-provision/images/vm-image-builder/create-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/create-containerdisk.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+SCRIPT_PATH=$(dirname "$(realpath "$0")")
+
+export CUSTOMIZE_IMAGE_SCRIPT=${CUSTOMIZE_IMAGE_SCRIPT:-"${SCRIPT_PATH}/customize-image.sh"}
+
+function customize_image() {
+  local source_image=$1
+  local os_variant=$2
+  local customized_image=$3
+  local cloud_config=$4
+
+  # Backup the VM image and pass copy of the original image
+  # in case customizing script fail.
+  vm_image_copy="$(dirname "${customized_image}")/copy-${source_image}"
+  cp "${source_image}" "${vm_image_copy}"
+
+  # TODO: convert this script and its dependencies to container
+  ${CUSTOMIZE_IMAGE_SCRIPT} "${vm_image_copy}" "${os_variant}" "${customized_image}" "${cloud_config}"
+
+  # Backup no longer needed.
+  rm -f "${vm_image_copy}"
+}
+
+function cleanup() {
+  if [ $? -ne 0 ]; then
+    rm -rf "${build_directory}"
+  fi
+
+  rm -f "copy-${VM_IMAGE}"
+}
+
+export IMAGE_NAME=${IMAGE_NAME:-example-fedora}
+export TAG=${TAG:-32}
+export OS_VARIANT=${OS_VARIANT:-fedora31}
+export CLOUD_CONFIG_PATH=${CLOUD_CONFIG_PATH:-"${SCRIPT_PATH}/example/cloud-config"}
+export VM_IMAGE_URL=${VM_IMAGE_URL:-$(cat "${SCRIPT_PATH}/example/image-url")}
+
+readonly VM_IMAGE="source-image.qcow2"
+readonly build_directory="${IMAGE_NAME}_build"
+readonly new_vm_image_name="provisioned-image.qcow2"
+
+trap 'cleanup' EXIT SIGINT
+
+pushd "${SCRIPT_PATH}"
+  cleanup
+
+   if ! [ -e "${VM_IMAGE}" ]; then
+    # Download base VM image
+    curl -L "${VM_IMAGE_URL}" -o "${VM_IMAGE}"
+  fi
+
+  mkdir "${build_directory}"
+
+  customize_image "${VM_IMAGE}" "${OS_VARIANT}" "${build_directory}/${new_vm_image_name}" "${CLOUD_CONFIG_PATH}"
+
+  ${SCRIPT_PATH}/build-containerdisk.sh "${IMAGE_NAME}" "${TAG}" "${build_directory}/${new_vm_image_name}"
+
+popd

--- a/cluster-provision/images/vm-image-builder/customize-image.sh
+++ b/cluster-provision/images/vm-image-builder/customize-image.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+function cleanup() {
+  if [ $? -ne 0 ]; then
+    rm -f "${CUSTOMIZE_IMAGE_PATH}"
+  fi
+
+  rm -rf "${CLOUD_INIT_ISO}"
+  virsh destroy "${DOMAIN_NAME}" || true
+  virsh undefine "${DOMAIN_NAME}" || true
+}
+
+SOURCE_IMAGE_PATH=$1
+OS_VARIANT=$2
+CUSTOMIZE_IMAGE_PATH=$3
+CLOUD_CONFIG_PATH=$4
+
+readonly DOMAIN_NAME="provision-vm"
+readonly CLOUD_INIT_ISO="cloudinit.iso"
+
+trap 'cleanup' EXIT SIGINT
+
+# Create cloud-init user data ISO
+cloud-localds "${CLOUD_INIT_ISO}" "${CLOUD_CONFIG_PATH}"
+
+echo "Customize image by booting a VM with
+ the image and cloud-init disk
+ press ctrl+] to exit"
+virt-install \
+  --memory 2048 \
+  --vcpus 2 \
+  --name $DOMAIN_NAME \
+  --disk "${SOURCE_IMAGE_PATH}",device=disk \
+  --disk "${CLOUD_INIT_ISO}",device=cdrom \
+  --os-type Linux \
+  --os-variant "${OS_VARIANT}" \
+  --virt-type kvm \
+  --graphics none \
+  --network default \
+  --import
+
+# Stop VM
+virsh destroy $DOMAIN_NAME || true
+
+# Prepare VM image
+virt-sysprep -d $DOMAIN_NAME --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr
+
+# Remove VM
+virsh undefine $DOMAIN_NAME
+
+# Convert image
+qemu-img convert -c -O qcow2 "${SOURCE_IMAGE_PATH}" "${CUSTOMIZE_IMAGE_PATH}"

--- a/cluster-provision/images/vm-image-builder/example/cloud-config
+++ b/cluster-provision/images/vm-image-builder/example/cloud-config
@@ -1,0 +1,11 @@
+#cloud-config
+password: fedora
+chpasswd: { expire: False }
+ssh_pwauth: yes
+runcmd:
+  - sudo dnf install -y qemu-guest-agent stress
+  - sudo dnf clean all
+  - sudo hostnamectl set-hostname ""
+  - sudo hostnamectl set-hostname "" --transient
+  - sudo systemctl start qemu-guest-agent
+  - sudo shutdown

--- a/cluster-provision/images/vm-image-builder/example/image-url
+++ b/cluster-provision/images/vm-image-builder/example/image-url
@@ -1,0 +1,1 @@
+https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-sriov-lane/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-sriov-lane/cloud-config
@@ -1,0 +1,26 @@
+#cloud-config
+password: fedora
+chpasswd: { expire: False }
+ssh_pwauth: yes
+write_files:
+    - path: /etc/modules-load.d/mlx5.conf
+      content: |
+        mlx5_core
+        mlx5_ib
+    - path: /etc/modules-load.d/mlx4.conf
+      content: |
+        mlx4_core
+        mlx4_ib
+    - path: /etc/modules-load.d/i40e.conf
+      content: |
+        i40e
+    - path: /etc/modules-load.d/igb.conf
+      content: |
+        igb
+runcmd:
+  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent
+  - sudo dnf clean all
+  - sudo hostnamectl set-hostname ""
+  - sudo hostnamectl set-hostname "" --transient
+  - sudo systemctl start qemu-guest-agent
+  - sudo shutdown

--- a/cluster-provision/images/vm-image-builder/fedora-sriov-lane/image-url
+++ b/cluster-provision/images/vm-image-builder/fedora-sriov-lane/image-url
@@ -1,0 +1,1 @@
+https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/publish-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/publish-containerdisk.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+export REGISTRY=${REGISTRY:-docker.io}
+export REPOSITORY=${REPOSITORY:-kubevirt}
+
+full_image_tag="${REGISTRY}/${REPOSITORY}/${IMAGE_NAME}:${TAG}"
+
+docker tag "${IMAGE_NAME}:${TAG}" "${full_image_tag}"
+docker push "${full_image_tag}"


### PR DESCRIPTION
This PR add tool for automating the process of creating new container-disk image for KubeVirt VMs
based on  http://github.com/ormergi/vm-image-builder

It is targeted for developers or anyone who would like to create customized ephemeral container disk image for Kubevirt VM's
As were presented at kubevirt/kubevirt#3834

This tool should be used on the user host, integrating this to CI will be presented in following PR.

This PR:
Fixes kubevirt/kubevirt#3903
Is needed to continue with kubevirt/kubevirt#3834 and  kubevirt/kubevirt#3850

Release note:
```
Automate creating customized KubeVirt container disk images.
```