### PR TITLE
Do not append KUBELET_EXTRA_ARGS to kubelet cfg in nodes.sh

### DIFF
--- a/cluster-provision/k8s/1.17/nodes.sh
+++ b/cluster-provision/k8s/1.17/nodes.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+source /var/lib/kubevirtci/kubelet_args.sh
+
 # Ensure that hugepages are there
 # Hugetlb holds total huge page size in kB including both 2M or 1G hugepages
 HUGETLB=`cat /proc/meminfo | sed -e "s/ //g" | grep "Hugetlb:"`
@@ -32,8 +34,8 @@ done
 
 if [ -f /etc/sysconfig/kubelet ]; then
     # TODO use config file! this is deprecated
-    cat <<EOT >>/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=${KUBELET_EXTRA_ARGS} --feature-gates=CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
+    cat <<EOT >/etc/sysconfig/kubelet
+KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --feature-gates=${KUBELET_FEATURE_GATES},CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
 EOT
 else
     cat <<EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf

--- a/cluster-provision/k8s/1.17/provision.sh
+++ b/cluster-provision/k8s/1.17/provision.sh
@@ -2,6 +2,16 @@
 
 set -ex
 
+KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
+mkdir -p $KUBEVIRTCI_SHARED_DIR
+cat << EOF > $KUBEVIRTCI_SHARED_DIR/kubelet_args.sh
+#!/bin/bash
+set -ex
+export KUBELET_CGROUP_ARGS="--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
+export KUBELET_FEATURE_GATES="BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true"
+EOF
+source $KUBEVIRTCI_SHARED_DIR/kubelet_args.sh
+
 function docker_pull_retry() {
     retry=0
     maxRetries=5

--- a/cluster-provision/k8s/1.18/nodes.sh
+++ b/cluster-provision/k8s/1.18/nodes.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+source /var/lib/kubevirtci/kubelet_args.sh
+
 # Ensure that hugepages are there
 cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
 
@@ -24,8 +26,8 @@ done
 
 if [ -f /etc/sysconfig/kubelet ]; then
     # TODO use config file! this is deprecated
-    cat <<EOT >>/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=${KUBELET_EXTRA_ARGS} --feature-gates=CPUManager=true,IPv6DualStack=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
+    cat <<EOT >/etc/sysconfig/kubelet
+KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --feature-gates=${KUBELET_FEATURE_GATES},CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
 EOT
 else
     cat <<EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf

--- a/cluster-provision/k8s/1.18/provision.sh
+++ b/cluster-provision/k8s/1.18/provision.sh
@@ -2,6 +2,16 @@
 
 set -ex
 
+KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
+mkdir -p $KUBEVIRTCI_SHARED_DIR
+cat << EOF > $KUBEVIRTCI_SHARED_DIR/kubelet_args.sh
+#!/bin/bash
+set -ex
+export KUBELET_CGROUP_ARGS="--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
+export KUBELET_FEATURE_GATES="BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true"
+EOF
+source $KUBEVIRTCI_SHARED_DIR/kubelet_args.sh
+
 function docker_pull_retry() {
     retry=0
     maxRetries=5

--- a/cluster-provision/k8s/1.19/nodes.sh
+++ b/cluster-provision/k8s/1.19/nodes.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+source /var/lib/kubevirtci/kubelet_args.sh
+
 # Ensure that hugepages are there
 cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
 
@@ -24,8 +26,8 @@ done
 
 if [ -f /etc/sysconfig/kubelet ]; then
     # TODO use config file! this is deprecated
-    cat <<EOT >>/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=${KUBELET_EXTRA_ARGS} --feature-gates=CPUManager=true,IPv6DualStack=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
+    cat <<EOT >/etc/sysconfig/kubelet
+KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --feature-gates=${KUBELET_FEATURE_GATES},CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
 EOT
 else
     cat <<EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf

--- a/cluster-provision/k8s/1.19/provision.sh
+++ b/cluster-provision/k8s/1.19/provision.sh
@@ -2,6 +2,16 @@
 
 set -ex
 
+KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
+mkdir -p $KUBEVIRTCI_SHARED_DIR
+cat << EOF > $KUBEVIRTCI_SHARED_DIR/kubelet_args.sh
+#!/bin/bash
+set -ex
+export KUBELET_CGROUP_ARGS="--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
+export KUBELET_FEATURE_GATES="BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true"
+EOF
+source $KUBEVIRTCI_SHARED_DIR/kubelet_args.sh
+
 function docker_pull_retry() {
     retry=0
     maxRetries=5

--- a/cluster-provision/k8s/1.20/nodes.sh
+++ b/cluster-provision/k8s/1.20/nodes.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+source /var/lib/kubevirtci/kubelet_args.sh
+
 # Ensure that hugepages are there
 cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
 
@@ -24,8 +26,8 @@ done
 
 if [ -f /etc/sysconfig/kubelet ]; then
     # TODO use config file! this is deprecated
-    cat <<EOT >>/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=${KUBELET_EXTRA_ARGS} --feature-gates=CPUManager=true,IPv6DualStack=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
+    cat <<EOT >/etc/sysconfig/kubelet
+KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --feature-gates=${KUBELET_FEATURE_GATES},CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
 EOT
 else
     cat <<EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf


### PR DESCRIPTION
In provision.sh script we create /etc/sysconfig/kubelet with
KUBELET_EXTRA_ARGS parameters. In nodes.sh, additional
parameters are added by  appending to the /etc/sysconfig/kubelet
which means that the config file containes the KUBELET_EXTRA_ARGS
twice. First from the provision.sh and second line is from nodes.sh, which seems unintended to me.

So after nodes.sh is finished, /etc/sysconfig/kubelet looks like this:
```
KUBELET_EXTRA_ARGS="--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --feature-gates=BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true"
KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --feature-gates=BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true,CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
```
This PR changes this so that only the second line is in there



Also I'd like to take this opportunity and ask if there is a reason for the `else` branch of [this condition](https://github.com/kubevirt/kubevirtci/blob/a2b389fadcc6dee26acc8f36c8be3d037e235f96/cluster-provision/k8s/1.20/nodes.sh#L25):
```
if [ -f /etc/sysconfig/kubelet ]; then
    # TODO use config file! this is deprecated
    cat <<EOT >/etc/sysconfig/kubelet
KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --feature-gates=${KUBELET_FEATURE_GATES},CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
EOT
else
    cat <<EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf
Environment="KUBELET_CPUMANAGER_ARGS=--feature-gates=CPUManager=true,IPv6DualStack=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m"
EOT
sed -i 's/$KUBELET_EXTRA_ARGS/$KUBELET_EXTRA_ARGS $KUBELET_CPUMANAGER_ARGS/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
fi
```
 
IIUC, the provision.sh script creates /etc/sysconfig/kubelet, so it cannot not exist 
 



Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>