### PR TITLE
KIND infra, SRIOV proivder,  Run in-memory etcd

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
@@ -18,18 +18,8 @@ function up() {
     docker run --rm --cap-add=SYS_RAWIO quay.io/phoracek/lspci@sha256:0f3cacf7098202ef284308c64e3fc0ba441871a846022bb87d65ff130c79adb1 sh -c "lspci | egrep -i 'network|ethernet'"
 
     cp $KIND_MANIFESTS_DIR/kind.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
-    _fetch_kind
-    prepare_workers
-    # adding mounts to control plane, need them for sriov
-    cat >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml << EOF 
-  extraMounts:
-  - containerPath: /lib/modules
-    hostPath: /lib/modules
-    readOnly: true
-  - containerPath: /dev/vfio/
-    hostPath: /dev/vfio/
-EOF
 
-    setup_kind
+    kind_up
+
     ${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/config_sriov.sh
 }

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
@@ -16,6 +16,7 @@ function up() {
     # print hardware info for easier debugging based on logs
     echo 'Available NICs'
     docker run --rm --cap-add=SYS_RAWIO quay.io/phoracek/lspci@sha256:0f3cacf7098202ef284308c64e3fc0ba441871a846022bb87d65ff130c79adb1 sh -c "lspci | egrep -i 'network|ethernet'"
+    echo ""
 
     cp $KIND_MANIFESTS_DIR/kind.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
 

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -192,6 +192,19 @@ function setup_kind() {
     prepare_config
 }
 
+function _add_worker_extra_mounts() {
+    if [[ "$KUBEVIRT_PROVIDER" =~ sriov.* ]]; then
+        cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+  extraMounts:
+  - containerPath: /lib/modules
+    hostPath: /lib/modules
+    readOnly: true
+  - containerPath: /dev/vfio/
+    hostPath: /dev/vfio/
+EOF
+  fi
+}
+
 function _add_worker_kubeadm_config_patch() {
     cat << EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
   kubeadmConfigPatches:
@@ -213,6 +226,7 @@ function _add_workers() {
 - role: worker
 EOF
     _add_worker_kubeadm_config_patch
+    _add_worker_extra_mounts
     done
 }
 

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -91,24 +91,6 @@ function _configure_network() {
     done
 }
 
-function prepare_workers() {
-    # appending eventual workers to the yaml
-    for ((n=0;n<$(($KUBEVIRT_NUM_NODES-1));n++)); do
-        cat << EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
-- role: worker
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        "feature-gates": "CPUManager=true"
-        "cpu-manager-policy": "static"
-        "kube-reserved": "cpu=500m"
-        "system-reserved": "cpu=500m"
-EOF
-    done
-}
-
 function _get_nodes() {
     _kubectl get nodes --no-headers
 }
@@ -210,9 +192,40 @@ function setup_kind() {
     prepare_config
 }
 
+function _add_worker_kubeadm_config_patch() {
+    cat << EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+  kubeadmConfigPatches:
+  - |-
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        "feature-gates": "CPUManager=true"
+        "cpu-manager-policy": "static"
+        "kube-reserved": "cpu=500m"
+        "system-reserved": "cpu=500m"
+EOF
+}
+
+function _add_workers() {
+    # appending eventual workers to the yaml
+    for ((n=0;n<$(($KUBEVIRT_NUM_NODES-1));n++)); do
+        cat << EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+- role: worker
+EOF
+    _add_worker_kubeadm_config_patch
+    done
+}
+
+function _prepare_kind_config() {
+    _add_workers
+
+    echo "Final KIND config:"
+    cat ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+}
+
 function kind_up() {
     _fetch_kind
-    prepare_workers
+    _prepare_kind_config
     setup_kind
 }
 


### PR DESCRIPTION
Currently we encounter bad performance of KIND cluster on DinD setup,
we get 'etcdserver: timeout errors' on SRIOV lane jobs causing jobs to fail often.

In such cases it is recommended to run in-memory etcd
kubernetes-sigs/kind#1922
kubernetes-sigs/kind#845
Running etcd in memory should improve performance and make sriov lane more stabilized

This PR patch the kind-config yaml for creating a cluster to run etcd from a specified path
which will be backed by in memory volume https://github.com/kubevirt/project-infra/pull/709

