### PR TITLE
Revert "config-sriov.sh: reduce wait time for operator readiness (#469)"

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -116,29 +116,29 @@ function is_taint_absence {
 function wait_for_taint_absence {
   local -r taint=$1
 
-  local -r tries=24
+  local -r tries=60
   local -r wait_time=5
 
-  local -r wait_message="Waiting for taint '$taint' absence"
-  local -r error_message="Taint $taint did not removed"
+  local -r wait_message="Waiting for $taint taint absence"
+  local -r error_message="Taint $taint $name did not removed"
   local -r action="is_taint_absence $taint"
 
   retry "$tries" "$wait_time" "$action" "$wait_message" && return 0
-  echo "$error_message" && return 1
+  echo $error_message && return 1
 }
 
 function wait_for_taint {
   local -r taint=$1
 
-  local -r tries=24
+  local -r tries=60
   local -r wait_time=5
 
-  local -r wait_message="Waiting for taint '$taint' to present"
-  local -r error_message="Taint '$taint' did not present"
+  local -r wait_message="Waiting for $taint taint to present"
+  local -r error_message="Taint $taint $name did not present"
   local -r action="_kubectl get nodes -o custom-columns=taints:.spec.taints[*].effect --no-headers | grep -i $taint"
 
   retry "$tries" "$wait_time" "$action" "$wait_message" && return 0
-  echo "$error_message" && return 1
+  echo $error_message && return 1
 }
 
 # not using kubectl wait since with the sriov operator the pods get restarted a couple of times and this is


### PR DESCRIPTION
This reverts commit 73a1177456cbf096c6a7256b28492e4c6ada4bd8.

Revert this due job failure caused by the time we waited for taint to be removed was too short
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4549/pull-kubevirt-e2e-kind-1.17-sriov/1326899919218282496#1:build-log.txt%3A3860
