### PR TITLE
Bump NM to 1.32

### DIFF
--- a/cluster-provision/k8s/1.19/provision.sh
+++ b/cluster-provision/k8s/1.19/provision.sh
@@ -151,8 +151,7 @@ sysctl --system
 echo bridge >> /etc/modules
 echo br_netfilter >> /etc/modules
 
-# Bump NetworkManager to 1.22.8
-NM_VERSION=1.30.0
+NM_VERSION=1.32.0
 dnf install -y NetworkManager-$NM_VERSION
 
 # configure additional settings for cni plugin

--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -186,7 +186,7 @@ systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet
 
-NM_VERSION=1.30.0
+NM_VERSION=1.32.0
 dnf install -y NetworkManager-$NM_VERSION
 
 # configure additional settings for cni plugin


### PR DESCRIPTION
NM 1.30 doesn't exists anymore [1]
`No match for argument: NetworkManager-config-server-1.30.0`

hence bump NM to 1.32

[1] https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/580/check-provision-k8s-1.19/1379691338701737984#1:build-log.txt%3A3230

Signed-off-by: Or Shoval <oshoval@redhat.com>