### PR TITLE
Make cluster-up/check.sh fail fast

### DIFF
--- a/cluster-up/check.sh
+++ b/cluster-up/check.sh
@@ -18,34 +18,46 @@
 #
 
 set -e
+fail=''
 if [ ! -c /dev/kvm ]; then
-	echo "[ERR ] missing /dev/kvm"
+    echo "[ERR ] missing /dev/kvm"
+    fail=1
 else
-	echo "[ OK ] found /dev/kvm"
+    echo "[ OK ] found /dev/kvm"
 fi
 
 KVM_ARCH=""
 KVM_NESTED="unknown"
 if [ -f "/sys/module/kvm_intel/parameters/nested" ]; then
-	KVM_NESTED=$( cat /sys/module/kvm_intel/parameters/nested )
-	KVM_ARCH="intel"
+    KVM_NESTED=$(cat /sys/module/kvm_intel/parameters/nested)
+    KVM_ARCH="intel"
 elif [ -f "/sys/module/kvm_amd/parameters/nested" ]; then
-	KVM_NESTED=$( cat /sys/module/kvm_amd/parameters/nested )
-	KVM_ARCH="amd"
+    KVM_NESTED=$(cat /sys/module/kvm_amd/parameters/nested)
+    KVM_ARCH="amd"
 fi
 
 function is_enabled() {
-	if [ "$1" == "1" ]; then
-		return 0
-	fi
-	if [ "$1" == "Y" ] || [ "$1" == "y"]; then
-		return 0
-	fi
-	return 1
+    if [ "$1" == "1" ]; then
+        return 0
+    fi
+    if [ "$1" == "Y" ] || [ "$1" == "y" ]; then
+        return 0
+    fi
+    return 1
 }
 
 if is_enabled "$KVM_NESTED"; then
-	echo "[ OK ] $KVM_ARCH nested virtualization enabled"
+    echo "[ OK ] $KVM_ARCH nested virtualization enabled"
 else
-	echo "[ERR ] $KVM_ARCH nested virtualization not enabled"
+    echo "[ERR ] $KVM_ARCH nested virtualization not enabled"
+    fail=1
+fi
+
+if [[ "$KUBEVIRT_PROVIDER" =~ external|local ]]; then
+    echo "nested virtualization not required"
+elif [ -z "$fail" ]; then
+    echo "nested virtualization check passed"
+else
+    echo "nested virtualization check failed, exiting"
+    exit 1
 fi


### PR DESCRIPTION
Except for providers external or local we make the check script fail
fast. If the kvm device is not there or nested virtualization is not enabled
there is no chance the cluster will start up. In that case we make the
script exit with non zero error code to fail early.

/cc @qinqon @fgimenez @oshoval 