### PR TITLE
Update prerequisites for vm-image-builder

### DIFF
--- a/cluster-provision/images/vm-image-builder/README.md
+++ b/cluster-provision/images/vm-image-builder/README.md
@@ -17,9 +17,11 @@ Use cases:
 The following RPM packages need to be present on your machine:
 - cloud-utils
 - docker-ce
-- libvirt
 - libguestfs
+- libguestfs-tools-c
+- libvirt
 - qemu-img
+- virt-install
 
 ## Quickstart: Build and publish an existing containerdisk
 


### PR DESCRIPTION
Adds packages required to prevent errors running `create-containerdisk.sh`

/cc @dhiller

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>