### PR TITLE
Configure cgroupv2 in k8s 1.20

### DIFF
--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -41,6 +41,7 @@ func NewProvisionCommand() *cobra.Command {
 	provision.Flags().Uint("vnc-port", 0, "port on localhost for vnc")
 	provision.Flags().Uint("ssh-port", 0, "port on localhost for ssh server")
 	provision.Flags().Bool("cgroupv2", false, "set UNIFIED_CGROUP_HIERARCHY environment variable for the provision script")
+	provision.Flags().String("container-suffix", "", "use additional suffix for the provisioned container image")
 
 	return provision
 }
@@ -58,8 +59,16 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 	}
 	base := fmt.Sprintf("quay.io/kubevirtci/%s", strings.TrimSpace(string(baseBytes)))
 
-	prefix := fmt.Sprintf("k8s-%s-provision", filepath.Base(packagePath))
-	target := fmt.Sprintf("quay.io/kubevirtci/k8s-%s", filepath.Base(packagePath))
+	containerSuffix, err := cmd.Flags().GetString("container-suffix")
+	if err != nil {
+		return err
+	}
+	name := filepath.Base(packagePath)
+	if len(containerSuffix) > 0 {
+		name = fmt.Sprintf("%s-%s", name, containerSuffix)
+	}
+	prefix := fmt.Sprintf("k8s-%s-provision", name)
+	target := fmt.Sprintf("quay.io/kubevirtci/k8s-%s", name)
 	scripts := filepath.Join(packagePath)
 
 	memory, err := cmd.Flags().GetString("memory")

--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -2,12 +2,20 @@
 
 set -ex
 
+# Configure cgroup version
+if [ "${UNIFIED_CGROUP_HIERARCHY}" == "1" ]; then
+    CMDLINE_LINUX_APPEND="${CMDLINE_LINUX_APPEND} systemd.unified_cgroup_hierarchy=1"
+    CGROUP_DRIVER="cgroupfs"
+else
+    CGROUP_DRIVER="systemd"
+fi
+
 KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
 mkdir -p $KUBEVIRTCI_SHARED_DIR
 cat << EOF > $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
 #!/bin/bash
 set -ex
-export KUBELET_CGROUP_ARGS="--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
+export KUBELET_CGROUP_ARGS="--cgroup-driver=${CGROUP_DRIVER} --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
 export KUBELET_FEATURE_GATES="BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true"
 export ISTIO_VERSION=1.9.0
 EOF
@@ -55,7 +63,9 @@ swapoff -a
 sed -i '/ swap / s/^/#/' /etc/fstab
 
 # Disable spectre and meltdown patches
-echo 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} spectre_v2=off nopti hugepagesz=2M hugepages=64 intel_iommu=on modprobe.blacklist=nouveau"' >> /etc/default/grub
+CMDLINE_LINUX_APPEND="${CMDLINE_LINUX_APPEND} spectre_v2=off nopti hugepagesz=2M hugepages=64 intel_iommu=on modprobe.blacklist=nouveau"
+
+echo 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} '"${CMDLINE_LINUX_APPEND}"'"' >> /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
 
 systemctl stop firewalld || :
@@ -99,6 +109,16 @@ enabled=1
 EOF
 dnf install -y cri-o
 
+if [ "${UNIFIED_CGROUP_HIERARCHY}" == "1" ]; then
+    CRIO_CONF_DIR=/etc/crio/crio.conf.d
+    mkdir -p ${CRIO_CONF_DIR}
+    cat << EOF > ${CRIO_CONF_DIR}/00-cgroupv2.conf
+[crio.runtime]
+conmon_cgroup = "pod"
+cgroup_manager = "cgroupfs"
+EOF
+fi
+
 # install podman for functionality missing in crictl (tag, etc)
 dnf install -y podman
 
@@ -138,7 +158,7 @@ dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y 
 
 # TODO use config file! this is deprecated
 cat <<EOT >/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --feature-gates="BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true"
+KUBELET_EXTRA_ARGS=--cgroup-driver=${CGROUP_DRIVER} --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --feature-gates="BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true"
 EOT
 
 # Needed for kubernetes service routing and dns

--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -9,6 +9,11 @@ CI=${CI:-"false"}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 provision_dir="$1"
 
+provider="${provision_dir}"
+if [ -n "${CONTAINER_SUFFIX}" ]; then
+    provider="${provision_dir}-${CONTAINER_SUFFIX}"
+fi
+
 function cleanup {
   cd "$DIR" && cd ../..
   make cluster-down
@@ -21,7 +26,7 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
   ssh="./cluster-up/ssh.sh"
   cd "$DIR" && cd ../..
   export KUBEVIRTCI_PROVISION_CHECK=1
-  export KUBEVIRT_PROVIDER="k8s-${provision_dir}"
+  export KUBEVIRT_PROVIDER="k8s-${provider}"
   export KUBEVIRT_NUM_NODES=2
   export KUBEVIRT_NUM_SECONDARY_NICS=2
   trap cleanup EXIT ERR SIGINT SIGTERM SIGQUIT

--- a/cluster-provision/k8s/provision.sh
+++ b/cluster-provision/k8s/provision.sh
@@ -9,7 +9,18 @@ export base="$(cat base | tr -d '\n')"
 
 cd $DIR
 
+gocli_args=""
+
+if [ "${CGROUPV2}" == "true" ]; then
+    gocli_args="${gocli_args} --cgroupv2=true"
+    CONTAINER_SUFFIX=cgroupsv2
+fi
+
+if [ -n "${CONTAINER_SUFFIX}" ]; then
+    gocli_args="${gocli_args} --container-suffix=${CONTAINER_SUFFIX}"
+fi
+
 (cd ../${base} && ./build.sh)
 make -C ../gocli cli
-../gocli/build/cli provision ${provision_dir}
-./check-cluster-up.sh ${provision_dir}
+../gocli/build/cli provision ${gocli_args} ${provision_dir}
+CONTAINER_SUFFIX=${CONTAINER_SUFFIX} ./check-cluster-up.sh ${provision_dir}

--- a/cluster-up/cluster/k8s-1.20-cgroupsv2/README.md
+++ b/cluster-up/cluster/k8s-1.20-cgroupsv2/README.md
@@ -1,0 +1,81 @@
+# Kubernetes 1.20 in ephemeral containers (with cgroups v2)
+
+Provides a pre-deployed Kubernetes with version 1.20 purely in docker
+containers with qemu. The provided VMs are completely ephemeral and are
+recreated on every cluster restart. The nodes are configured to use cgroups
+v2. The KubeVirt containers are built on the local machine and are then pushed
+to a registry which is exposed at `localhost:5000`.
+
+## Bringing the cluster up
+
+```bash
+export KUBEVIRT_PROVIDER=k8s-1.20-cgroupsv2
+export KUBEVIRT_NUM_NODES=2 # master + one node
+make cluster-up
+```
+
+The cluster can be accessed as usual:
+
+```bash
+$ cluster/kubectl.sh get nodes
+NAME      STATUS     ROLES     AGE       VERSION
+node01    NotReady   master    31s       v1.20.1
+node02    NotReady   <none>    5s        v1.20.1
+```
+
+## Bringing the cluster up with cluster-network-addons-operator provisioned
+
+```bash
+export KUBEVIRT_PROVIDER=k8s-1.20-cgroupsv2
+export KUBEVIRT_NUM_NODES=2 # master + one node
+export KUBEVIRT_WITH_CNAO=true
+make cluster-up
+```
+
+To get more info about CNAO you can check the github project documentation
+here https://github.com/kubevirt/cluster-network-addons-operator
+
+## Bringing the cluster down
+
+```bash
+export KUBEVIRT_PROVIDER=k8s-1.20-cgroupsv2
+make cluster-down
+```
+
+This destroys the whole cluster. Recreating the cluster is fast, since k8s is
+already pre-deployed. The only state which is kept is the state of the local
+docker registry.
+
+## Destroying the docker registry state
+
+The docker registry survives a `make cluster-down`. It's state is stored in a
+docker volume called `kubevirt_registry`. If the volume gets too big or the
+volume contains corrupt data, it can be deleted with
+
+```bash
+docker volume rm kubevirt_registry
+```
+
+## Enabling IPv6 connectivity
+
+In order to be able to reach from the cluster to the host's IPv6 network, IPv6
+has to be enabled on your Docker. Add following to your
+`/etc/docker/daemon.json` and restart docker service:
+
+```json
+{
+    "ipv6": true,
+    "fixed-cidr-v6": "2001:db8:1::/64"
+}
+```
+
+```bash
+systemctl restart docker
+```
+
+With an IPv6-connected host, you may want the pods to be able to reach the rest
+of the IPv6 world, too. In order to allow that, enable IPv6 NAT on your host:
+
+```bash
+ip6tables -t nat -A POSTROUTING -s 2001:db8:1::/64 -j MASQUERADE
+```

--- a/cluster-up/cluster/k8s-1.20-cgroupsv2/provider.sh
+++ b/cluster-up/cluster/k8s-1.20-cgroupsv2/provider.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+# shellcheck disable=SC1090
+source "${KUBEVIRTCI_PATH}/cluster/k8s-provider-common.sh"


### PR DESCRIPTION
This PR is an initial attempt to enable a new lane configured with cgroup v2. It is based on the existing k8s 1.20. The required changes are applied depending on the `UNIFIED_CGROUP_HIERARCHY` env var which is propagated to the provisioning script by the `--cgroupv2` gocli arg. That way the initial cluster provision (with cgroup v1) can still be used. Calling `CGROUPV2=true ../provision.sh` in turn triggers cgroup v2 configuration.

A dedicated lane is needed to enable cgroup v2 support in Kubevirt and to test end-to-end the changes in https://github.com/kubevirt/kubevirt/pull/4907 