### PR TITLE
sriov, Parameterize KIND_NODE_IMAGE

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
@@ -3,7 +3,7 @@
 set -e
 
 export CLUSTER_NAME="sriov"
-export KIND_NODE_IMAGE="kindest/node:v1.17.0"
+export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.17.0}"
 
 source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
 


### PR DESCRIPTION
The change allows to easily use a custom image
for testing locally.

For example a custom image with pre pulled images
(`calico`, `multus`, `sriov-operator`),
in order to improve `cluster-up` time
(almost 20-40% faster, in case image includes also the CNI),
and without getting `docker.io` pull rate limits.

Later on, in case desired, we can make an image like this
the default, with a mechanism to provision those images.
It will also support freezing `sriov-operator` version.

Signed-off-by: Or Shoval <oshoval@redhat.com>