### PR TITLE
kind-sriov, Add container alias of skopeo in case skopeo is missing

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -10,6 +10,16 @@ KUBECONFIG_PATH="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig"
 MASTER_NODE="${CLUSTER_NAME}-control-plane"
 WORKER_NODE_ROOT="${CLUSTER_NAME}-worker"
 
+if ! skopeo -v &> /dev/null
+then
+        echo "skopeo could not be found, creating alias for sriov operator, see hack/env.sh"
+        cat <<EOF > /usr/local/bin/skopeo
+#!/bin/bash
+docker run --rm quay.io/skopeo/stable "$@"
+EOF
+        chmod +x /usr/local/bin/skopeo
+fi
+
 OPERATOR_GIT_HASH=8d3c30de8ec5a9a0c9eeb84ea0aa16ba2395cd68  # release-4.4
 
 # This function gets a command string and invoke it


### PR DESCRIPTION
SRIOV operator uses `skopeo` to get the image hashes.

On SRIOV operator 4.6 we would need `skopeo` even if the env variables are set:
https://github.com/openshift/sriov-network-operator/blob/release-4.6/hack/env.sh#L1

Having `skopeo` would also remove the errors printed while running
cluster-up in case `skopeo` isn't installed on the host.

Fixing known problems and making the logs cleaner is important,
as it reduces noise and adapt code to future changes (l.e `skopeo` is mandatory for release 4.6 of SRIOV operator),
and sometimes fix other bugs (not in this case, but generally speaking).

Notes:
In case of local clusters, installing `skopeo` manually would be needed, as this PR require sudo access
to `/usr/local/bin` (which we do have on prow).

Signed-off-by: Or Shoval <oshoval@redhat.com>