### PR TITLE
jumbo frames: use an env var to set jumbo frames on the cluster

### DIFF
--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -43,4 +43,12 @@ function up() {
         $kubectl create -f /opt/cnao/network-addons-config-example.cr.yaml
         $kubectl wait networkaddonsconfig cluster --for condition=Available --timeout=200s
     fi
+
+    if [ "$KUBEVIRT_WITH_JUMBO_FRAMES" == "true" ];then
+      client_kubectl=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+      $client_kubectl patch configmap/calico-config -n kube-system --type merge \
+          -p '{"data":{"veth_mtu": "9000"}}'
+
+      $client_kubectl rollout restart daemonset calico-node -n kube-system
+    fi
 }


### PR DESCRIPTION
Configure the cluster's MTU to use jumbo frames

It will apply jumbo frames on:
  - bridge connecting the nodes (only primary iface)
  - tap device connecting the nodes to the bridge (only primary iface)
  - calico CNI mtu

