### PR TITLE
Disable qemu guest agent at startup for fedora tools image

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -7,5 +7,8 @@ runcmd:
   - sudo dnf clean all
   - sudo hostnamectl set-hostname ""
   - sudo hostnamectl set-hostname "" --transient
-  - sudo systemctl start qemu-guest-agent
+  - sudo systemctl stop qemu-guest-agent
+  - sudo systemctl disable qemu-guest-agent
+  - sudo mv /lib/systemd/system/qemu-guest-agent.service /home/fedora/
+  - sudo systemctl daemon-reload
   - sudo shutdown

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url
@@ -1,1 +1,1 @@
-https://mirror.atl.genesisadaptive.com/fedora/linux/development/rawhide/Cloud/x86_64/images/Fedora-Cloud-Base-Rawhide-20210114.n.1.x86_64.qcow2
+https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2


### PR DESCRIPTION
The guest agent is being used by the functional tests as a gating mechanism to determine when cloud-init has run. There's a condition that tests are waiting on that signifies the agent has connected. That also indicates that whatever other changes that were in cloud-init have also been executed. By making the agent run automatically at startup, it messes up functional test timing. 

Instead, we need to simply ensure the agent is installed, but disabled at startup. Then let the functional tests enable it.

I had to actually completely remove the service file from being installed to do this. `systemctl disable qemu-guest-agent` isn't enough to prevent it from starting up due to a service dependency tree. 