### PR TITLE
Make the provider's config path dynamic

### DIFF
--- a/cluster-up/cluster/local/provider.sh
+++ b/cluster-up/cluster/local/provider.sh
@@ -32,7 +32,8 @@ function up() {
 }
 
 function prepare_config() {
-    cat >hack/config-provider-local.sh <<EOF
+    PROVIDER_CONFIG_FILE_PATH="${BASE_PATH}/$KUBEVIRT_PROVIDER/config-provider-$KUBEVIRT_PROVIDER.sh"
+    cat > "$PROVIDER_CONFIG_FILE_PATH" <<EOF
 master_ip=$(_main_ip)
 docker_tag=devel
 kubeconfig=$(_cert_dir)/admin.kubeconfig


### PR DESCRIPTION
This is done in order to support the local provider config path.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>