### PR TITLE
Emulate krew integration for virtctl.sh in our dev environment

### DIFF
--- a/cluster-up/kubectl.sh
+++ b/cluster-up/kubectl.sh
@@ -31,8 +31,10 @@ source ${KUBEVIRTCI_CLUSTER_PATH}/$KUBEVIRT_PROVIDER/provider.sh
 source ${KUBEVIRTCI_PATH}/hack/config.sh
 
 if [ "$1" == "console" ] || [ "$1" == "vnc" ] || [ "$1" == "start" ] || [ "$1" == "stop" ] || [ "$1" == "migrate" ]; then
-    ${KUBEVIRTCI_PATH}/../_out/cmd/virtctl/virtctl --kubeconfig=${kubeconfig} "$@"
+    ${KUBEVIRTCI_PATH}/virtctl.sh "$@"
+elif [ "$1" == "virt" ]; then
+    shift
+    ${KUBEVIRTCI_PATH}/virtctl.sh "$@"
 else
     _kubectl "$@"
 fi
-


### PR DESCRIPTION
virtctl is available as krew plugin. In order to train the muscle memory of people the right way, emulate the krew invocation.

The following will work now:

```
cluster-up/kubectl.sh console myvm # just to keep working what was there before
cluster-up/kubectl.sh virt console myvm # like with krew
```