### PR TITLE
Cargo cult NAT forwarding for IPv6

### DIFF
--- a/cluster-provision/centos8/scripts/dnsmasq.sh
+++ b/cluster-provision/centos8/scripts/dnsmasq.sh
@@ -35,5 +35,8 @@ done
 iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 iptables -A FORWARD -i br0 -o eth0 -j ACCEPT
+ip6tables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+ip6tables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+ip6tables -A FORWARD -i br0 -o eth0 -j ACCEPT
 
 exec dnsmasq --interface=br0 --enable-ra -d ${DHCP_HOSTS} --dhcp-range=192.168.66.10,192.168.66.200,infinite --dhcp-range=::10,::200,constructor:br0,static

--- a/cluster-provision/k8s/1.18/provision.sh
+++ b/cluster-provision/k8s/1.18/provision.sh
@@ -135,6 +135,7 @@ cat <<EOF >  /etc/sysctl.d/k8s.conf
 net.bridge.bridge-nf-call-ip6tables = 1
 net.bridge.bridge-nf-call-iptables = 1
 net.ipv4.ip_forward = 1
+net.ipv6.conf.all.forwarding = 1
 EOF
 sysctl --system
 


### PR DESCRIPTION
I wanted to ssh.sh node01 and be able to ping6 google.com. I couldn't.
Running (some) of these commands locally allowed me do so.

---
Question: why are we using NAT at all? wouldn't it be enough to bridge tap01 and eth0?