### PR TITLE
Fix 1.21 provider: Move fetch-images.sh into provision folder

### DIFF
--- a/cluster-provision/k8s/1.21/fetch-images.sh
+++ b/cluster-provision/k8s/1.21/fetch-images.sh
@@ -2,9 +2,7 @@
 
 set -euo pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-function usage {
+function usage() {
     cat <<EOF
 Usage: $0 <k8s-cluster-dir> [source-image-list]
 
@@ -16,7 +14,7 @@ Usage: $0 <k8s-cluster-dir> [source-image-list]
 EOF
 }
 
-function check_args {
+function check_args() {
     if [ "$#" -lt 1 ]; then
         usage
         exit 1
@@ -28,7 +26,7 @@ function check_args {
     fi
 }
 
-function main {
+function main() {
     check_args "$@"
 
     temp_file=$(mktemp)
@@ -41,14 +39,14 @@ function main {
     (
         # Avoid bailing out because of nothing found in scripts part
         set +e
-        find "$provision_dir" -type f -name '*.sh' -print0 | \
+        find "$provision_dir" -type f -name '*.sh' -print0 |
             xargs -0 grep -iE '(docker|podman)[ _]pull[^ ]+ '"${image_regex_w_double_quotes}"
-        find "$provision_dir" -type f -name '*.yaml' -print0 | \
+        find "$provision_dir" -type f -name '*.yaml' -print0 |
             xargs -0 grep -iE '(image|value): '"${image_regex_w_double_quotes}"
         set -e
         # last `grep -v` is necessary to avoid trying to pre pull istio "images", as the regex also matches on values
         # from the generated istio deployment manifest
-    ) | grep -ioE "${image_regex_w_double_quotes}"'$' | grep -v '.svc:' >> "${temp_file}"
+    ) | grep -ioE "${image_regex_w_double_quotes}"'$' | grep -v '.svc:' >>"${temp_file}"
 
     sed -E 's/"//g' "${temp_file}" | sort | uniq
 }

--- a/cluster-provision/k8s/README.md
+++ b/cluster-provision/k8s/README.md
@@ -1,7 +1,7 @@
 Updating image list for pre pulling
 -----------------------------------
 
-`fetch-images.sh` can be called to extract the image identifiers from the manifests and the shell scripts in the provision dir that exists per k8s version.
+`<provision-dir>/fetch-images.sh` can be called to extract the image identifiers from the manifests and the shell scripts in the provision dir that exists per k8s version.
 
 However, it does **not** retrieve transitive dependencies. Therefore it can occur that during cluster up check there are images found that do not appear in the list. You can then just manually add them to the file `extra-pre-pull-images` and therefore achieve that transitive images are then also pre pulled during provisioning.
 

--- a/cluster-provision/k8s/check-pod-images.sh
+++ b/cluster-provision/k8s/check-pod-images.sh
@@ -3,7 +3,7 @@
 
 set -exuo pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ksh="$(cd "$DIR/../.." && pwd)/cluster-up/kubectl.sh"
 provision_dir="$1"
 export KUBEVIRT_PROVIDER="k8s-${provision_dir}"
@@ -17,12 +17,12 @@ fi
 images_not_in_list=$(mktemp)
 images_from_manifests=$(mktemp)
 trap 'rm -f $images_not_in_list $images_from_manifests' EXIT SIGINT SIGTERM
-${DIR}/fetch-images.sh "$DIR/${provision_dir}" > "${images_from_manifests}"
+$DIR/${provision_dir}/fetch-images.sh "$DIR/${provision_dir}" >"${images_from_manifests}"
 for image in $(${ksh} get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | grep -v 'k8s.gcr.io' | sort | uniq); do
     set +e
     if ! grep -q "$image" "${pre_pull_image_file}"; then
         if ! grep -q "$image" "${images_from_manifests}"; then
-            echo "$image" >> "${images_not_in_list}"
+            echo "$image" >>"${images_not_in_list}"
         fi
     fi
     set -e

--- a/cluster-provision/k8s/check-pod-images.sh
+++ b/cluster-provision/k8s/check-pod-images.sh
@@ -18,7 +18,7 @@ images_not_in_list=$(mktemp)
 images_from_manifests=$(mktemp)
 trap 'rm -f $images_not_in_list $images_from_manifests' EXIT SIGINT SIGTERM
 $DIR/${provision_dir}/fetch-images.sh "$DIR/${provision_dir}" >"${images_from_manifests}"
-for image in $(${ksh} get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | grep -v 'k8s.gcr.io' | sort | uniq); do
+for image in $(KUBEVIRTCI_VERBOSE=false ${ksh} get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | grep -v 'k8s.gcr.io' | sort | uniq); do
     set +e
     if ! grep -q "$image" "${pre_pull_image_file}"; then
         if ! grep -q "$image" "${images_from_manifests}"; then

--- a/cluster-provision/k8s/provision.sh
+++ b/cluster-provision/k8s/provision.sh
@@ -3,9 +3,10 @@
 
 set -ex
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-provision_dir="$(basename $(pwd))"
-export base="$(cat base | tr -d '\n')"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+provision_dir="$(basename "$(pwd)")"
+base="$(cat base | tr -d '\n')"
+export base
 
 cd $DIR
 
@@ -22,7 +23,5 @@ fi
 
 (cd ../${base} && ./build.sh)
 make -C ../gocli cli
-cp "${DIR}/fetch-images.sh" "${provision_dir}/"
-trap 'rm -f ${provision_dir}/fetch-images.sh' EXIT SIGINT SIGTERM
 ../gocli/build/cli provision ${gocli_args} ${provision_dir}
 CONTAINER_SUFFIX=${CONTAINER_SUFFIX} ./check-cluster-up.sh ${provision_dir}

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -4,6 +4,7 @@ set -e
 
 KUBEVIRT_WITH_ETC_IN_MEMORY=${KUBEVIRT_WITH_ETC_IN_MEMORY:-false}
 KUBEVIRT_WITH_ETC_CAPACITY=${KUBEVIRT_WITH_ETC_CAPACITY:-none}
+KUBEVIRTCI_VERBOSE=${KUBEVIRTCI_VERBOSE:-true}
 
 if [ -z "${KUBEVIRTCI_TAG}" ] && [ -z "${KUBEVIRTCI_GOCLI_CONTAINER}" ]; then
     echo "FATAL: either KUBEVIRTCI_TAG or KUBEVIRTCI_GOCLI_CONTAINER must be set"
@@ -15,24 +16,24 @@ if [ -n "${KUBEVIRTCI_TAG}" ] && [ -n "${KUBEVIRTCI_GOCLI_CONTAINER}" ]; then
 fi
 
 if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
-	_cri_bin=podman
-	_docker_socket="${HOME}/podman.sock"
+    _cri_bin=podman
+    _docker_socket="${HOME}/podman.sock"
 elif [ "${KUBEVIRTCI_RUNTIME}" = "docker" ]; then
-	_cri_bin=docker
-	_docker_socket="/var/run/docker.sock"
+    _cri_bin=docker
+    _docker_socket="/var/run/docker.sock"
 else
-	if curl --unix-socket /${HOME}/podman.sock http://d/v3.0.0/libpod/info > /dev/null 2>&1 ; then
-		_cri_bin=podman
-		_docker_socket="${HOME}/podman.sock"
-		echo "selecting podman as container runtime"
-	elif docker ps >/dev/null; then
-		_cri_bin=docker
-		_docker_socket="/var/run/docker.sock"
-		echo "selecting docker as container runtime"
-	else
-		echo "no working container runtime found. Neither docker nor podman seems to work."
-		exit 1
-	fi
+    if curl --unix-socket /${HOME}/podman.sock http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
+        _cri_bin=podman
+        _docker_socket="${HOME}/podman.sock"
+        [ "$KUBEVIRTCI_VERBOSE" = 'true' ] && echo "selecting podman as container runtime"
+    elif docker ps >/dev/null; then
+        _cri_bin=docker
+        _docker_socket="/var/run/docker.sock"
+        [ "$KUBEVIRTCI_VERBOSE" = 'true' ] && echo "selecting docker as container runtime"
+    else
+        echo "no working container runtime found. Neither docker nor podman seems to work."
+        exit 1
+    fi
 fi
 
 _cli_container="${KUBEVIRTCI_GOCLI_CONTAINER:-quay.io/kubevirtci/gocli:${KUBEVIRTCI_TAG}}"
@@ -49,6 +50,7 @@ function _main_ip() {
 }
 
 function _port() {
+    # shellcheck disable=SC2154
     ${_cli} ports --prefix $provider_prefix "$@"
 }
 
@@ -65,10 +67,12 @@ EOF
 }
 
 function _registry_volume() {
+    # shellcheck disable=SC2154
     echo ${job_prefix}_registry
 }
 
 function _add_common_params() {
+    # shellcheck disable=SC2155
     local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 6 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) ${KUBEVIRT_PROVIDER} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
     if [[ $TARGET =~ windows.* ]] && [ -n "$WINDOWS_NFS_DIR" ]; then
         params=" --nfs-data $WINDOWS_NFS_DIR $params"
@@ -82,11 +86,11 @@ function _add_common_params() {
     if [ $KUBEVIRT_WITH_ETC_IN_MEMORY == "true" ]; then
         params=" --run-etcd-on-memory $params"
         if [ $KUBEVIRT_WITH_ETC_CAPACITY != "none" ]; then
-          params=" --etcd-capacity $KUBEVIRT_WITH_ETC_CAPACITY $params"
+            params=" --etcd-capacity $KUBEVIRT_WITH_ETC_CAPACITY $params"
         fi
     fi
     if [ $KUBEVIRT_DEPLOY_ISTIO == "true" ]; then
-       params=" --enable-istio $params"
+        params=" --enable-istio $params"
     fi
 
     # alternate (new) way to specify storage providers
@@ -94,7 +98,7 @@ function _add_common_params() {
         params=" --enable-ceph $params"
     fi
 
-    if [[ $KUBEVIRT_DEPLOY_PROMETHEUS == "true" ]] && 
+    if [[ $KUBEVIRT_DEPLOY_PROMETHEUS == "true" ]] &&
         [[ $KUBEVIRT_PROVIDER_EXTRA_ARGS != *"--enable-prometheus"* ]]; then
 
         if [[ ($KUBEVIRT_PROVIDER =~ k8s-1\.1.*) || ($KUBEVIRT_PROVIDER =~ k8s-1.20) ]]; then
@@ -105,18 +109,17 @@ function _add_common_params() {
         fi
 
         params=" --enable-prometheus $params"
-        
-        if [[ $KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER == "true" ]] && 
+
+        if [[ $KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER == "true" ]] &&
             [[ $KUBEVIRT_PROVIDER_EXTRA_ARGS != *"--enable-grafana"* ]]; then
             params=" --enable-prometheus-alertmanager $params"
         fi
 
-        if [[ $KUBEVIRT_DEPLOY_GRAFANA == "true" ]] && 
+        if [[ $KUBEVIRT_DEPLOY_GRAFANA == "true" ]] &&
             [[ $KUBEVIRT_PROVIDER_EXTRA_ARGS != *"--enable-grafana"* ]]; then
             params=" --enable-grafana $params"
         fi
     fi
-
 
     echo $params
 }


### PR DESCRIPTION
Instead of copying and removing the script we put it directly into the
folder where it belongs. Also we adjust pathes and the README.

Original setup causes this error on provisioning within `publish.sh`:
```
ERROR: fetch-images.sh missing
+ '[' '!' -f /tmp/extra-pre-pull-images ']'
+ '[' '!' -f /tmp/fetch-images.sh ']'
+ echo 'ERROR: fetch-images.sh missing'
+ exit 1
```

publish failed here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirtci/1405529938345332736