### PR TITLE
Add 'stress' tool SRIOV Lane Containerdisk

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-sriov-lane/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-sriov-lane/cloud-config
@@ -18,7 +18,7 @@ write_files:
       content: |
         igb
 runcmd:
-  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent
+  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress
   - sudo dnf clean all
   - sudo hostnamectl set-hostname ""
   - sudo hostnamectl set-hostname "" --transient


### PR DESCRIPTION
On SRIOV Live Migration, SRIOV host-devices are hot-unplugged just before migration start on source, 
and hot-plugged back on the target when finished successfully.

On Live Migration  e2e tests in order to enable asserting the migration process phases
stress tool is being to slow down the migration process by putting load on the VM memory.

Following kubevirt/kubevirt#5922,
In order to test SRIOV Live Migration abort scenario (migration stops due to failure or cancel request),
its necessary to assert the SRIOV host-device unplug before the migration starts.
By doing that we make sure that the device was unplugged and then plugged back on the source VM
And that the device wasn't plugged the whole time.
This will prevent the tests from passing in case the migration failed/canceled before the device was unplugged.

Thus we need to add stress tool to the VM image that being used on SRIOV lane e2e tests.

Signed-off-by: Or Mergi <ormergi@redhat.com>