### PR TITLE
cnao, Add KUBVIRT_WITH_CNAO_SKIP_CONFIG env

### DIFF
--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -33,14 +33,17 @@ function up() {
     $kubectl label node -l $label node-role.kubernetes.io/worker=''
 
     # Activate cluster-network-addons-operator if flag is passed
-    if [ "$KUBEVIRT_WITH_CNAO" == "true" ]; then
+    if [ "$KUBEVIRT_WITH_CNAO" == "true" ] || [ "$KUBVIRT_WITH_CNAO_SKIP_CONFIG" == "true" ]; then
 
         $kubectl create -f /opt/cnao/namespace.yaml
         $kubectl create -f /opt/cnao/network-addons-config.crd.yaml
         $kubectl create -f /opt/cnao/operator.yaml
         $kubectl wait deployment -n cluster-network-addons cluster-network-addons-operator --for condition=Available --timeout=200s
 
-        $kubectl create -f /opt/cnao/network-addons-config-example.cr.yaml
-        $kubectl wait networkaddonsconfig cluster --for condition=Available --timeout=200s
+        if [ "$KUBVIRT_WITH_CNAO_SKIP_CONFIG" != "true" ]; then
+
+            $kubectl create -f /opt/cnao/network-addons-config-example.cr.yaml
+            $kubectl wait networkaddonsconfig cluster --for condition=Available --timeout=200s
+        fi
     fi
 }


### PR DESCRIPTION
Currently, we only have KUBEVIRT_WITH_CNAO env that
is used to deploy cluster-network-addons-operator
with all it's components.
in those components (macvtap for example) we sometimes
want to deploy CNAO as well, but with a subset of
the components.
Added a new env KUBVIRT_WITH_CNAO_SKIP_CONFIG that will
only deploy CNAO without the networkaddonsconfig CR,
so components can be added customely.

once this env is added, I can use it on macvtap [PR](https://github.com/kubevirt/macvtap-cni/pull/38) for neater deploy