### PR TITLE
SRIOV  provider fine tunes: reduce wait time for sriov-operator readiness

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -115,29 +115,29 @@ function is_taint_absence {
 function wait_for_taint_absence {
   local -r taint=$1
 
-  local -r tries=60
+  local -r tries=24
   local -r wait_time=5
 
-  local -r wait_message="Waiting for $taint taint absence"
-  local -r error_message="Taint $taint $name did not removed"
+  local -r wait_message="Waiting for taint '$taint' absence"
+  local -r error_message="Taint $taint did not removed"
   local -r action="is_taint_absence $taint"
 
   retry "$tries" "$wait_time" "$action" "$wait_message" && return 0
-  echo $error_message && return 1
+  echo "$error_message" && return 1
 }
 
 function wait_for_taint {
   local -r taint=$1
 
-  local -r tries=60
+  local -r tries=24
   local -r wait_time=5
 
-  local -r wait_message="Waiting for $taint taint to present"
-  local -r error_message="Taint $taint $name did not present"
+  local -r wait_message="Waiting for taint '$taint' to present"
+  local -r error_message="Taint '$taint' did not present"
   local -r action="_kubectl get nodes -o custom-columns=taints:.spec.taints[*].effect --no-headers | grep -i $taint"
 
   retry "$tries" "$wait_time" "$action" "$wait_message" && return 0
-  echo $error_message && return 1
+  echo "$error_message" && return 1
 }
 
 # not using kubectl wait since with the sriov operator the pods get restarted a couple of times and this is


### PR DESCRIPTION
As for today we wait at most 10 minutes for the sriov-operator to be ready and 
verify that all taints that have been placed on the cluster nodes to be removed.

We wait 5 minutes for `NoSchedule` taints to be placed/removed after sriov-network-operator webhooks are patched with certificates.
And another 5 for `NoSchedule` taints after `SriovNetworkNodePolicy` is applied.
See this issue for more details why we need to wait for taints https://github.com/openshift/sriov-network-operator/issues/339

The wait time for the operator to be ready is monitored for a while now and waiting 4 minutes is enough.
This PR reduce the time we wait for taints to be placed and removed, it will reduce the time the cluster to be ready.
