### PR TITLE
sriov, Parameterize kind version

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/README.md
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/README.md
@@ -30,3 +30,15 @@ make cluster-down
 
 This destroys the whole cluster. 
 
+## Setting a custom kind version
+
+In order to use a custom kind image / kind version,
+export KIND_NODE_IMAGE, KIND_VERSION, KUBECTL_PATH before running cluster-up.
+For example in order to use kind 0.9.0 (which is based on k8s-1.19.1) use:
+```bash
+export KIND_NODE_IMAGE="kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600"
+export KIND_VERSION="0.9.0"
+export KUBECTL_PATH="/usr/bin/kubectl"
+```
+This allows users to test or use custom images / different kind versions before making them official.
+See https://github.com/kubernetes-sigs/kind/releases for details about node images according to the kind version.

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
@@ -3,9 +3,12 @@
 set -e
 
 export CLUSTER_NAME="sriov"
-export KIND_NODE_IMAGE="kindest/node:v1.17.0"
 
-source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
+function set_kind_params() {
+    export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.17.0}"
+    export KIND_VERSION="${KIND_VERSION:-0.7.0}"
+    export KUBECTL_PATH="${KUBECTL_PATH:-/kind/bin/kubectl}"
+}
 
 function up() {
     if [[ "$KUBEVIRT_NUM_NODES" -ne 2 ]]; then
@@ -27,3 +30,7 @@ function up() {
 
     ${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/config_sriov.sh
 }
+
+set_kind_params
+
+source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -52,11 +52,13 @@ function _wait_containers_ready {
 }
 
 function _fetch_kind() {
-    if [ ! -f ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind ]; then
-        curl -LSs  https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-${ARCH} -o ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind
-        chmod +x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind
+    KIND="${KUBEVIRTCI_CONFIG_PATH}"/"$KUBEVIRT_PROVIDER"/.kind
+    current_kind_version=$($KIND --version |& awk '{print $3}')
+    if [[ $current_kind_version != $KIND_VERSION ]]; then
+        echo "Downloading kind v$KIND_VERSION"
+        curl -LSs https://github.com/kubernetes-sigs/kind/releases/download/v$KIND_VERSION/kind-linux-${ARCH} -o "$KIND"
+        chmod +x "$KIND"
     fi
-    KIND=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind
 }
 
 function _configure-insecure-registry-and-reload() {
@@ -172,7 +174,7 @@ function setup_kind() {
     $KIND --loglevel debug create cluster --retain --name=${CLUSTER_NAME} --config=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml --image=$KIND_NODE_IMAGE
     $KIND get kubeconfig --name=${CLUSTER_NAME} > ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
-    docker cp ${CLUSTER_NAME}-control-plane:/kind/bin/kubectl ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    docker cp ${CLUSTER_NAME}-control-plane:$KUBECTL_PATH ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
     chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
 
     if [ $KUBEVIRT_WITH_KIND_ETCD_IN_MEMORY == "true" ]; then


### PR DESCRIPTION
Kind version is determined by kind binary version,
and the kindest node image.
Extract required parameters into one function,
which will manage them all.
   
This change has several benefits:
1. Centralizing parameters:
In order to bump kind, change `set_kind_params`.
2. The developer can override the needed parameters,
in order to check custom versions.
3. The developer can use a preprovisioned image,
such an image can consist of prepulled container images
of `sriov-operator` and `multus` which in turn:
a. Improves cluster creation timing.
b. Workarounds `docker.io` limits.
c. Freezes `sriov-operator` images from being updated.

Signed-off-by: Or Shoval <oshoval@redhat.com>