### PR TITLE
Fix provider image tag

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -17,7 +17,7 @@ docker tag ${TARGET_REPO}/gocli ${TARGET_REPO}/gocli:${KUBEVIRTCI_TAG}
 # Provision all clusters
 for i in $(find cluster-provision/k8s/* -maxdepth 0 -type d -printf '%f\n'); do
     cluster-provision/gocli/build/cli provision cluster-provision/k8s/$i
-    docker tag kubevirtci/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}
+    docker tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}
 done
 
 # Push all images


### PR DESCRIPTION
It will prevent errors like https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/publish-kubevirtci/1351093774310182912
```
+ docker tag kubevirtci/k8s-1.17 quay.io/kubevirtci/k8s-1.17:2101180908-a2a78b7
Error response from daemon: No such image: kubevirtci/k8s-1.17:latest
```

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>