### PR TITLE
Calico interface regex

### DIFF
--- a/cluster-provision/k8s/1.20/manifests/cni.diff
+++ b/cluster-provision/k8s/1.20/manifests/cni.diff
@@ -1,5 +1,5 @@
---- a/cluster-provision/k8s/1.19/manifests/cni.do-not-change.yaml
-+++ b/cluster-provision/k8s/1.19/manifests/cni.do-not-change.yaml
+--- a/cluster-provision/k8s/1.20/manifests/cni.do-not-change.yaml
++++ b/cluster-provision/k8s/1.20/manifests/cni.do-not-change.yaml
 @@ -32,7 +32,12 @@ data:
            "nodename": "__KUBERNETES_NODE_NAME__",
            "mtu": __CNI_MTU__,

--- a/cluster-provision/k8s/1.20/manifests/cni.diff
+++ b/cluster-provision/k8s/1.20/manifests/cni.diff
@@ -14,6 +14,18 @@
            },
            "policy": {
                "type": "k8s"
+@@ -3642,6 +3642,11 @@ spec:
+             # Auto-detect the BGP IP address.
+             - name: IP
+               value: "autodetect"
++            # Use IP/IPv6 addresses on ifaces eth0, eth1, eth2, etc.
++            - name: IP_AUTODETECTION_METHOD
++              value: "interface=eth.*"
++            - name: IP6_AUTODETECTION_METHOD
++              value: "interface=eth.*"
+             # Enable IPIP
+             - name: CALICO_IPV4POOL_IPIP
+               value: "Always"
 @@ -3671,6 +3676,8 @@ spec:
              # no effect. This should fall within `--cluster-cidr`.
              # - name: CALICO_IPV4POOL_CIDR

--- a/cluster-provision/k8s/1.21/manifests/cni.diff
+++ b/cluster-provision/k8s/1.21/manifests/cni.diff
@@ -1,5 +1,5 @@
---- a/cluster-provision/k8s/1.19/manifests/cni.do-not-change.yaml
-+++ b/cluster-provision/k8s/1.19/manifests/cni.do-not-change.yaml
+--- a/cluster-provision/k8s/1.21/manifests/cni.do-not-change.yaml
++++ b/cluster-provision/k8s/1.21/manifests/cni.do-not-change.yaml
 @@ -32,7 +32,12 @@ data:
            "nodename": "__KUBERNETES_NODE_NAME__",
            "mtu": __CNI_MTU__,

--- a/cluster-provision/k8s/1.21/manifests/cni.diff
+++ b/cluster-provision/k8s/1.21/manifests/cni.diff
@@ -14,6 +14,18 @@
            },
            "policy": {
                "type": "k8s"
+@@ -3642,6 +3642,11 @@ spec:
+             # Auto-detect the BGP IP address.
+             - name: IP
+               value: "autodetect"
++            # Use IP/IPv6 addresses on ifaces eth0, eth1, eth2, etc.
++            - name: IP_AUTODETECTION_METHOD
++              value: "interface=eth.*"
++            - name: IP6_AUTODETECTION_METHOD
++              value: "interface=eth.*"
+             # Enable IPIP
+             - name: CALICO_IPV4POOL_IPIP
+               value: "Always"
 @@ -3671,6 +3676,8 @@ spec:
              # no effect. This should fall within `--cluster-cidr`.
              # - name: CALICO_IPV4POOL_CIDR


### PR DESCRIPTION
Currently, kubevirtci uses Calico's default IP auto-
detection method: first-found.

The disadvantage of this method is that it makes only simplified
guess and on top of that, when new interfaces are added (bridges, veths,
etc.) calico may decide to change the NODE IP, which breaks BGP updates.

This method is not recommended by the documentation either [0].

It's quite simple to reproduce this, just creating a bridge on a node
and assigning an IP address to it makes calico-node pod to pick up the
assigned address and start using that address for BGP.

Since this is certainly not a desired behaviour, this commit adds
IP_AUTODETECTION_METHOD=interface=eth.*
IP6_AUTODETECTION_METHOD=interface=eth.*
setting to only consider interfaces called eth0, eth1, etc. for IP
address autodetection.


[0] https://docs.projectcalico.org/reference/node/configuration#ip-setting