### PR TITLE
Move k8s 1.20 to crio CE

### DIFF
--- a/cluster-provision/k8s/1.20/node01.sh
+++ b/cluster-provision/k8s/1.20/node01.sh
@@ -19,8 +19,8 @@ done
 version=`kubectl version --short --client | cut -d":" -f2 |sed  's/ //g' | cut -c2- `
 cni_manifest="/provision/cni.yaml"
 
-# Wait for docker, else network might not be ready yet
-while [[ `systemctl status docker | grep active | wc -l` -eq 0 ]]
+# Wait for crio, else network might not be ready yet
+while [[ `systemctl status crio | grep active | wc -l` -eq 0 ]]
 do
     sleep 2
 done

--- a/cluster-provision/k8s/1.20/nodes.sh
+++ b/cluster-provision/k8s/1.20/nodes.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+source /var/lib/kubevirtci/kubelet_args.sh
+
 # Ensure that hugepages are there
 cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
 
@@ -16,8 +18,8 @@ while ! hostnamectl  |grep Transient ; do
     fi
 done
 
-# Wait for docker, else network might not be ready yet
-while [[ `systemctl status docker | grep active | wc -l` -eq 0 ]]
+# Wait for crio, else network might not be ready yet
+while [[ `systemctl status crio | grep active | wc -l` -eq 0 ]]
 do
     sleep 2
 done
@@ -25,7 +27,7 @@ done
 if [ -f /etc/sysconfig/kubelet ]; then
     # TODO use config file! this is deprecated
     cat <<EOT >>/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=${KUBELET_EXTRA_ARGS} --feature-gates=CPUManager=true,IPv6DualStack=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
+KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --feature-gates=${KUBELET_FEATURE_GATES},CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
 EOT
 else
     cat <<EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf

--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -69,10 +69,24 @@ yum -y install iscsi-initiator-utils
 # To prevent preflight issue related to tc not found
 dnf install -y tc
 
-export CRIO_OS=CentOS_8_Stream
 export CRIO_VERSION=1.20
-curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$CRIO_OS/devel:kubic:libcontainers:stable.repo
-curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:$CRIO_VERSION.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:$CRIO_VERSION/$CRIO_OS/devel:kubic:libcontainers:stable:cri-o:$CRIO_VERSION.repo
+
+cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo
+[devel_kubic_libcontainers_stable]
+name=Stable Releases of Upstream github.com/containers packages (CentOS_8_Stream)
+type=rpm-md
+baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcontainers_stable/
+gpgcheck=0
+enabled=1
+EOF
+cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_1.20.repo
+[devel_kubic_libcontainers_stable_cri-o_1.20]
+name=devel:kubic:libcontainers:stable:cri-o:1.20 (CentOS_8_Stream)
+type=rpm-md
+baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcontainers_stable_cri-o_1.20
+gpgcheck=0
+enabled=1
+EOF
 dnf install -y cri-o
 
 # "crio pull" and "docker pull" is needed in test repos to pre-pull images

--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -17,7 +17,7 @@ function pull_container_retry() {
     maxRetries=5
     retryAfterSeconds=3
     until [ ${retry} -ge ${maxRetries} ]; do
-        crictl pull $@ && break
+        podman pull $@ && break
         retry=$((${retry} + 1))
         echo "Retrying ${FUNCNAME} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
         sleep ${retryAfterSeconds}
@@ -79,19 +79,22 @@ baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcon
 gpgcheck=0
 enabled=1
 EOF
-cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_1.20.repo
-[devel_kubic_libcontainers_stable_cri-o_1.20]
-name=devel:kubic:libcontainers:stable:cri-o:1.20 (CentOS_8_Stream)
+cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}.repo
+[devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}]
+name=devel:kubic:libcontainers:stable:cri-o:${CRIO_VERSION} (CentOS_8_Stream)
 type=rpm-md
-baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcontainers_stable_cri-o_1.20
+baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}
 gpgcheck=0
 enabled=1
 EOF
 dnf install -y cri-o
 
-# "crio pull" and "docker pull" is needed in test repos to pre-pull images
+# install podman for functionality missing in crictl (tag, etc)
+dnf install -y podman
+
+# link docker to podman as we need docker in test repos to pre-pull images
 # don't break them by doing a symlink
-ln -s /usr/bin/crictl /usr/bin/docker
+ln -s /usr/bin/podman /usr/bin/docker
 
 cat << EOF > /etc/containers/registries.conf
 [registries.search]

--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -2,12 +2,22 @@
 
 set -ex
 
-function docker_pull_retry() {
+KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
+mkdir -p $KUBEVIRTCI_SHARED_DIR
+cat << EOF > $KUBEVIRTCI_SHARED_DIR/kubelet_args.sh
+#!/bin/bash
+set -ex
+export KUBELET_CGROUP_ARGS="--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
+export KUBELET_FEATURE_GATES="BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true"
+EOF
+source $KUBEVIRTCI_SHARED_DIR/kubelet_args.sh
+
+function pull_container_retry() {
     retry=0
     maxRetries=5
     retryAfterSeconds=3
     until [ ${retry} -ge ${maxRetries} ]; do
-        docker pull $@ && break
+        crictl pull $@ && break
         retry=$((${retry} + 1))
         echo "Retrying ${FUNCNAME} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
         sleep ${retryAfterSeconds}
@@ -21,7 +31,7 @@ function docker_pull_retry() {
 
 kubeadmn_patches_path="/provision/kubeadm-patches"
 
-# Need to have the latest kernel
+# Update to the latest kernel
 dnf update -y kernel
 
 # Resize root partition
@@ -56,55 +66,29 @@ yum -y remove firewalld
 # Required for iscsi demo to work.
 yum -y install iscsi-initiator-utils
 
-# To prevent preflight issue realted to tc not found
+# To prevent preflight issue related to tc not found
 dnf install -y tc
 
-# Install docker required packages.
-dnf -y install yum-utils \
-    device-mapper-persistent-data \
-    lvm2
+export CRIO_OS=CentOS_8_Stream
+export CRIO_VERSION=1.20
+curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$CRIO_OS/devel:kubic:libcontainers:stable.repo
+curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:$CRIO_VERSION.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:$CRIO_VERSION/$CRIO_OS/devel:kubic:libcontainers:stable:cri-o:$CRIO_VERSION.repo
+dnf install -y cri-o
 
-# Add Docker repository.
-dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+# "crio pull" and "docker pull" is needed in test repos to pre-pull images
+# don't break them by doing a symlink
+ln -s /usr/bin/crictl /usr/bin/docker
 
-# Enable the nightly version to get a new enough runc version which includes containerd
-# with a new enough runc version to avoid https://github.com/kubernetes/kubernetes/issues/95296#issuecomment-714419461
-# which manifests in /dev/* permission denied flakes on cpu manager enabled nodes
-dnf config-manager --set-enabled docker-ce-nightly
+cat << EOF > /etc/containers/registries.conf
+[registries.search]
+registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
 
-# Install package(s) that trigger the enablement of the container-tools yum module
-dnf -y install container-selinux
+[registries.insecure]
+registries = ['registry:5000']
 
-# Disable the container-tools module, as it forces containerd.io to an ancient version,
-#   which in turn forces docker-ce to an older version, making it incompatible with docker-ce-cli...
-dnf -y module disable container-tools
-
-# Install iptables needed for docker-ce
-dnf install -y iptables
-
-# Install Docker CE.
-dnf install -y docker-ce --nobest
-
-# Create /etc/docker directory.
-mkdir /etc/docker
-
-# Setup docker daemon
-cat << EOF > /etc/docker/daemon.json
-{
-  "insecure-registries" : ["registry:5000"],
-  "log-driver": "json-file",
-  "exec-opts": ["native.cgroupdriver=systemd"],
-  "ipv6": true,
-  "fixed-cidr-v6": "2001:db9:1::/64",
-  "selinux-enabled": true
-}
+[registries.block]
+registries = []
 EOF
-
-mkdir -p /etc/systemd/system/docker.service.d
-
-# Restart Docker
-systemctl daemon-reload
-systemctl restart docker
 
 #TODO: el8 repo
 # Add Kubernetes repository.
@@ -130,14 +114,10 @@ cat <<EOT >/etc/sysconfig/kubelet
 KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --feature-gates="BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true"
 EOT
 
-systemctl daemon-reload
-
-systemctl enable docker && systemctl start docker
-systemctl enable kubelet && systemctl start kubelet
-
 # Needed for kubernetes service routing and dns
 # https://github.com/kubernetes/kubernetes/issues/33798#issuecomment-250962627
 modprobe bridge
+modprobe overlay
 modprobe br_netfilter
 cat <<EOF >  /etc/sysctl.d/k8s.conf
 net.bridge.bridge-nf-call-iptables = 1
@@ -148,8 +128,13 @@ net.bridge.bridge-nf-call-ip6tables = 1
 EOF
 sysctl --system
 
-echo bridge >> /etc/modules
-echo br_netfilter >> /etc/modules
+echo bridge >> /etc/modules-load.d/k8s.conf
+echo br_netfilter >> /etc/modules-load.d/k8s.conf
+echo overlay >> /etc/modules-load.d/k8s.conf
+
+systemctl daemon-reload
+systemctl enable crio && systemctl start crio
+systemctl enable kubelet && systemctl start kubelet
 
 NM_VERSION=1.30.0
 dnf install -y NetworkManager-$NM_VERSION
@@ -281,23 +266,23 @@ chmod -R 777 /var/local/kubevirt-storage/local-volume
 chcon -R unconfined_u:object_r:svirt_sandbox_file_t:s0 /mnt/local-storage/
 
 # Pre pull fluentd image used in logging
-docker_pull_retry fluent/fluentd:v1.2-debian
-docker_pull_retry fluent/fluentd-kubernetes-daemonset:v1.2-debian-syslog
+pull_container_retry fluent/fluentd:v1.2-debian
+pull_container_retry fluent/fluentd-kubernetes-daemonset:v1.2-debian-syslog
 
 # Pre pull images used in Ceph CSI
-docker_pull_retry quay.io/k8scsi/csi-attacher:v1.0.1
-docker_pull_retry quay.io/k8scsi/csi-provisioner:v1.0.1
-docker_pull_retry quay.io/k8scsi/csi-snapshotter:v1.0.1
-docker_pull_retry quay.io/cephcsi/rbdplugin:v1.0.0
-docker_pull_retry quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+pull_container_retry quay.io/k8scsi/csi-attacher:v1.0.1
+pull_container_retry quay.io/k8scsi/csi-provisioner:v1.0.1
+pull_container_retry quay.io/k8scsi/csi-snapshotter:v1.0.1
+pull_container_retry quay.io/cephcsi/rbdplugin:v1.0.0
+pull_container_retry quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
 
 # Pre pull cluster network addons operator images and store manifests
 # so we can use them at cluster-up
 cp -rf /tmp/cnao/ /opt/
-for i in $(grep -A 2 "IMAGE" /opt/cnao/operator.yaml | grep value | awk '{print $2}'); do docker_pull_retry $i; done
+for i in $(grep -A 2 "IMAGE" /opt/cnao/operator.yaml | grep value | awk '{print $2}'); do pull_container_retry $i; done
 
 # Pre pull local-volume-provisioner
-for i in $(grep -A 2 "IMAGE" /provision/local-volume.yaml | grep value | awk -F\" '{print $2}'); do docker_pull_retry $i; done
+for i in $(grep -A 2 "IMAGE" /provision/local-volume.yaml | grep value | awk -F\" '{print $2}'); do pull_container_retry $i; done
 
 # Create a properly labelled tmp directory for testing
 mkdir -p /var/provision/kubevirt.io/tests


### PR DESCRIPTION
Use crio container engine insted of docker.

Intent of this PR is to switch from using docker container engine to crio.
The PR keeps the doors open for switching back to docker or any other CE if needed.

There are two reasons to switch to crio:
- docker deprecation in k8s
- docker issue with selinux categories https://github.com/moby/moby/issues/41370

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>