### PR TITLE
Remove NetworkManager version pinning on cluster provision

### DIFF
--- a/cluster-provision/k8s/1.19/provision.sh
+++ b/cluster-provision/k8s/1.19/provision.sh
@@ -151,9 +151,7 @@ sysctl --system
 echo bridge >> /etc/modules
 echo br_netfilter >> /etc/modules
 
-# Bump NetworkManager to 1.22.8
-NM_VERSION=1.30.0
-dnf install -y NetworkManager-$NM_VERSION
+dnf install -y NetworkManager
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -320,7 +318,7 @@ mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
-dnf install -y NetworkManager-config-server-$NM_VERSION
+dnf install -y NetworkManager-config-server
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -186,8 +186,7 @@ systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet
 
-NM_VERSION=1.30.0
-dnf install -y NetworkManager-$NM_VERSION
+dnf install -y NetworkManager
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -346,7 +345,7 @@ mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
-dnf install -y NetworkManager-config-server-$NM_VERSION
+dnf install -y NetworkManager-config-server
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)


### PR DESCRIPTION
On QEMU based providers we use Centos Stream OS which frequently
changes causing check-provision lanes to fail due to no longer
available version of NetworkManager.
NetworkManager version is pinned for compatibility
with other projects, e.g: kubernetes-nmstate, CNAO.

check-provision-k8s-1.19 and check-provision-k8s-1.18 lanes are 
broken due to missing NetworkManager version.

This PR remove the version pinning for NetworkManager.
Consumers of kubevirtci who needs specific version can install after the cluster is up.

Signed-off-by: Or Mergi <ormergi@redhat.com>