### PR TITLE
Revert "Move etd on k8s-1.19 to in-memory storage (#498)"

### DIFF
--- a/cluster-provision/k8s/1.19/node01.sh
+++ b/cluster-provision/k8s/1.19/node01.sh
@@ -25,9 +25,6 @@ do
     sleep 2
 done
 
-mkdir -p /var/lib/etcd/
-mount -t tmpfs -o size=300M tmpfs /var/lib/etcd/
-
 kubeadm init --config /etc/kubernetes/kubeadm.conf --experimental-kustomize /provision/kubeadm-patches/
 
 kubectl --kubeconfig=/etc/kubernetes/admin.conf patch deployment coredns -n kube-system -p "$(cat /provision/kubeadm-patches/add-security-context-deployment-patch.yaml)"


### PR DESCRIPTION
We have mixed results. 300 MB do not seem to be enough anymore. It initially worked but fails now afer a Z release bump in kubevirtci. Reverting #498 to unblock kubevirtci.