### PR TITLE
Expose prometheus and grafana via nodeports

### DIFF
--- a/cluster-provision/gocli/cmd/utils/ports.go
+++ b/cluster-provision/gocli/cmd/utils/ports.go
@@ -27,9 +27,9 @@ const (
 	//PortOCPConsole contains OCP console port
 	PortOCPConsole = 443
 	//PortPrometheus contains Prometheus server port
-	PortPrometheus = 9090
+	PortPrometheus = 30007
 	//PortGrafana contains Grafana server port
-	PortGrafana = 3000
+	PortGrafana = 30008
 
 	// PortNameSSH contains master node SSH port name
 	PortNameSSH = "ssh"

--- a/cluster-provision/k8s/1.21/manifests/nodeports/monitoring.yaml
+++ b/cluster-provision/k8s/1.21/manifests/nodeports/monitoring.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-nodeport
+  namespace: monitoring
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+  ports:
+    - port: 9090
+      nodePort: 30007
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-nodeport
+  namespace: monitoring
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: kube-prometheus
+  ports:
+    - port: 3000
+      nodePort: 30008

--- a/cluster-provision/k8s/1.21/prometheus.sh
+++ b/cluster-provision/k8s/1.21/prometheus.sh
@@ -122,3 +122,6 @@ if [[ ($GRAFANA != "false") && ($GRAFANA != "FALSE") ]]; then
     kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/prometheus/grafana/grafana-serviceAccount.yaml
     kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/prometheus/grafana/grafana-serviceMonitor.yaml
 fi
+
+# Deploy nodeports
+kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/nodeports/monitoring.yaml


### PR DESCRIPTION
In order to access prometheus and grafana a nodeport is needed, since we
have no ingress installed.