### PR TITLE
sriov, Fix PF_BLACKLIST to respect full word matching

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.17.0/config_sriov.sh
@@ -236,7 +236,7 @@ function move_sriov_pfs_netns_to_node {
     local pf_name="${pf%%/device/*}"
     pf_name="${pf_name##*/}"
 
-    if [ $(echo "${PF_BLACKLIST[@]}" | grep "${pf_name}") ]; then
+    if echo "${PF_BLACKLIST[@]}" | grep -qw "${pf_name}"; then
       continue
     fi
 


### PR DESCRIPTION
PFs might have names that are a suffix of other PF name.
In this case the current logic of PF_BLACKLIST might
match a PF even if its not in the list.

Fix it by using the right bash syntax needed, and by
matching with grep -w (whole word).

Signed-off-by: Or Shoval <oshoval@redhat.com>