### PR TITLE
sriov, Support running multi clusters side by side (locally)

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/README.md
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/README.md
@@ -4,7 +4,7 @@ Provides a pre-deployed k8s cluster with version 1.17.0 that runs using [kind](h
 The KubeVirt containers are built on the local machine and are then pushed to a registry which is exposed at
 `localhost:5000`.
 
-This version also expects to have sriov-enabed nics on the current host, and will move all the physical interfaces and virtual interfaces into the `kind`'s cluster master node so that they can be used through multus.
+This version also expects to have sriov-enabled nics on the current host, and will move physical interfaces into the `kind`'s cluster worker node(s) so that they can be used through multus.
 
 ## Bringing the cluster up
 
@@ -17,8 +17,9 @@ The cluster can be accessed as usual:
 
 ```bash
 $ cluster-up/kubectl.sh get nodes
-NAME                  STATUS    ROLES     AGE       VERSION
-sriov-control-plane   Ready     master    2m33s     v1.17.0
+NAME                  STATUS   ROLES    AGE     VERSION
+sriov-control-plane   Ready    master   6m14s   v1.17.0
+sriov-worker          Ready    worker   5m36s   v1.17.0
 ```
 
 ## Bringing the cluster down
@@ -42,3 +43,33 @@ export KUBECTL_PATH="/usr/bin/kubectl"
 ```
 This allows users to test or use custom images / different kind versions before making them official.
 See https://github.com/kubernetes-sigs/kind/releases for details about node images according to the kind version.
+
+## Running multi sriov clusters locally
+Kubevirtci sriov provider supports running two clusters side by side with few known limitations.
+
+General considerations:
+
+- A sriov PF must be available for each cluster.
+In order to achieve that, there are two options:
+1. Assign just one PF for each worker node of each cluster by using `export PF_COUNT_PER_NODE=1` (this is the default value).
+2. Optional method: `export PF_BLACKLIST=<PF names>` the non used PFs, in order to prevent them from being allocated to the current cluster.
+The user can list the PFs that should not be allocated to the current cluster, keeping in mind
+that at least one (or 2 in case of migration), should not be listed, so they would be allocated for the current cluster.
+Note: another reason to blacklist a PF, is in case its has a defect or should be kept for other operations (for example sniffing).
+- The cluster names must be different.
+This can be achieved by setting `export CLUSTER_NAME=sriov2` on the 2nd cluster.
+The default `CLUSTER_NAME` is `sriov`.
+The 2nd cluster registry would be exposed at `localhost:5001` automatically, once the `CLUSTER_NAME`
+is set to a non default value.
+- Each cluster should be created on its own git clone folder, i.e
+`/root/project/kubevirtci1`
+`/root/project/kubevirtci2`
+In order to switch between them, change dir to that folder and set the env variables `KUBECONFIG` and `KUBEVIRT_PROVIDER`.
+- In case only one PF exists, for example if running on prow which will assign only one PF per job in its own DinD,
+Kubevirtci is agnostic and nothing needs to be done, since all conditions above are met.
+- Upper limit of the number of clusters that can be run on the same time equals number of PFs / number of PFs per cluster,
+therefore, in case there is only one PF, only one cluster can be created.
+Locally the actual limit currently supported is two clusters.
+- Kubevirtci supports starting `cluster-up` simultaneously, since it is capable of handling race conditions,
+when allocating PFs.
+- In order to use `make cluster-down` please make sure the right `CLUSTER_NAME` is exported.

--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/provider.sh
@@ -2,7 +2,16 @@
 
 set -e
 
-export CLUSTER_NAME="sriov"
+DEFAULT_CLUSTER_NAME="sriov"
+DEFAULT_HOST_PORT=5000
+ALTERNATE_HOST_PORT=5001
+export CLUSTER_NAME=${CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}
+
+if [ $CLUSTER_NAME == $DEFAULT_CLUSTER_NAME ]; then
+    export HOST_PORT=$DEFAULT_HOST_PORT
+else
+    export HOST_PORT=$ALTERNATE_HOST_PORT
+fi
 
 function set_kind_params() {
     export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.17.0}"

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -86,7 +86,7 @@ function _run_registry() {
         docker rm $REGISTRY_NAME || true
         sleep 5
     done
-    docker run -d -p 5000:5000 --restart=always --name $REGISTRY_NAME registry:2
+    docker run -d -p $HOST_PORT:5000 --restart=always --name $REGISTRY_NAME registry:2
 }
 
 function _configure_registry_on_node() {
@@ -129,7 +129,7 @@ function prepare_config() {
 master_ip="127.0.0.1"
 kubeconfig=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 kubectl=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubectl
-docker_prefix=localhost:5000/kubevirt
+docker_prefix=localhost:${HOST_PORT}/kubevirt
 manifest_docker_prefix=registry:5000/kubevirt
 EOF
 }


### PR DESCRIPTION
Add support for running two sriov clusters side by side,
locally, with few known limitations.

The feature allows:
1. Context switch easier between clusters in case needed,
without the need to tear down, and recreate the cluster.
2. Testable environment for the multi sriov feature.

The clusters can be spinned at the same time, as the PF allocation
is reentrant.

This feature doesn't affect the default behavior.

Limitations:
* Each cluster should be created on its own git clone folder, i.e
/root/project/kubevirtci1
/root/project/kubevirtci2
* Locally only two clusters are supported, at the same time.

Note:
In order to not have cross talk between the clusters,
for example PF resetting each other, or adding PFs which were not requested,
the bump of sriov CNI / DP is needed, and it is done on other PR. 
see #507 and #486 (without /  with the sriov-operator) for reference.
 
Signed-off-by: Or Shoval <oshoval@redhat.com>