### PR TITLE
sriov vm image, Remove cloud-init user update module

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-sriov-lane/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-sriov-lane/cloud-config
@@ -23,4 +23,5 @@ runcmd:
   - sudo hostnamectl set-hostname ""
   - sudo hostnamectl set-hostname "" --transient
   - sudo systemctl start qemu-guest-agent
+  - sudo sed -i /users-groups/d /etc/cloud/cloud.cfg
   - sudo shutdown


### PR DESCRIPTION
Cloud-init has a module "users-groups" that configure users/groups according
to cloud-init config file.
    
While provisioning we are using the cloud-init config file in order to set
the user / password fedora:fedora (distro default).
    
When rerunning the provisioned VM, the cloud-init default configuration,
resets the users and cleans the password would run again,
In case any UserData exists.
This enforces reconfigurating the password via UserData and
cause flakiness to VM login.
    
There is no need to reset the user/passwords in subsequent VM spinning.
UserData may still be used in order to do user management commands
in case one would still need it.
Setting the user/password using the Cloud-init config is used only once during provision.
  
This commit removes the module, so subsequent Cloud-init triggering
would not reconfigure the default fedora user.

Kubevirt counterpart https://github.com/kubevirt/kubevirt/pull/5135

Signed-off-by: Or Shoval <oshoval@redhat.com>