### PR TITLE
SRIOV provider: Add Initial Example SriovNetwork

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/manifests/sriov-network-example.yaml
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/manifests/sriov-network-example.yaml
@@ -1,0 +1,10 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-network-example
+  namespace: sriov-network-operator
+spec:
+  ipam: '{}'
+  vlan: 0
+  resourceName: sriov_net
+  networkNamespace: default


### PR DESCRIPTION
This PR adds an example SriovNetwork creation after sriov-operaor-deployment for SRIOV provider.
It enable one to create VM without worrying about creating SriovNetwork for initial results.

This is necessary for kubevirt/kubevirt#4356

Signed-off-by: Or Mergi <ormergi@redhat.com>