### PR TITLE
sriov, Support running multi clusters side by side

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/README.md
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/README.md
@@ -4,7 +4,7 @@ Provides a pre-deployed k8s cluster with version 1.17.0 that runs using [kind](h
 The KubeVirt containers are built on the local machine and are then pushed to a registry which is exposed at
 `localhost:5000`.
 
-This version also expects to have sriov-enabed nics on the current host, and will move all the physical interfaces and virtual interfaces into the `kind`'s cluster master node so that they can be used through multus.
+This version also expects to have sriov-enabled nics on the current host, and will move all the physical interfaces and virtual interfaces into the `kind`'s cluster master node so that they can be used through multus.
 
 ## Bringing the cluster up
 
@@ -17,8 +17,9 @@ The cluster can be accessed as usual:
 
 ```bash
 $ cluster-up/kubectl.sh get nodes
-NAME                  STATUS    ROLES     AGE       VERSION
-sriov-control-plane   Ready     master    2m33s     v1.17.0
+NAME                  STATUS   ROLES    AGE     VERSION
+sriov-control-plane   Ready    master   6m14s   v1.17.0
+sriov-worker          Ready    worker   5m36s   v1.17.0
 ```
 
 ## Bringing the cluster down
@@ -42,3 +43,25 @@ export KUBECTL_PATH="/usr/bin/kubectl"
 ```
 This allows users to test or use custom images / different kind versions before making them official.
 See https://github.com/kubernetes-sigs/kind/releases for details about node images according to the kind version.
+
+## Running multi sriov clusters locally
+Kubevirtci sriov provider supports running two clusters side by side with few known limitations.
+
+General considerations:
+
+- A sriov PF must be available for the cluster.
+In order to achieve that, there are two options:
+1. `PF_BLACKLIST` the non used PFs, in order to prevent them from being allocated.
+2. Assign just one PF for each cluster by using `export PF_COUNT_PER_NODE=1` (this is the default value).
+- The cluster names must be different.
+This can be achieved by setting `export CLUSTER_NAME=sriov2` on the 2nd cluster.
+The default `CLUSTER_NAME` is `sriov`.
+The 2nd cluster registry would be exposed at `localhost:5001` automatically, once the `CLUSTER_NAME`
+is set to a non default value.
+- Each cluster should be created on its own git clone folder, i.e
+`/root/project/kubevirtci1`
+`/root/project/kubevirtci2`
+- In case only one PF exists, for example if running on prow which will assign only one PF per job in its own DinD,
+Kubevirtci is agnostic and nothing needs to be done, since all conditions above are met.
+- Kubevirtci supports starting `cluster-up` simultaneously, since it is capable of handling race conditions,
+when allocating PFs.

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -11,8 +11,10 @@ MASTER_NODE="${CLUSTER_NAME}-control-plane"
 WORKER_NODE_ROOT="${CLUSTER_NAME}-worker"
 PF_COUNT_PER_NODE=${PF_COUNT_PER_NODE:-1}
 
-OPERATOR_GIT_HASH=8d3c30de8ec5a9a0c9eeb84ea0aa16ba2395cd68  # release-4.4
 SRIOV_OPERATOR_NAMESPACE="sriov-network-operator"
+
+export RELEASE_VERSION=4.8
+OPERATOR_GIT_HASH=49045c36efb9136813f049b9977fe2b93c0a46c0
 
 [ $PF_COUNT_PER_NODE -le 0 ] && echo "FATAL: PF_COUNT_PER_NODE must be a positive integer" >&2 && exit 1
 
@@ -176,15 +178,27 @@ function deploy_sriov_operator {
 
   echo 'Installing the SR-IOV operator'
   pushd $operator_path
-    export RELEASE_VERSION=4.4
     export SRIOV_NETWORK_OPERATOR_IMAGE=quay.io/openshift/origin-sriov-network-operator:${RELEASE_VERSION}
-    export SRIOV_NETWORK_CONFIG_DAEMON_IMAGE=quay.io/openshift/origin-sriov-network-config-daemon:${RELEASE_VERSION}
+    # origin-sriov-network-config-daemon includes fixes for:
+    # unsupported nics
+    # cross communication of the two clusters
+    # Working on official PRs to fix those.
+    export SRIOV_NETWORK_CONFIG_DAEMON_IMAGE=quay.io/oshoval/origin-sriov-network-config-daemon:x557_reset
     export SRIOV_NETWORK_WEBHOOK_IMAGE=quay.io/openshift/origin-sriov-network-webhook:${RELEASE_VERSION}
     export NETWORK_RESOURCES_INJECTOR_IMAGE=quay.io/openshift/origin-sriov-dp-admission-controller:${RELEASE_VERSION}
     export SRIOV_CNI_IMAGE=quay.io/openshift/origin-sriov-cni:${RELEASE_VERSION}
     export SRIOV_DEVICE_PLUGIN_IMAGE=quay.io/openshift/origin-sriov-network-device-plugin:${RELEASE_VERSION}
+    export SRIOV_INFINIBAND_CNI_IMAGE=quay.io/openshift/origin-sriov-infiniband-cni:${RELEASE_VERSION}
+
+    export SKIP_VAR_SET=1
+    export CGO_ENABLED=0
+    # use deploy-setup in order to avoid eliminating webhook creation by deploy-setup-k8s
+    export NAMESPACE=sriov-network-operator
+    export ENABLE_ADMISSION_CONTROLLER="true"
+    export CNI_BIN_PATH=/opt/cni/bin
     export OPERATOR_EXEC=${KUBECTL}
-    make deploy-setup-k8s SHELL=/bin/bash  # on prow nodes the default shell is dash and some commands are not working
+    # on prow nodes the default shell is dash and some commands are not working
+    make deploy-setup SHELL=/bin/bash
   popd
 
   echo 'Generating webhook certificates for the SR-IOV operator webhooks'
@@ -194,13 +208,13 @@ function deploy_sriov_operator {
   popd
 
   echo 'Setting caBundle for SR-IOV webhooks'
-  wait_k8s_object "validatingwebhookconfiguration" "operator-webhook-config"
-  _kubectl patch validatingwebhookconfiguration operator-webhook-config --patch '{"webhooks":[{"name":"operator-webhook.sriovnetwork.openshift.io", "clientConfig": { "caBundle": "'"$(cat $CERTCREATOR_PATH/operator-webhook.cert)"'" }}]}'
+  wait_k8s_object "validatingwebhookconfiguration" "sriov-operator-webhook-config"
+  _kubectl patch validatingwebhookconfiguration sriov-operator-webhook-config --patch '{"webhooks":[{"name":"operator-webhook.sriovnetwork.openshift.io", "clientConfig": { "caBundle": "'"$(cat $CERTCREATOR_PATH/operator-webhook.cert)"'" }}]}'
 
-  wait_k8s_object "mutatingwebhookconfiguration"   "operator-webhook-config"
-  _kubectl patch mutatingwebhookconfiguration operator-webhook-config --patch '{"webhooks":[{"name":"operator-webhook.sriovnetwork.openshift.io", "clientConfig": { "caBundle": "'"$(cat $CERTCREATOR_PATH/operator-webhook.cert)"'" }}]}'
+  wait_k8s_object "mutatingwebhookconfiguration" "sriov-operator-webhook-config"
+  _kubectl patch mutatingwebhookconfiguration sriov-operator-webhook-config --patch '{"webhooks":[{"name":"operator-webhook.sriovnetwork.openshift.io", "clientConfig": { "caBundle": "'"$(cat $CERTCREATOR_PATH/operator-webhook.cert)"'" }}]}'
 
-  wait_k8s_object "mutatingwebhookconfiguration"   "network-resources-injector-config"
+  wait_k8s_object "mutatingwebhookconfiguration" "network-resources-injector-config"
   _kubectl patch mutatingwebhookconfiguration network-resources-injector-config --patch '{"webhooks":[{"name":"network-resources-injector-config.k8s.io", "clientConfig": { "caBundle": "'"$(cat $CERTCREATOR_PATH/network-resources-injector.cert)"'" }}]}'
 
   return 0
@@ -215,7 +229,21 @@ function apply_sriov_node_policy {
   local -r policy=$(NODE_PF=$node_pf NODE_PF_NUM_VFS=$num_vfs envsubst < $policy_file)
   echo "Applying SriovNetworkNodeConfigPolicy:"
   echo "$policy"
-  _kubectl create -f - <<< "$policy"
+
+  set +x
+  trap "set -x" RETURN
+  # until https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/3 is fixed we need to inject CaBundle and retry policy creation
+  tries=0
+  until _kubectl create -f - <<< "$policy"; do
+    if [ $tries -eq 10 ]; then
+      echo "could not create policy"
+      return 1
+    fi
+    _kubectl patch validatingwebhookconfiguration sriov-operator-webhook-config --patch '{"webhooks":[{"name":"operator-webhook.sriovnetwork.openshift.io", "clientConfig": { "caBundle": "'"$(cat $CERTCREATOR_PATH/operator-webhook.cert)"'" }}]}'
+    _kubectl patch mutatingwebhookconfiguration sriov-operator-webhook-config --patch '{"webhooks":[{"name":"operator-webhook.sriovnetwork.openshift.io", "clientConfig": { "caBundle": "'"$(cat $CERTCREATOR_PATH/operator-webhook.cert)"'" }}]}'
+    _kubectl patch mutatingwebhookconfiguration network-resources-injector-config --patch '{"webhooks":[{"name":"network-resources-injector-config.k8s.io", "clientConfig": { "caBundle": "'"$(cat $CERTCREATOR_PATH/network-resources-injector.cert)"'" }}]}'
+    tries=$((tries+1))
+  done
 
   return 0
 }
@@ -240,16 +268,22 @@ function move_sriov_pfs_netns_to_node {
       continue
     fi
 
-    ip link set "$pf_name" netns "$node"
-    pf_array+=("$pf_name")
-    [ "${#pf_array[@]}" -eq "$pf_count_per_node" ] && break
+    # In case two clusters started at the same time, they might race on the same PF.
+    # The first will manage to assign the PF to its container, and the 2nd will just skip it
+    # and try the rest of the PFs available.
+    if ip link set "$pf_name" netns "$node"; then
+      if timeout 10s bash -c "until docker exec $node ip address | grep -qw $pf_name; do sleep 1; done"; then
+        pf_array+=($pf_name)
+        [ "${#pf_array[@]}" -eq "$pf_count_per_node" ] && break
+      fi
+    fi
   done
 
   [ "${#pf_array[@]}" -lt "$pf_count_per_node" ] && \
     echo "FATAL: Not enough PFs allocated, PF_BLACKLIST (${PF_BLACKLIST[@]}), PF_COUNT_PER_NODE ${PF_COUNT_PER_NODE}" >&2 && \
     return 1
 
-  echo "${pf_array[@]}"
+  echo ${pf_array[@]}
 }
 
 # The first worker needs to be handled specially as it has no ending number, and sort will not work
@@ -282,6 +316,18 @@ wait_pods_ready
 
 deploy_sriov_operator
 wait_pods_ready
+
+cat <<EOF | _kubectl apply -f -
+apiVersion: v1
+data:
+  X557: 8086 1589 154c
+kind: ConfigMap
+metadata:
+  name: unsupported-nic-ids
+  namespace: sriov-network-operator
+EOF
+sleep 60
+_kubectl get configmap -n sriov-network-operator unsupported-nic-ids -oyaml
 
 # We use just the first suitable pf, for the SriovNetworkNodePolicy manifest.
 # We also need the num of vfs because if we don't set this value equals to the total, in case of mellanox

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -178,17 +178,17 @@ function deploy_sriov_operator {
 
   echo 'Installing the SR-IOV operator'
   pushd $operator_path
-    export SRIOV_NETWORK_OPERATOR_IMAGE=quay.io/openshift/origin-sriov-network-operator:${RELEASE_VERSION}
+    export SRIOV_NETWORK_OPERATOR_IMAGE=quay.io/oshoval/multi-poc-sriov-network-operator:v1
     # origin-sriov-network-config-daemon includes fixes for:
     # unsupported nics
     # cross communication of the two clusters
     # Working on official PRs to fix those.
     export SRIOV_NETWORK_CONFIG_DAEMON_IMAGE=quay.io/oshoval/origin-sriov-network-config-daemon:x557_reset
-    export SRIOV_NETWORK_WEBHOOK_IMAGE=quay.io/openshift/origin-sriov-network-webhook:${RELEASE_VERSION}
-    export NETWORK_RESOURCES_INJECTOR_IMAGE=quay.io/openshift/origin-sriov-dp-admission-controller:${RELEASE_VERSION}
-    export SRIOV_CNI_IMAGE=quay.io/openshift/origin-sriov-cni:${RELEASE_VERSION}
-    export SRIOV_DEVICE_PLUGIN_IMAGE=quay.io/openshift/origin-sriov-network-device-plugin:${RELEASE_VERSION}
-    export SRIOV_INFINIBAND_CNI_IMAGE=quay.io/openshift/origin-sriov-infiniband-cni:${RELEASE_VERSION}
+    export SRIOV_NETWORK_WEBHOOK_IMAGE=quay.io/oshoval/multi-poc-sriov-network-webhook:v1
+    export NETWORK_RESOURCES_INJECTOR_IMAGE=quay.io/oshoval/multi-poc-sriov-dp-admission-controller:v1
+    export SRIOV_CNI_IMAGE=quay.io/oshoval/multi-poc-sriov-cni:v1
+    export SRIOV_DEVICE_PLUGIN_IMAGE=quay.io/oshoval/multi-poc-sriov-network-device-plugin:v1
+    export SRIOV_INFINIBAND_CNI_IMAGE=quay.io/oshoval/multi-poc-sriov-infiniband-cni:v1
 
     export SKIP_VAR_SET=1
     export CGO_ENABLED=0

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
@@ -2,7 +2,19 @@
 
 set -e
 
-export CLUSTER_NAME="sriov"
+DEFAULT_CLUSTER_NAME="sriov"
+DEFAULT_HOST_PORT=5000
+ALTERNATE_HOST_PORT=5001
+export CLUSTER_NAME=${CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}
+export KIND_NODE_IMAGE="kindest/node:v1.17.0"
+
+if [ $CLUSTER_NAME == $DEFAULT_CLUSTER_NAME ]; then
+    export HOST_PORT=$DEFAULT_HOST_PORT
+else
+    export HOST_PORT=$ALTERNATE_HOST_PORT
+fi
+
+source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
 
 function set_kind_params() {
     export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.17.0}"

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
@@ -6,15 +6,12 @@ DEFAULT_CLUSTER_NAME="sriov"
 DEFAULT_HOST_PORT=5000
 ALTERNATE_HOST_PORT=5001
 export CLUSTER_NAME=${CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}
-export KIND_NODE_IMAGE="kindest/node:v1.17.0"
 
 if [ $CLUSTER_NAME == $DEFAULT_CLUSTER_NAME ]; then
     export HOST_PORT=$DEFAULT_HOST_PORT
 else
     export HOST_PORT=$ALTERNATE_HOST_PORT
 fi
-
-source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
 
 function set_kind_params() {
     export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.17.0}"

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -86,7 +86,7 @@ function _run_registry() {
         docker rm $REGISTRY_NAME || true
         sleep 5
     done
-    docker run -d -p 5000:5000 --restart=always --name $REGISTRY_NAME registry:2
+    docker run -d -p $HOST_PORT:5000 --restart=always --name $REGISTRY_NAME registry:2
 }
 
 function _configure_registry_on_node() {
@@ -129,7 +129,7 @@ function prepare_config() {
 master_ip="127.0.0.1"
 kubeconfig=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 kubectl=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubectl
-docker_prefix=localhost:5000/kubevirt
+docker_prefix=localhost:${HOST_PORT}/kubevirt
 manifest_docker_prefix=registry:5000/kubevirt
 EOF
 }


### PR DESCRIPTION
Add support for running two sriov clusters side by side, locally, with few known limitations.

The feature allows:
* Utilize all the available sriov PFs, since `Kubevirtci` lane require only one PF.
* Context switch easier between clusters in case needed, 
without the need to tear down, recreate cluster and re-sync for example `Kubevirt`.

General considerations:

- Each cluster should be created on its own git clone folder, i.e
`/root/project/kubevirtci1`
`/root/project/kubevirtci2`

This feature with it's default values doesn't conflict with prow sriov CNI.
Once prow sriov CNI will allocate one PF to each job, Kubevirtci would be naturally robust to this change.

Signed-off-by: Or Shoval <oshoval@redhat.com>