### PR TITLE
Revert http and https port to randomized

### DIFF
--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -25,7 +25,7 @@ KUBEVIRT_NUM_SECONDARY_NICS=${KUBEVIRT_NUM_SECONDARY_NICS:-0}
 # If on a developer setup, expose ocp on 8443, so that the openshift web console can be used (the port is important because of auth redirects)
 # http and https ports are accessed by testing framework and should not be randomized
 if [ -z "${JOB_NAME}" ]; then
-    KUBEVIRT_PROVIDER_EXTRA_ARGS="${KUBEVIRT_PROVIDER_EXTRA_ARGS} --ocp-port 8443 --http-port 80 --https-port 443"
+    KUBEVIRT_PROVIDER_EXTRA_ARGS="${KUBEVIRT_PROVIDER_EXTRA_ARGS} --ocp-port 8443"
 fi
 
 #If run on jenkins, let us create isolated environments based on the job and


### PR DESCRIPTION
PR #440 exposed port 80 and 443 for dnsmasq to
fixed port in the host by default.
This change makes them randomized instead