### PR TITLE
SRIOV provider fine tunes: Logs and Missing Configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-export KUBEVIRTCI_TAG ?= $(shell curl -L https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+export KUBEVIRTCI_TAG ?= $(shell curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
 
 cluster-up:
 	./cluster-up/check.sh

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
@@ -22,5 +22,8 @@ function up() {
 
     kind_up
 
+    # remove the rancher.io kind default storageClass
+    _kubectl delete sc standard
+
     ${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/config_sriov.sh
 }

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -35,7 +35,7 @@ function _wait_containers_ready {
 
 function _fetch_kind() {
     if [ ! -f ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind ]; then
-        wget https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64 -O ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind
+        curl -LSs  https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64 -o ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind
         chmod +x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind
     fi
     KIND=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind
@@ -169,7 +169,7 @@ function setup_kind() {
     fi
 
     for node in $(_get_nodes | awk '{print $1}'); do
-        docker exec $node /bin/sh -c "curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar xz -C /opt/cni/bin"
+        docker exec $node /bin/sh -c "curl -LSs https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar xz -C /opt/cni/bin"
     done
 
     echo "Installing Calico CNI plugin"

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -284,5 +284,6 @@ function down() {
         return
     fi
     $KIND delete cluster --name=${CLUSTER_NAME}
+    docker rm -f $REGISTRY_NAME >> /dev/null
     rm -f ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
 }


### PR DESCRIPTION
This PR intent is to reduce sriov provider cluster-up logs noise, 
and add missing configurations for sriov provider.

In Sriov lane job logs we have download progress for sriov binary and for every time we use `make` (e.g: make cluster-up, make cluster-down) for fetching kubevirtci tag.
 
Most of the helpers we use in config_sriov.sh print commands and their arguments as they are executed, which cause a lot of noise in the logs and dont help much on having them.

Also SRIOV provider provider.sh scripts misses configuration
- Remove rancher standard storage class (that deployed by kind)
- Delete local registry container on `make cluster-down`
