### PR TITLE
sriov, Fix non allocatable PF list

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -293,7 +293,7 @@ for ifs in "${sriov_pfs[@]}"; do
   ifs_name="${ifs%%/device/*}"
   ifs_name="${ifs_name##*/}"
 
-  if [ $(echo "${PF_BLACKLIST[@]}" | grep -q "${ifs_name}") ]; then
+  if [ $(echo "${PF_BLACKLIST[@]}" | grep "${ifs_name}") ]; then
     continue
   fi
 


### PR DESCRIPTION
In case the user needs to prevent a SRIOV PF from being allocated by the cluster,
`PF_BLACKLIST` should be used.
The logic was broken, and the PF would be allocated even if it was
listed as part of `PF_BLACKLIST`.

Signed-off-by: Or Shoval <oshoval@redhat.com>