### PR TITLE
Include vm-dump-metrics in the fedora-with-test-tooling image

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -3,7 +3,7 @@ password: fedora
 chpasswd: { expire: False }
 ssh_pwauth: yes
 runcmd:
-  - sudo dnf install -y qemu-guest-agent stress dmidecode virt-what 
+  - sudo dnf install -y qemu-guest-agent stress dmidecode virt-what vm-dump-metrics
   - sudo dnf clean all
   - sudo hostnamectl set-hostname ""
   - sudo hostnamectl set-hostname "" --transient


### PR DESCRIPTION
The tool is needed for downwardsMetrics testing.