### PR TITLE
Enable docker-ce-nightly repos to get newer containerd

### DIFF
--- a/cluster-provision/k8s/1.17/provision.sh
+++ b/cluster-provision/k8s/1.17/provision.sh
@@ -67,6 +67,11 @@ dnf -y install yum-utils \
 # Add Docker repository.
 dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+# Enable the nightly version to get a new enough runc version which includes containerd
+# with a new enough runc version to avoid https://github.com/kubernetes/kubernetes/issues/95296#issuecomment-714419461
+# which manifests in /dev/* permission denied flakes on cpu manager enabled nodes
+dnf config-manager --set-enabled docker-ce-nightly
+
 # Install package(s) that trigger the enablement of the container-tools yum module
 dnf -y install container-selinux
 

--- a/cluster-provision/k8s/1.18/provision.sh
+++ b/cluster-provision/k8s/1.18/provision.sh
@@ -67,6 +67,11 @@ dnf -y install yum-utils \
 # Add Docker repository.
 dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+# Enable the nightly version to get a new enough runc version which includes containerd
+# with a new enough runc version to avoid https://github.com/kubernetes/kubernetes/issues/95296#issuecomment-714419461
+# which manifests in /dev/* permission denied flakes on cpu manager enabled nodes
+dnf config-manager --set-enabled docker-ce-nightly
+
 # Install package(s) that trigger the enablement of the container-tools yum module
 dnf -y install container-selinux
 

--- a/cluster-provision/k8s/1.19/provision.sh
+++ b/cluster-provision/k8s/1.19/provision.sh
@@ -67,6 +67,11 @@ dnf -y install yum-utils \
 # Add Docker repository.
 dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+# Enable the nightly version to get a new enough runc version which includes containerd
+# with a new enough runc version to avoid https://github.com/kubernetes/kubernetes/issues/95296#issuecomment-714419461
+# which manifests in /dev/* permission denied flakes on cpu manager enabled nodes
+dnf config-manager --set-enabled docker-ce-nightly
+
 # Install package(s) that trigger the enablement of the container-tools yum module
 dnf -y install container-selinux
 


### PR DESCRIPTION
In order to get rid of our /dev/null permission denied issues on cpu
manager enabled nodes, we need a newer runc version (>=1.0.0-91).

See https://github.com/kubernetes/kubernetes/issues/95296 for details.