### PR TITLE
Add a Dockerfile for kernel-boot container used for testing

### DIFF
--- a/cluster-provision/images/kubevirt-testing/kernel-boot-container/Dockerfile.alpine-ext-kernel-boot-demo
+++ b/cluster-provision/images/kubevirt-testing/kernel-boot-container/Dockerfile.alpine-ext-kernel-boot-demo
@@ -1,0 +1,6 @@
+FROM alpine:latest
+RUN apk update
+RUN apk add linux-virt
+RUN apk add openrc
+RUN chown -R 107:107 /boot/initramfs-virt /boot/vmlinuz-virt 
+


### PR DESCRIPTION
The Dockerfile is used to create the container stored here:
https://quay.io/repository/kubevirt/alpine-ext-kernel-boot-demo

This container is used to test our exmaple VMI that boots through an external initrd/kernel that exist in this container. The feature was first introduced here: https://github.com/kubevirt/kubevirt/pull/5416.