### PR TITLE
Use latest gocli if non specified at `make cluster-up`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+
+export KUBEVIRTCI_TAG ?= $(shell curl -L https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+
 cluster-up:
 	./cluster-up/check.sh
 	./cluster-up/up.sh


### PR DESCRIPTION
The Makefile from kubevirtci is only consumed by kubevirtci itself
to test it, this commit use latest KUBEVIRTCI_TAG if not specified.

Signed-off-by: Quique Llorente <ellorent@redhat.com>