### PR TITLE
SRIOV provier fine tunes: increase time we wait for taints a bit

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -115,7 +115,7 @@ function is_taint_absence {
 function wait_for_taint_absence {
   local -r taint=$1
 
-  local -r tries=24
+  local -r tries=30
   local -r wait_time=5
 
   local -r wait_message="Waiting for taint '$taint' absence"
@@ -129,7 +129,7 @@ function wait_for_taint_absence {
 function wait_for_taint {
   local -r taint=$1
 
-  local -r tries=24
+  local -r tries=30
   local -r wait_time=5
 
   local -r wait_message="Waiting for taint '$taint' to present"


### PR DESCRIPTION
During sriov provider cluster-up we deploy sriov-network-operator and due to the fact that
this operator has no CR to indicate the deployment is ready we need to assert multiple things
catching NoSchedule taints is one of them.

Getting the right time to "catch" a taint is tricky since it vary according to the sriov hardware and configuration (how much Vfs ware configured on the time the cluster was created).
We used to wait for 5 minutes which was too long.
And the fact that we have a node on CI with different hardware that didnt schedule jobs until two days ago
could explain why we never had to wait longer then two minutes.

Based on the last two days jobs with status successfully - 42 jobs.
The maximal time it took for a taint to be removed was 140 seconds and it happens only on one jobs.
The average time is 30 seconds and the median is 25 seconds.

This PR increase the time we wait for another 30 seconds, so it will be 2:30 minutes (150 seconds)