### PR TITLE
k8s providers, Fix provision sanity check flakes

### DIFF
--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -26,8 +26,8 @@ export KUBEVIRTCI_GOCLI_CONTAINER=kubevirtci/gocli:latest
   export KUBEVIRT_NUM_SECONDARY_NICS=2
   trap cleanup EXIT ERR SIGINT SIGTERM SIGQUIT
   bash -x ./cluster-up/up.sh
-  ${ksh} wait --for=condition=Ready pod --timeout=200s --all
-  ${ksh} wait --for=condition=Ready pod --timeout=200s -n kube-system --all
+  timeout 210s bash -c "until ${ksh} wait --for=condition=Ready pod --timeout=30s --all; do sleep 1; done"
+  timeout 210s bash -c "until ${ksh} wait --for=condition=Ready pod --timeout=30s -n kube-system --all; do sleep 1; done"
   ${ksh} get nodes
   ${ksh} get pods -A
 


### PR DESCRIPTION
Provision sanity check uses kubectl `wait` command.
If a pod restart occurred, the `wait` command would fail even if the new pod is healthy.
The reason is that `wait` samples the pod name just once, and the old pod name
is now outdated, resulting in a timeout waiting for it's condition.

Therefore:
Use shorter iterations of wait pods, in order to allow the `wait` command to resample
the new pod name in case the pod restarted.

Fixes the flake seen while provisioning:
Timeout waiting for pods.
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/481/check-provision-k8s-1.18/1329363780320104448#1:build-log.txt%3A3713

We know this is the reason, because in this PR, the job had the timeout and recovered from it,
because of the fix.
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/491/check-provision-k8s-1.19/1331500211620548608#1:build-log.txt%3A3868

Signed-off-by: Or Shoval <oshoval@redhat.com>