### PR TITLE
sriov VM, Disable qemu guest agent at startup

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-sriov-lane/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-sriov-lane/cloud-config
@@ -22,5 +22,8 @@ runcmd:
   - sudo dnf clean all
   - sudo hostnamectl set-hostname ""
   - sudo hostnamectl set-hostname "" --transient
-  - sudo systemctl start qemu-guest-agent
+  - sudo systemctl stop qemu-guest-agent
+  - sudo systemctl disable qemu-guest-agent
+  - sudo mv /lib/systemd/system/qemu-guest-agent.service /home/fedora/
+  - sudo systemctl daemon-reload
   - sudo shutdown


### PR DESCRIPTION
There is a race condition at Kubevirt e2e tests,
between LoginToFedora and cloud-init which sets the password.

In order to fix this race condition and make sure
cloud-init finished, we disable quest agent when creating the VM image.
The e2e tests would enable it as the last thing
in cloud-init UserData, wait for the guest agent to finish
and only then login the the VM.

Notes:
1. The next reboot won't be idempotent, because
the guest agent would be reinstalled on the first boot of the e2e tests,
using the Cloud-init UserData.
We don't reboot sriov VMs in e2e tests so its ok.
In case reboot is needed, the same sequence can be done before the
reboot from the test.

Kubevirt counterpart:
https://github.com/kubevirt/kubevirt/pull/5072

Built using:
```
export TAG="32"
export OS_VARIANT=fedora32
```

See more info on
https://github.com/kubevirt/kubevirtci/pull/533
https://github.com/kubevirt/kubevirt/pull/4839#discussion_r561004638

Signed-off-by: Or Shoval <oshoval@redhat.com>