### PR TITLE
sriov, Update retry function description

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -12,8 +12,9 @@ WORKER_NODE_ROOT="${CLUSTER_NAME}-worker"
 
 OPERATOR_GIT_HASH=8d3c30de8ec5a9a0c9eeb84ea0aa16ba2395cd68  # release-4.4
 
-# This function gets a command string and invoke it
-# until the command returns an empty string or until timeout
+# This function gets a command string and invoke it repeatedly
+# until the command returns a non empty STDOUT string (success)
+# or until timeout (failure)
 function retry {
   local -r tries=$1
   local -r wait_time=$2


### PR DESCRIPTION
Retry function invoke command repeatedly
until command result is non empty (STDOUT only matters),
resulting in a success,
or until the timeout has been reached, resulting in a failure.

Update description to reflect this,
as the opposite was written about the emptiness of the string.
This function is widely used in sriov so the comment should
reflect what it does.

Signed-off-by: Or Shoval <oshoval@redhat.com>