### PR TITLE
Configure cgroup v2 settings on cluster-up

### DIFF
--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -41,7 +41,6 @@ func NewProvisionCommand() *cobra.Command {
 	provision.Flags().Bool("random-ports", false, "expose all ports on random localhost ports")
 	provision.Flags().Uint("vnc-port", 0, "port on localhost for vnc")
 	provision.Flags().Uint("ssh-port", 0, "port on localhost for ssh server")
-	provision.Flags().Bool("cgroupv2", false, "set UNIFIED_CGROUP_HIERARCHY environment variable for the provision script")
 	provision.Flags().String("container-suffix", "", "use additional suffix for the provisioned container image")
 	provision.Flags().StringArray("additional-persistent-kernel-arguments", []string{}, "additional persistent kernel arguments applied after provision")
 
@@ -222,15 +221,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 
-	cgroupv2, err := cmd.Flags().GetBool("cgroupv2")
-	if err != nil {
-		return err
-	}
-
 	envVars := fmt.Sprintf("version=%s", version)
-	if cgroupv2 {
-		envVars = fmt.Sprintf("%s UNIFIED_CGROUP_HIERARCHY=1", envVars)
-	}
 
 	err = _cmd(cli, nodeContainer(prefix, nodeName), fmt.Sprintf("ssh.sh sudo %s /bin/bash < /scripts/provision.sh", envVars), "provisioning the node")
 	if err != nil {
@@ -263,9 +254,6 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 	additionalKernelArguments, err := cmd.Flags().GetStringArray("additional-persistent-kernel-arguments")
 	if err != nil {
 		return err
-	}
-	if cgroupv2 {
-		additionalKernelArguments = append(additionalKernelArguments, "systemd.unified_cgroup_hierarchy=1")
 	}
 
 	dir, err := ioutil.TempDir("", "gocli")

--- a/cluster-provision/k8s/1.21/provision.sh
+++ b/cluster-provision/k8s/1.21/provision.sh
@@ -11,19 +11,12 @@ if [ ! -f "/tmp/fetch-images.sh" ]; then
     exit 1
 fi
 
-# Configure cgroup version
-if [ "${UNIFIED_CGROUP_HIERARCHY}" == "1" ]; then
-    CGROUP_DRIVER="cgroupfs"
-else
-    CGROUP_DRIVER="systemd"
-fi
-
 KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
 mkdir -p $KUBEVIRTCI_SHARED_DIR
 cat << EOF > $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
 #!/bin/bash
 set -ex
-export KUBELET_CGROUP_ARGS="--cgroup-driver=${CGROUP_DRIVER} --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
+export KUBELET_CGROUP_ARGS="--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
 export KUBELET_FEATURE_GATES="VolumeSnapshotDataSource=true,IPv6DualStack=true"
 export ISTIO_VERSION=1.10.0
 EOF
@@ -114,16 +107,6 @@ enabled=1
 EOF
 dnf install -y cri-o
 
-if [ "${UNIFIED_CGROUP_HIERARCHY}" == "1" ]; then
-    CRIO_CONF_DIR=/etc/crio/crio.conf.d
-    mkdir -p ${CRIO_CONF_DIR}
-    cat << EOF > ${CRIO_CONF_DIR}/00-cgroupv2.conf
-[crio.runtime]
-conmon_cgroup = "pod"
-cgroup_manager = "cgroupfs"
-EOF
-fi
-
 # install podman for functionality missing in crictl (tag, etc)
 dnf install -y podman
 
@@ -163,7 +146,7 @@ dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y 
 
 # TODO use config file! this is deprecated
 cat <<EOT >/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=--cgroup-driver=${CGROUP_DRIVER} --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --feature-gates="VolumeSnapshotDataSource=true,IPv6DualStack=true"
+KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --feature-gates="VolumeSnapshotDataSource=true,IPv6DualStack=true"
 EOT
 
 # Needed for kubernetes service routing and dns

--- a/cluster-provision/k8s/provision.sh
+++ b/cluster-provision/k8s/provision.sh
@@ -12,11 +12,6 @@ cd $DIR
 
 gocli_args=""
 
-if [ "${CGROUPV2}" == "true" ]; then
-    gocli_args="${gocli_args} --cgroupv2=true"
-    CONTAINER_SUFFIX=cgroupsv2
-fi
-
 if [ -n "${CONTAINER_SUFFIX}" ]; then
     gocli_args="${gocli_args} --container-suffix=${CONTAINER_SUFFIX}"
 fi

--- a/cluster-up/cluster/k8s-1.20-cgroupsv2/provider.sh
+++ b/cluster-up/cluster/k8s-1.20-cgroupsv2/provider.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -e
+
+export KUBEVIRT_PROVIDER=k8s-1.20
+export KUBEVIRT_PROVIDER_EXTRA_ARGS="${KUBEVIRT_PROVIDER_EXTRA_ARGS} --kernel-args='systemd.unified_cgroup_hierarchy=1'"
+
 # shellcheck disable=SC1090
 source "${KUBEVIRTCI_PATH}/cluster/k8s-provider-common.sh"

--- a/cluster-up/cluster/k8s-1.21-cgroupsv2/provider.sh
+++ b/cluster-up/cluster/k8s-1.21-cgroupsv2/provider.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -e
+
+export KUBEVIRT_PROVIDER=k8s-1.21
+export KUBEVIRT_PROVIDER_EXTRA_ARGS="${KUBEVIRT_PROVIDER_EXTRA_ARGS} --kernel-args='systemd.unified_cgroup_hierarchy=1'"
+
 # shellcheck disable=SC1090
 source "${KUBEVIRTCI_PATH}/cluster/k8s-provider-common.sh"

--- a/publish.sh
+++ b/publish.sh
@@ -21,18 +21,8 @@ for i in ${CLUSTERS}; do
     docker tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}
 done
 
-# Provision 1.20-cgroupsv2 cluster
-CGV2_CLUSTER="1.20"
-CGV2_SUFFIX="cgroupsv2"
-CGV2_IMAGE="${CGV2_CLUSTER}-${CGV2_SUFFIX}"
-cluster-provision/gocli/build/cli provision \
-    --cgroupv2=true --container-suffix=${CGV2_SUFFIX} \
-    cluster-provision/k8s/${CGV2_CLUSTER}
-docker tag ${TARGET_REPO}/k8s-${CGV2_IMAGE} \
-    ${TARGET_REPO}/k8s-${CGV2_IMAGE}:${KUBEVIRTCI_TAG}
-
 # Push all images
-IMAGES="${CLUSTERS} ${CGV2_IMAGE}"
+IMAGES="${CLUSTERS}"
 docker push ${TARGET_REPO}/gocli:${KUBEVIRTCI_TAG}
 for i in ${IMAGES}; do
     docker push ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}


### PR DESCRIPTION
This is a follow-up of the https://github.com/kubevirt/kubevirtci/pull/593. Now it is possible to pass additional kernel arguments to qemu and that allows moving the configuration of cgroup v2 from the proviosion step to cluster-up. That way cgroup v2 testing lanes can reuse the existing "pure" 1.20 and 1.21 images.

Th PR does the following:
* adds `systemd.unified_cgroup_hierarchy=1` to qemu kernel args
* configures cgroup settings during VM boot in `node01.sh/nodes.sh`
* removes cgroup configuration during provision step