### PR TITLE
Add a specific label to prometheus

### DIFF
--- a/cluster-provision/k8s/1.21/manifests/prometheus/README.md
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/README.md
@@ -28,4 +28,8 @@ The `kubevirt-prometheus-metrics` service can then be discovered by the ServiceM
 KubeVirt’s virt-operator, by default, checks the existence of the MonitorNamespace and MonitorServiceAccount, and automatically creates a ServiceMonitor resource in the MonitorNamespace. Additionally, KubeVirt also appropriate role and rolebinding in KubeVirt’s namespace.
 
 ## Upgrading
-All the files are based on the `release-0.8` of the repository [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus), the only change applied was decreasing the Prometheus and Alertmanager replicas from 2 to 1.
+All the files are based on the `release-0.8` of the repository [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus).
+
+The applied changes are:
+- decreased the Prometheus and Alertmanager replicas from 2 to 1.
+- included the label `ci.kubevirt.io/prometheus: ""` in both prometheus-prometheus.yaml and prometheus-service.yaml

--- a/cluster-provision/k8s/1.21/manifests/prometheus/prometheus/prometheus-prometheus.yaml
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/prometheus/prometheus-prometheus.yaml
@@ -26,6 +26,7 @@ spec:
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 2.26.0
+      ci.kubevirt.io/prometheus: ""
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
   probeNamespaceSelector: {}

--- a/cluster-provision/k8s/1.21/manifests/prometheus/prometheus/prometheus-service.yaml
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/prometheus/prometheus-service.yaml
@@ -20,4 +20,5 @@ spec:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     prometheus: k8s
+    ci.kubevirt.io/prometheus: ""
   sessionAffinity: ClientIP


### PR DESCRIPTION
Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>

In order to configure Prometheus Federation, we need to add a specific label to prometheus to enable it to be found via PodMonitor.