### PR TITLE
Use alternative registry on conformance tests

### DIFF
--- a/hack/conformance.sh
+++ b/hack/conformance.sh
@@ -2,10 +2,16 @@
 
 set -xeuo pipefail
 
+SCRIPT_PATH=$(dirname "$(realpath "$0")")
+
 ARTIFACTS=${ARTIFACTS:-${PWD}}
+
 config_file=${1:-}
 sonobuoy_version=0.50.0
 [[ -f "$config_file" ]] && sonobuoy_version=$(jq -r '.Version' "$config_file" | grep -oE '[0-9\.]+')
+
+conformance_image_config_file="$SCRIPT_PATH/confromance-image-config.yaml"
+! [[ -f "$conformance_image_config_file" ]] && echo "FATAL: Conformance image config file does not exists" 1>&2 && exit 1
 
 if [[ -z "$KUBEVIRT_PROVIDER" ]]; then
     echo "KUBEVIRT_PROVIDER is not set" 1>&2
@@ -59,7 +65,7 @@ curl -L "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_
 
 trap teardown EXIT
 
-run_cmd="./sonobuoy run --wait"
+run_cmd="./sonobuoy run --wait --e2e-repo-config $conformance_image_config_file"
 
 if [ "$config_file" != "" ]; then
     run_cmd+=" --config $config_file"

--- a/hack/confromance-image-config.yaml
+++ b/hack/confromance-image-config.yaml
@@ -1,0 +1,1 @@
+dockerLibraryRegistry: mirror.gcr.io/library


### PR DESCRIPTION
When running kubernetes e2e conformance tests,
Sonobuoy pull images from docker.io by default.
Due to that CI check-up lanes that run conformance
tests hit docker pull images rate limit and fail.

Following https://github.com/vmware-tanzu/sonobuoy/pull/1194/
this PR points Sonobuoy to pull images
from 'mirror.gcr.io/library' registry instead of docker.io.

Signed-off-by: Or Mergi <ormergi@redhat.com>