### PR TITLE
SRIOV Provider fine tunes: Simplify Readiness Checks

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -145,10 +145,8 @@ function deploy_multus {
   echo 'Waiting for Multus deployment to become ready'
   daemonset_name=$(cat $MANIFESTS_DIR/multus.yaml | grep -i daemonset -A 3 | grep -Po '(?<=name:) \S*amd64$')
   daemonset_namespace=$(cat $MANIFESTS_DIR/multus.yaml | grep -i daemonset -A 3 | grep -Po '(?<=namespace:) \S*$' | head -1)
-  wait_k8s_object "daemonset" $daemonset_name $daemonset_namespace || return 1
-
-  required_replicas=$(_kubectl get daemonset kube-multus-ds-amd64 -n  kube-system -o jsonpath='{.status.desiredNumberScheduled}')
-  wait_for_daemonSet $daemonset_name $daemonset_namespace $required_replicas || return 1
+  required_replicas=$(_kubectl get daemonset $daemonset_name -n $daemonset_namespace -o jsonpath='{.status.desiredNumberScheduled}')
+  wait_for_daemonSet $daemonset_name $daemonset_namespace $required_replicas
 
   return 0
 }
@@ -253,7 +251,7 @@ ${SRIOV_NODE_CMD} mount -o remount,rw /sys     # kind remounts it as readonly wh
 ${SRIOV_NODE_CMD} chmod 666 /dev/vfio/vfio
 _kubectl label node $SRIOV_NODE sriov=true
 
-deploy_multus || exit 1
+deploy_multus
 wait_pods_ready
 
 deploy_sriov_operator

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set -x
+#!/bin/bash
+set -xe
 
 source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
 

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -12,21 +12,24 @@ WORKER_NODE_ROOT="${CLUSTER_NAME}-worker"
 
 OPERATOR_GIT_HASH=8d3c30de8ec5a9a0c9eeb84ea0aa16ba2395cd68  # release-4.4
 
-# This function gets a command string and invoke it repeatedly
-# until the command returns a non empty STDOUT string (success)
-# or until timeout (failure)
+# This function gets a command and invoke it repeatedly
+# until the command return code is zero
 function retry {
   local -r tries=$1
   local -r wait_time=$2
   local -r action=$3
   local -r wait_message=$4
+  local -r waiting_action=$5
 
-  local result=$(eval $action)
+  eval $action
+  local return_code=$?
   for i in $(seq $tries); do
-    if [[ -z $result ]] ; then
+    if [[ $return_code -ne 0 ]] ; then
       echo "[$i/$tries] $wait_message"
+      eval $waiting_action
       sleep $wait_time
-      result=$(eval $action)
+      eval $action
+      return_code=$?
     else
       return 0
     fi


### PR DESCRIPTION
On SRIOV provider we deploy sriov-network-opertator, this deployment has two phases
- Operator deployment;
  - Build and create all necessary objects for the operator.
  - Create secrets, certificats and patch webhooks configurations for the operator webhooks.
- Creating SriovNetworkNodePolicy, configuring PF and VF's according to the policy, deploys `sriov-cni` and `sriov-device-plugin` pods
At the currents state there are many asserts during the operator deployment.

After a while we monitor and test the process of deploying sriov-network-operator 
there are few asserts that we can get rid of:
- Remove checks for taints being placed and removed in both phases
- Remove checking for pods being create and become ready after policy creation (phase 2)
- Remove checking SriovNetworkNodePolicy object is created (phase 2)

This PR intent is to simplify how we deploy and check for readiness of sriov operator
 w/o compromising on the provider reliability making it less procedural then it is now.
