### PR TITLE
Fix rsync command in local kubevirt testing guide for provisioned cluster

### DIFF
--- a/KUBEVIRTCI_LOCAL_TESTING.md
+++ b/KUBEVIRTCI_LOCAL_TESTING.md
@@ -57,9 +57,9 @@ Steps:
 
 ```bash
 # sync _ci-configs folder (mandatory, since it has data about the current running cluster).
-rsync -av $KUBEVIRTCI_DIR/_ci-configs $KUBEVIRT_DIR/_ci-configs
+rsync -av $KUBEVIRTCI_DIR/_ci-configs/ $KUBEVIRT_DIR/_ci-configs
 # sync cluster-up folder if it has changed.
-rsync -av $KUBEVIRTCI_DIR/cluster-up $KUBEVIRT_DIR/cluster-up
+rsync -av $KUBEVIRTCI_DIR/cluster-up/ $KUBEVIRT_DIR/cluster-up
 ```
 
 ```bash


### PR DESCRIPTION
`rsync -av $KUBEVIRTCI_DIR/_ci-configs $KUBEVIRT_DIR/_ci-configs`
copies $KUBEVIRTCI_DIR/_ci-configs folder to $KUBEVIRT_DIR/_ci-configs
which results in $KUBEVIRT_DIR/_ci-configs/_ci-configs

`rsync -av $KUBEVIRTCI_DIR/_ci-configs/ $KUBEVIRT_DIR/_ci-configs`
copies content of $KUBEVIRTCI_DIR/_ci-configs folder to $KUBEVIRT_DIR/_ci-configs
which is what is needed.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>