### PR TITLE
add CPUNodeDiscovery and HypervStrictCheck as default featureGates

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -44,6 +44,7 @@ kubectl=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubectl
 gocli=${BASE_PATH}/../cluster-up/cli.sh
 docker_prefix=\${DOCKER_PREFIX:-localhost:$(_port registry)/kubevirt}
 manifest_docker_prefix=\${DOCKER_PREFIX:-registry:5000/kubevirt}
+feature_gates=CPUNodeDiscovery,HypervStrictCheck
 EOF
 }
 


### PR DESCRIPTION
Default CPUNodeDiscovery and HypervStrictCheck to enabled as node-labeler is now a part of kubevirt.
/cc @jean-edouard @omeryahud @stu-gott