### PR TITLE
Make KUBEVIRTCI_TAG requirement explicit

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+if [ -z "${KUBEVIRTCI_TAG}" ] && [ -z "${KUBEVIRTCI_GOCLI_CONTAINER}" ]; then
+    echo "FATAL: either KUBEVIRTCI_TAG or KUBEVIRTCI_GOCLI_CONTAINER must be set"
+    exit 1
+fi
+
+if [ -n "${KUBEVIRTCI_TAG}" ] && [ -n "${KUBEVIRTCI_GOCLI_CONTAINER}" ]; then
+    echo "WARNING: KUBEVIRTCI_GOCLI_CONTAINER is set and will take precedence over the also set KUBEVIRTCI_TAG"
+fi
+
 if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
     _cli="pack8s"
 else


### PR DESCRIPTION
when the KUBEVIRTCI_TAG env variable is missing, cluster-up fails with a
cryptic error on docker command line format.
This cnange makes it explicit that the variable is mandatory and fails
the script with an explanation