### PR TITLE
cnao, Update CNAO manifest in k8s provider folders to v0.42.3 

### DIFF
--- a/cluster-provision/k8s/1.17/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.17/manifests/cnao/network-addons-config-example.cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1
+apiVersion: networkaddonsoperator.network.kubevirt.io/v1
 kind: NetworkAddonsConfig
 metadata:
   name: cluster

--- a/cluster-provision/k8s/1.17/manifests/cnao/network-addons-config.crd.yaml
+++ b/cluster-provision/k8s/1.17/manifests/cnao/network-addons-config.crd.yaml
@@ -27,8 +27,10 @@ spec:
         status:
           type: object
       type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - name: v1
     served: true
     storage: true
+  - name: v1alpha1
+    served: true
+    storage: false

--- a/cluster-provision/k8s/1.17/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.17/manifests/cnao/operator.yaml
@@ -121,7 +121,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.39.2
+    networkaddonsoperator.network.kubevirt.io/version: 0.42.3
   name: cluster-network-addons-operator
   namespace: cluster-network-addons
 spec:
@@ -139,27 +139,27 @@ spec:
       containers:
       - env:
         - name: MULTUS_IMAGE
-          value: nfvpe/multus:v3.4.1
+          value: nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins:v0.8.6
+          value: quay.io/kubevirt/cni-default-plugins@sha256:3dd438117076016d6d2acd508b93f106ca80a28c0af6e2e914d812f9a1d55142
         - name: LINUX_BRIDGE_MARKER_IMAGE
-          value: quay.io/kubevirt/bridge-marker:0.3.0
+          value: quay.io/kubevirt/bridge-marker@sha256:e55f73526468fee46a35ae41aa860f492d208b8a7a132832c5b9a76d4a51566a
         - name: NMSTATE_HANDLER_IMAGE
-          value: quay.io/nmstate/kubernetes-nmstate-handler:v0.21.0
+          value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150
         - name: OVS_CNI_IMAGE
-          value: quay.io/kubevirt/ovs-cni-plugin:v0.12.0
+          value: quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53
         - name: OVS_MARKER_IMAGE
-          value: quay.io/kubevirt/ovs-cni-marker:v0.12.0
+          value: quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool:v0.14.5
+          value: quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e
         - name: MACVTAP_CNI_IMAGE
-          value: quay.io/kubevirt/macvtap-cni:v0.2.0
+          value: quay.io/kubevirt/macvtap-cni@sha256:407f75760fc096666becfa45d94f51757ebbe8f382e9e7b57ceeded0b8cfb6b8
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:0.39.2
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.42.3
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.39.2
+          value: 0.42.3
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -173,8 +173,10 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WATCH_NAMESPACE
-        image: quay.io/kubevirt/cluster-network-addons-operator:0.39.2
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.42.3
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources: {}
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: cluster-network-addons-operator

--- a/cluster-provision/k8s/1.18/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.18/manifests/cnao/network-addons-config-example.cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1
+apiVersion: networkaddonsoperator.network.kubevirt.io/v1
 kind: NetworkAddonsConfig
 metadata:
   name: cluster

--- a/cluster-provision/k8s/1.18/manifests/cnao/network-addons-config.crd.yaml
+++ b/cluster-provision/k8s/1.18/manifests/cnao/network-addons-config.crd.yaml
@@ -27,8 +27,10 @@ spec:
         status:
           type: object
       type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - name: v1
     served: true
     storage: true
+  - name: v1alpha1
+    served: true
+    storage: false

--- a/cluster-provision/k8s/1.18/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.18/manifests/cnao/operator.yaml
@@ -121,7 +121,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.39.2
+    networkaddonsoperator.network.kubevirt.io/version: 0.42.3
   name: cluster-network-addons-operator
   namespace: cluster-network-addons
 spec:
@@ -139,27 +139,27 @@ spec:
       containers:
       - env:
         - name: MULTUS_IMAGE
-          value: nfvpe/multus:v3.4.1
+          value: nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins:v0.8.6
+          value: quay.io/kubevirt/cni-default-plugins@sha256:3dd438117076016d6d2acd508b93f106ca80a28c0af6e2e914d812f9a1d55142
         - name: LINUX_BRIDGE_MARKER_IMAGE
-          value: quay.io/kubevirt/bridge-marker:0.3.0
+          value: quay.io/kubevirt/bridge-marker@sha256:e55f73526468fee46a35ae41aa860f492d208b8a7a132832c5b9a76d4a51566a
         - name: NMSTATE_HANDLER_IMAGE
-          value: quay.io/nmstate/kubernetes-nmstate-handler:v0.21.0
+          value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150
         - name: OVS_CNI_IMAGE
-          value: quay.io/kubevirt/ovs-cni-plugin:v0.12.0
+          value: quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53
         - name: OVS_MARKER_IMAGE
-          value: quay.io/kubevirt/ovs-cni-marker:v0.12.0
+          value: quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool:v0.14.5
+          value: quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e
         - name: MACVTAP_CNI_IMAGE
-          value: quay.io/kubevirt/macvtap-cni:v0.2.0
+          value: quay.io/kubevirt/macvtap-cni@sha256:407f75760fc096666becfa45d94f51757ebbe8f382e9e7b57ceeded0b8cfb6b8
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:0.39.2
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.42.3
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.39.2
+          value: 0.42.3
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -173,8 +173,10 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WATCH_NAMESPACE
-        image: quay.io/kubevirt/cluster-network-addons-operator:0.39.2
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.42.3
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources: {}
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: cluster-network-addons-operator

--- a/cluster-provision/k8s/1.19/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.19/manifests/cnao/network-addons-config-example.cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networkaddonsoperator.network.kubevirt.io/v1alpha1
+apiVersion: networkaddonsoperator.network.kubevirt.io/v1
 kind: NetworkAddonsConfig
 metadata:
   name: cluster

--- a/cluster-provision/k8s/1.19/manifests/cnao/network-addons-config.crd.yaml
+++ b/cluster-provision/k8s/1.19/manifests/cnao/network-addons-config.crd.yaml
@@ -27,8 +27,10 @@ spec:
         status:
           type: object
       type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - name: v1
     served: true
     storage: true
+  - name: v1alpha1
+    served: true
+    storage: false

--- a/cluster-provision/k8s/1.19/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.19/manifests/cnao/operator.yaml
@@ -121,7 +121,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.39.2
+    networkaddonsoperator.network.kubevirt.io/version: 0.42.3
   name: cluster-network-addons-operator
   namespace: cluster-network-addons
 spec:
@@ -139,27 +139,27 @@ spec:
       containers:
       - env:
         - name: MULTUS_IMAGE
-          value: nfvpe/multus:v3.4.1
+          value: nfvpe/multus@sha256:167722b954355361bd69829466f27172b871dbdbf86b85a95816362885dc0aba
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins:v0.8.6
+          value: quay.io/kubevirt/cni-default-plugins@sha256:3dd438117076016d6d2acd508b93f106ca80a28c0af6e2e914d812f9a1d55142
         - name: LINUX_BRIDGE_MARKER_IMAGE
-          value: quay.io/kubevirt/bridge-marker:0.3.0
+          value: quay.io/kubevirt/bridge-marker@sha256:e55f73526468fee46a35ae41aa860f492d208b8a7a132832c5b9a76d4a51566a
         - name: NMSTATE_HANDLER_IMAGE
-          value: quay.io/nmstate/kubernetes-nmstate-handler:v0.21.0
+          value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:444ab3349882ac58f594396529708146993b831c2e3e1d524eaa12e17e09f150
         - name: OVS_CNI_IMAGE
-          value: quay.io/kubevirt/ovs-cni-plugin:v0.12.0
+          value: quay.io/kubevirt/ovs-cni-plugin@sha256:4101c52617efb54a45181548c257a08e3689f634b79b9dfcff42bffd8b25af53
         - name: OVS_MARKER_IMAGE
-          value: quay.io/kubevirt/ovs-cni-marker:v0.12.0
+          value: quay.io/kubevirt/ovs-cni-marker@sha256:0f08d6b1550a90c9f10221f2bb07709d1090e7c675ee1a711981bd429074d620
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool:v0.14.5
+          value: quay.io/kubevirt/kubemacpool@sha256:79c4534d418c4a350a663e38499c22d54dc68c400f517aead4479f6d862b408e
         - name: MACVTAP_CNI_IMAGE
-          value: quay.io/kubevirt/macvtap-cni:v0.2.0
+          value: quay.io/kubevirt/macvtap-cni@sha256:407f75760fc096666becfa45d94f51757ebbe8f382e9e7b57ceeded0b8cfb6b8
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:0.39.2
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.42.3
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.39.2
+          value: 0.42.3
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -173,8 +173,10 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WATCH_NAMESPACE
-        image: quay.io/kubevirt/cluster-network-addons-operator:0.39.2
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.42.3
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources: {}
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: cluster-network-addons-operator


### PR DESCRIPTION
This PR updates the  CNAO manifest in provider folders {1.17,1.18,1.19} to v0.42.3

This is used in macvtap [PR](https://github.com/kubevirt/macvtap-cni/pull/38)