### PR TITLE
Allow more than 8 nodes cluster

### DIFF
--- a/cluster-provision/centos8/scripts/vm.sh
+++ b/cluster-provision/centos8/scripts/vm.sh
@@ -33,7 +33,7 @@ function calc_next_disk {
 }
 
 NODE_NUM=${NODE_NUM-1}
-n="$(printf "%02d" ${NODE_NUM})"
+n="$(printf "%02d" $(( 10#${NODE_NUM} )))"
 
 cat >/usr/local/bin/ssh.sh <<EOL
 #!/bin/bash


### PR DESCRIPTION
There is a bug at vm.sh that fails if KUBEVIRT_NUM_NODES=8, this change
convert the number into decimal so we can use printf as expected.

failure at vm.sh

```
+ NODE_NUM=08
++ printf %02d 08
/vm.sh: line 36: printf: 08: invalid octal number
+ n=00
```

Signed-off-by: Quique Llorente <ellorent@redhat.com>