### PR TITLE
Move etcd on k8s-1.19 to in-memory storage

### DIFF
--- a/cluster-provision/k8s/1.19/node01.sh
+++ b/cluster-provision/k8s/1.19/node01.sh
@@ -25,6 +25,9 @@ do
     sleep 2
 done
 
+mkdir -p /var/lib/etcd/
+mount -t tmpfs -o size=300M tmpfs /var/lib/etcd/
+
 kubeadm init --config /etc/kubernetes/kubeadm.conf --experimental-kustomize /provision/kubeadm-patches/
 
 kubectl --kubeconfig=/etc/kubernetes/admin.conf patch deployment coredns -n kube-system -p "$(cat /provision/kubeadm-patches/add-security-context-deployment-patch.yaml)"


### PR DESCRIPTION
Following the example of #478, move etcd on one of the providers to in-memory. Locally running the kubevirt e2e tests show that 300M are more than enough for etcd. After this is running for a while in kubevirt/kubevirt, we can decide if we move all clusters over.