### PR TITLE
Suggestion - sriov provider, Let cluster stabilize after deployed

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -334,4 +334,10 @@ wait_allocatable_resource $SRIOV_NODE "openshift.io/$resource_name" $NODE_PF_NUM
 _kubectl get nodes
 _kubectl get pods -n $SRIOV_OPERATOR_NAMESPACE
 echo
+
+# Upon cluster start we might see "etcdserver: request timed out"
+# when accessing API, due to IO pressure.
+# Let the transient pass away (skip it by export SKIP_SRIOV_SLEEP=1)
+[ -z $SKIP_SRIOV_SLEEP ] && echo "sleeping 120 seconds to stabilize etcd, export SKIP_SRIOV_SLEEP=1 to skip"  && sleep 120
+
 echo "$KUBEVIRT_PROVIDER cluster is ready"


### PR DESCRIPTION
Since the tests start right after cluster is deployed,
and some pods still work with etcd extensively
we should let the cluster stabilize in order
to avoid `etcdserver: request timed out` which is caused by IO pressure
typically when cluster starts, before it stabilized.

SKIP_SRIOV_SLEEP can be set in order to skip the
waiting.

Fixes:
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4511/pull-kubevirt-e2e-kind-1.17-sriov/1325727568359329793

Reference that can help more:
https://github.com/kubernetes-sigs/kind/issues/717#issuecomment-512507692
https://github.com/kubernetes-sigs/kind/issues/717#issuecomment-513083096 (unless already bumped high enough)
https://github.com/etcd-io/etcd/issues/11809#issuecomment-621004811

See https://github.com/kubevirt/kubevirt/issues/4519

Signed-off-by: Or Shoval <oshoval@redhat.com>