### PR TITLE
sriov, Fix certsecret backward compatibility

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/certcreator/certsecret.go
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/certcreator/certsecret.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"kubevirt.io/kubevirtci/cluster-up/cluster/kind-k8s-sriov-1.17.0/certcreator/certlib"
+	"./certlib"
 )
 
 func handleKubeClientConfig(kubeconfig string) (*rest.Config, error) {

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/certcreator/go.mod
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/certcreator/go.mod
@@ -1,4 +1,4 @@
-module kubevirt.io/kubevirtci/cluster-up/cluster/kind-k8s-sriov-1.17.0/certcreator
+module certcreator
 
 go 1.13
 

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -208,8 +208,8 @@ function deploy_sriov_operator {
 
   echo 'Generating webhook certificates for the SR-IOV operator webhooks'
   pushd "${CERTCREATOR_PATH}"
-    go run . -namespace sriov-network-operator -secret operator-webhook-service -hook operator-webhook -kubeconfig $KUBECONFIG_PATH || return 1
-    go run . -namespace sriov-network-operator -secret network-resources-injector-secret -hook network-resources-injector -kubeconfig $KUBECONFIG_PATH || return 1
+    go run certsecret.go -namespace sriov-network-operator -secret operator-webhook-service -hook operator-webhook -kubeconfig $KUBECONFIG_PATH || return 1
+    go run certsecret.go -namespace sriov-network-operator -secret network-resources-injector-secret -hook network-resources-injector -kubeconfig $KUBECONFIG_PATH || return 1
   popd
 
   echo 'Setting caBundle for SR-IOV webhooks'


### PR DESCRIPTION
Use local imports so we can run certsecret
even on machines with older go (1.12.14 for example).

This method is also better, because it uses explicitly
the local certlib, and doesn't point to an external folder,
where the certlib might be different.

Without this change, updating go to 1.13.x was a must
Tried the following successful update:
go1.12.14 to go1.13.15.

Tested on kubevirt as well locally.

Signed-off-by: Or Shoval <oshoval@redhat.com>