### PR TITLE
sriov, Fix VFs allocation race condition of sriov operator 

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -262,6 +262,10 @@ ${SRIOV_NODE_CMD} mount -o remount,rw /sys     # kind remounts it as readonly wh
 ${SRIOV_NODE_CMD} chmod 666 /dev/vfio/vfio
 _kubectl label node $SRIOV_NODE sriov=true
 
+for pf in "${NODE_PFS[@]}"; do
+  docker exec $SRIOV_NODE bash -c "echo 0 > /sys/class/net/$pf/device/sriov_numvfs"
+done
+
 deploy_multus
 wait_pods_ready
 


### PR DESCRIPTION
The flow is as follows:

1. The undercloud CNI of prow currently sets VFs number (`sriov_numvfs`)
to max allowed (according `sriov_totalvfs`).

2. The sriov operator is deployed.
3. The sriov operator sets all unused PFs to have zero VFs,
since no policy applies to these PFs yet.
Number of VFs equal zero would eventually be reported at `SriovNetworkNodeState`.

4. Kubevirtci creates a new `SriovNetworkNodePolicy`, 
with numVfs equals `sriov_totalvfs` value.

5. The sriov operator checks if it should update number of VFs,
by comparing the desired numVfs (according to policy) to the current
numVfs configured  according `SriovNetworkNodeState` status.

In case `SriovNetworkNodeState` didn't finish updating the actual
numVfs yet in the status,
the sriov operator would not create VFs, because the desired state
equals the current state.

The result would be that the cluster would stay with zero
VFs until a new policy is created,
or until the network config daemon is restarted.

By resetting the VFs before deploying the operator we fix this race condition.
The operator assumes it starts on a clean setup, so this change is natural.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1878566

Signed-off-by: Or Shoval <oshoval@redhat.com>