### PR TITLE
Istio, Add configuration for cluster without CNAO

### DIFF
--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -17,7 +17,7 @@ cat << EOF > $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
 set -ex
 export KUBELET_CGROUP_ARGS="--cgroup-driver=${CGROUP_DRIVER} --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
 export KUBELET_FEATURE_GATES="BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,IPv6DualStack=true"
-export ISTIO_VERSION=1.9.0
+export ISTIO_VERSION=1.10.0
 EOF
 source $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
 

--- a/cluster-provision/k8s/1.21/provision.sh
+++ b/cluster-provision/k8s/1.21/provision.sh
@@ -17,7 +17,7 @@ cat << EOF > $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
 set -ex
 export KUBELET_CGROUP_ARGS="--cgroup-driver=${CGROUP_DRIVER} --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
 export KUBELET_FEATURE_GATES="VolumeSnapshotDataSource=true,IPv6DualStack=true"
-export ISTIO_VERSION=1.9.0
+export ISTIO_VERSION=1.10.0
 EOF
 source $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
 

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -46,4 +46,28 @@ function up() {
             $kubectl wait networkaddonsconfig cluster --for condition=Available --timeout=200s
         fi
     fi
+
+    if [ "$KUBEVIRT_DEPLOY_ISTIO" == "true" ] && [[ $KUBEVIRT_PROVIDER =~ k8s-1\.1.* ]]; then
+        echo "ERROR: Istio is not supported on kubevirtci version < 1.20"
+        exit 1
+
+    elif [ "$KUBEVIRT_DEPLOY_ISTIO" == "true" ]; then
+        if [ "$KUBEVIRT_WITH_CNAO" == "true" ]; then
+            $kubectl create -f /opt/istio/istio-operator-with-cnao.cr.yaml
+        else
+            $kubectl create -f /opt/istio/istio-operator.cr.yaml
+        fi
+        
+        istio_operator_ns=istio-system
+        retries=0
+        while [[ $retries -lt 20 ]]; do
+            echo "waiting for istio-operator to be healthy"
+            sleep 5
+            retries=$((retries + 1))
+            health=$(kubectl -n $istio_operator_ns get istiooperator istio-operator -o jsonpath="{.status.status}")
+            if [[ $health == "HEALTHY" ]]; then
+                break
+            fi
+        done
+    fi
 }


### PR DESCRIPTION
Currently, Istio only works when CNAO is deployed at the same time.

This commit adds Istio operator configuration
for the case when CNAO is not deployed, improving
the usability of istio in kubevirtci.

Additionally, the wait loop is improved to wait not
just for the istio-cni-node daemonset to be present
but also for all it's pods to be running.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>