### PR TITLE
Generate random product_uuid at qemu nodes

### DIFF
--- a/cluster-provision/centos8/scripts/vm.sh
+++ b/cluster-provision/centos8/scripts/vm.sh
@@ -119,4 +119,5 @@ exec qemu-system-x86_64 -enable-kvm -drive format=qcow2,file=${next},if=virtio,c
   -vnc :${n} -cpu host,migratable=no,+invtsc -m ${MEMORY} -smp ${CPU} \
   -serial pty -M q35,accel=kvm,kernel_irqchip=split \
   -device intel-iommu,intremap=on,caching-mode=on -soundhw hda \
+  -uuid $(cat /proc/sys/kernel/random/uuid) \
   ${QEMU_ARGS}


### PR DESCRIPTION
As stated at [1] at kubernetes cluster should have the nodes with
different product_uuid. This change pass the -uuid flag so a random one
is generated at startup.

[1] https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#verify-mac-address