### PR TITLE
Mount /lib/modules at gocli if exists

### DIFF
--- a/cluster-provision/cli/cli
+++ b/cluster-provision/cli/cli
@@ -173,7 +173,13 @@ if [ "$COMMAND" = "update" ] ; then
   exit 0
 fi
 
-DNSMASQ_CID=$(docker run -d ${PORTS} -v /lib/modules:/lib/modules -e NUM_NODES=${NODES} --name ${PREFIX}dnsmasq --privileged ${BASE} /bin/bash -c /dnsmasq.sh)
+# gocli will try to mount /lib/modules to make it accessible to dnsmasq in
+# in case it exists
+if [ -d /lib/modules ]; then
+        dnsmasq_mounts="-v /lib/modules/:/lib/modules/"
+fi
+
+DNSMASQ_CID=$(docker run -d ${PORTS} ${dnsmasq_mounts} -e NUM_NODES=${NODES} --name ${PREFIX}dnsmasq --privileged ${BASE} /bin/bash -c /dnsmasq.sh)
 CONTAINERS=${DNSMASQ_CID}
 
 if [ "$COMMAND" == "provision" ] ; then

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -194,6 +194,21 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
+	// Mount /lib/modules at dnsmasq if it's there since sometimes
+	// some kernel modules may be mounted
+	dnsmasqMounts := []mount.Mount{}
+	_, err = os.Stat("/lib/modules")
+	if err == nil {
+		dnsmasqMounts = []mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: "/lib/modules",
+				Target: "/lib/modules",
+			},
+		}
+
+	}
+
 	// Start dnsmasq
 	dnsmasq, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: cluster,
@@ -218,13 +233,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 			"registry:192.168.66.2",
 			"ceph:192.168.66.2",
 		},
-		Mounts: []mount.Mount{
-			{
-				Type:   mount.TypeBind,
-				Source: "/lib/modules",
-				Target: "/lib/modules",
-			},
-		},
+		Mounts: dnsmasqMounts,
 	}, nil, prefix+"-dnsmasq")
 	if err != nil {
 		return err

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -8,7 +8,13 @@ if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
     _cli="pack8s"
 else
     _cli_container="${KUBEVIRTCI_GOCLI_CONTAINER:-kubevirtci/${IMAGES[gocli]}}"
-    _cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
+    _cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock"
+    # gocli will try to mount /lib/modules to make it accessible to dnsmasq in
+    # in case it exists
+    if [ -d /lib/modules ]; then
+        _cli="${_cli} -v /lib/modules/:/lib/modules/"
+    fi
+    _cli="${_cli} ${_cli_container}"
 fi
 
 function _main_ip() {

--- a/cluster-up/cluster/images.sh
+++ b/cluster-up/cluster/images.sh
@@ -3,7 +3,7 @@
 set -e
 
 declare -A IMAGES
-IMAGES[gocli]="gocli@sha256:83a9238c071810e3efb6303560e33ac5d4c39cc655fb1c61ded136ae482b1013"
+IMAGES[gocli]="gocli@sha256:22586076428b7d285c7bfc6cfab50be2f7e4b69ad0f643bc598d1ab2f76ba116"
 if [ -z $KUBEVIRTCI_PROVISION_CHECK ]; then
     IMAGES[k8s-fedora-1.17.0]="k8s-fedora-1.17.0@sha256:aebf67b8b1b499c721f4d98a7ab9542c680553a14cbc144d1fa701fe611f3c0d"
     IMAGES[k8s-1.19]="k8s-1.19@sha256:b8d560e1a6df01ae4947d8e0f4d7645443b9369e3a88aabd2ef4c01a5dc468ea"


### PR DESCRIPTION
Right now it tries always to mount /lib/modules at gocli but this brings problems
with prow jobs since they are not mounted on the job's pod, let's make this optional,
normal users will use scripts here and we mount /lib/modules at those scripts.

Signed-off-by: Quique Llorente <ellorent@redhat.com>