### PR TITLE
Change the pre-provisioned path on the K8s nodes

### DIFF
--- a/cluster-provision/k8s/1.16/provision.sh
+++ b/cluster-provision/k8s/1.16/provision.sh
@@ -221,6 +221,6 @@ docker pull quay.io/cephcsi/rbdplugin:v1.0.0
 docker pull quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
 
 # Create a properly labelled tmp directory for testing
-mkdir -p /provision/kubevirt.io/tests
-chcon -t container_file_t /provision/kubevirt.io/tests
-echo "tmpfs /provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
+mkdir -p /var/provision/kubevirt.io/tests
+chcon -t container_file_t /var/provision/kubevirt.io/tests
+echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab

--- a/cluster-provision/k8s/1.17/provision.sh
+++ b/cluster-provision/k8s/1.17/provision.sh
@@ -352,9 +352,9 @@ for i in $(grep -A 2 "IMAGE" /opt/cnao/operator.yaml | grep value | awk '{print 
 for i in $(grep -A 2 "IMAGE" /provision/local-volume.yaml | grep value | awk -F\" '{print $2}'); do docker_pull_retry $i; done
 
 # Create a properly labelled tmp directory for testing
-mkdir -p /provision/kubevirt.io/tests
-chcon -t container_file_t /provision/kubevirt.io/tests
-echo "tmpfs /provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
+mkdir -p /var/provision/kubevirt.io/tests
+chcon -t container_file_t /var/provision/kubevirt.io/tests
+echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
 dnf install -y NetworkManager-config-server
 

--- a/cluster-provision/k8s/1.18/provision.sh
+++ b/cluster-provision/k8s/1.18/provision.sh
@@ -300,9 +300,9 @@ for i in $(grep -A 2 "IMAGE" /opt/cnao/operator.yaml | grep value | awk '{print 
 for i in $(grep -A 2 "IMAGE" /provision/local-volume.yaml | grep value | awk -F\" '{print $2}'); do docker_pull_retry $i; done
 
 # Create a properly labelled tmp directory for testing
-mkdir -p /provision/kubevirt.io/tests
-chcon -t container_file_t /provision/kubevirt.io/tests
-echo "tmpfs /provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
+mkdir -p /var/provision/kubevirt.io/tests
+chcon -t container_file_t /var/provision/kubevirt.io/tests
+echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
 dnf install -y NetworkManager-config-server
 


### PR DESCRIPTION
This is done in order to enable testing on CoreOS, where the root path
is read only.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>