### PR TITLE
cnao, provision, Bump k8s-1.19/1.20/1.21 cnao to v0.56.0

### DIFF
--- a/cluster-provision/k8s/1.19/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.19/manifests/cnao/operator.yaml
@@ -121,7 +121,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.54.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.56.0
   name: cluster-network-addons-operator
   namespace: cluster-network-addons
 spec:
@@ -148,21 +148,21 @@ spec:
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker@sha256:799459f8509a06ea643aa2f6ac02826721a641333aacab07e53166139a5a66c3
         - name: NMSTATE_HANDLER_IMAGE
-          value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:293566ed496aec06f07f8503c19a4f8aa28d9eef7fe9686cf18a590bb9502ded
+          value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:12628286c41b56a63a5aaa4f174bd3b836a5b9b7c1b8ea3c66de8ea4616ca71a
         - name: OVS_CNI_IMAGE
-          value: quay.io/kubevirt/ovs-cni-plugin@sha256:9ea002a51fd6cd706064a13e4eb79618e286f31be291ea4485de92675f26daa1
+          value: quay.io/kubevirt/ovs-cni-plugin@sha256:bc39215d0108659f8f05ebc9cfd55a161dc8885583612c37e4151f0417eb6e6f
         - name: OVS_MARKER_IMAGE
-          value: quay.io/kubevirt/ovs-cni-marker@sha256:dca0d0432eacb1e97ea49c755df1c232159fe4267e7f872222ef0ef77e3d8915
+          value: quay.io/kubevirt/ovs-cni-marker@sha256:8443bd0e283bc01cd67f50f5da741f70014d2661811c13258dee6a9e56059fc2
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool@sha256:c418e60fa48f137f638b8a043c6263c41c12eb35bc0e05933835aa9205638277
+          value: quay.io/kubevirt/kubemacpool@sha256:89de9849fd8b96fe2590f74c4972a8382aa2bcb4fc3e610daadc3175f6f4cafe
         - name: MACVTAP_CNI_IMAGE
           value: quay.io/kubevirt/macvtap-cni@sha256:f20d5e56f8b8c1ab7e5a64e536b66f65aa688b2d1dc0b37e3c26c2af2b481266
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.54.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.56.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.54.0
+          value: 0.56.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -176,7 +176,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WATCH_NAMESPACE
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.54.0
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.56.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources: {}

--- a/cluster-provision/k8s/1.20/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.20/manifests/cnao/operator.yaml
@@ -121,7 +121,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.54.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.56.0
   name: cluster-network-addons-operator
   namespace: cluster-network-addons
 spec:
@@ -148,21 +148,21 @@ spec:
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker@sha256:799459f8509a06ea643aa2f6ac02826721a641333aacab07e53166139a5a66c3
         - name: NMSTATE_HANDLER_IMAGE
-          value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:293566ed496aec06f07f8503c19a4f8aa28d9eef7fe9686cf18a590bb9502ded
+          value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:12628286c41b56a63a5aaa4f174bd3b836a5b9b7c1b8ea3c66de8ea4616ca71a
         - name: OVS_CNI_IMAGE
-          value: quay.io/kubevirt/ovs-cni-plugin@sha256:9ea002a51fd6cd706064a13e4eb79618e286f31be291ea4485de92675f26daa1
+          value: quay.io/kubevirt/ovs-cni-plugin@sha256:bc39215d0108659f8f05ebc9cfd55a161dc8885583612c37e4151f0417eb6e6f
         - name: OVS_MARKER_IMAGE
-          value: quay.io/kubevirt/ovs-cni-marker@sha256:dca0d0432eacb1e97ea49c755df1c232159fe4267e7f872222ef0ef77e3d8915
+          value: quay.io/kubevirt/ovs-cni-marker@sha256:8443bd0e283bc01cd67f50f5da741f70014d2661811c13258dee6a9e56059fc2
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool@sha256:c418e60fa48f137f638b8a043c6263c41c12eb35bc0e05933835aa9205638277
+          value: quay.io/kubevirt/kubemacpool@sha256:89de9849fd8b96fe2590f74c4972a8382aa2bcb4fc3e610daadc3175f6f4cafe
         - name: MACVTAP_CNI_IMAGE
           value: quay.io/kubevirt/macvtap-cni@sha256:f20d5e56f8b8c1ab7e5a64e536b66f65aa688b2d1dc0b37e3c26c2af2b481266
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.54.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.56.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.54.0
+          value: 0.56.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -176,7 +176,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WATCH_NAMESPACE
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.54.0
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.56.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources: {}

--- a/cluster-provision/k8s/1.21/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.21/manifests/cnao/operator.yaml
@@ -121,7 +121,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.53.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.56.0
   name: cluster-network-addons-operator
   namespace: cluster-network-addons
 spec:
@@ -148,21 +148,21 @@ spec:
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker@sha256:799459f8509a06ea643aa2f6ac02826721a641333aacab07e53166139a5a66c3
         - name: NMSTATE_HANDLER_IMAGE
-          value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:293566ed496aec06f07f8503c19a4f8aa28d9eef7fe9686cf18a590bb9502ded
+          value: quay.io/nmstate/kubernetes-nmstate-handler@sha256:12628286c41b56a63a5aaa4f174bd3b836a5b9b7c1b8ea3c66de8ea4616ca71a
         - name: OVS_CNI_IMAGE
-          value: quay.io/kubevirt/ovs-cni-plugin@sha256:9ea002a51fd6cd706064a13e4eb79618e286f31be291ea4485de92675f26daa1
+          value: quay.io/kubevirt/ovs-cni-plugin@sha256:bc39215d0108659f8f05ebc9cfd55a161dc8885583612c37e4151f0417eb6e6f
         - name: OVS_MARKER_IMAGE
-          value: quay.io/kubevirt/ovs-cni-marker@sha256:dca0d0432eacb1e97ea49c755df1c232159fe4267e7f872222ef0ef77e3d8915
+          value: quay.io/kubevirt/ovs-cni-marker@sha256:8443bd0e283bc01cd67f50f5da741f70014d2661811c13258dee6a9e56059fc2
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool@sha256:2274391736f2e54b5620bc221d23a8ff2eae7330a816db1d4f7f382c971d6d0a
+          value: quay.io/kubevirt/kubemacpool@sha256:89de9849fd8b96fe2590f74c4972a8382aa2bcb4fc3e610daadc3175f6f4cafe
         - name: MACVTAP_CNI_IMAGE
           value: quay.io/kubevirt/macvtap-cni@sha256:f20d5e56f8b8c1ab7e5a64e536b66f65aa688b2d1dc0b37e3c26c2af2b481266
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.53.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.56.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.53.0
+          value: 0.56.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -176,7 +176,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: WATCH_NAMESPACE
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.53.0
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.56.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources: {}


### PR DESCRIPTION
CNAO version v0.54.0+ has a crucial fix for Kubemacpool / kubevirt sync [1]
Without it, kubemacpool will add the VM finalizer, but the kubemacpool manager won't restart
resulting in the finalizer not removed from the VM, as seen on [2].

[1] https://github.com/k8snetworkplumbingwg/kubemacpool/pull/292
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.21-sig-network/1407559103336681472