### PR TITLE
Fix error redirection to stderr on kind/podpreset.sh

### DIFF
--- a/cluster-up/cluster/kind/podpreset.sh
+++ b/cluster-up/cluster/kind/podpreset.sh
@@ -38,7 +38,7 @@ EOT
 function podpreset::create_virt_launcher_fake_product_uuid_podpreset() {
     local -r namespace=$1
 
-    if ! _kubectl get ns "$namespace" &>2; then
+    if ! _kubectl get ns "$namespace" >&2; then
         _kubectl create ns "$namespace"
     fi
 


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

Currently the error redirection on `kind/podpreset.sh` is wrong, and instead a file is created with the error message
This PR fix the redirection to stderr.