### PR TITLE
Fedora image with test tooling pre-configured

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -1,0 +1,11 @@
+#cloud-config
+password: fedora
+chpasswd: { expire: False }
+ssh_pwauth: yes
+runcmd:
+  - sudo dnf install -y qemu-guest-agent stress dmidecode virt-what 
+  - sudo dnf clean all
+  - sudo hostnamectl set-hostname ""
+  - sudo hostnamectl set-hostname "" --transient
+  - sudo systemctl start qemu-guest-agent
+  - sudo shutdown

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url
@@ -1,0 +1,1 @@
+https://mirror.atl.genesisadaptive.com/fedora/linux/development/rawhide/Cloud/x86_64/images/Fedora-Cloud-Base-Rawhide-20210114.n.1.x86_64.qcow2


### PR DESCRIPTION
In the kubevirt/kubevirt repo, we have functional tests that require tools like the guest agent, stress, and more. Having those tools pre-configured in an image prevents us from having to do some of the strange logic we're doing today where we're caching binaries in http servers to pull into guests. 

