### PR TITLE
Autostart the CNI DHCP daemon on CNAO lanes

### DIFF
--- a/cluster-provision/k8s/1.19/provision.sh
+++ b/cluster-provision/k8s/1.19/provision.sh
@@ -316,6 +316,39 @@ echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:
 
 dnf install -y NetworkManager-config-server
 
+# Add CNI DHCP daemon service and socket, disabled by default
+# TODO: remove after switching from kubernetes-cni.rpm to containernetworking-plugins,
+#   as containernetworking-plugins provides these 2 files
+cat > /etc/systemd/system/cni-dhcp.service <<EOF
+[Unit]
+Description=CNI DHCP service
+Documentation=https://github.com/containernetworking/plugins/tree/master/plugins/ipam/dhcp
+After=network.target cni-dhcp.socket
+Requires=cni-dhcp.socket
+
+[Service]
+ExecStart=/opt/cni/bin/dhcp daemon
+
+[Install]
+WantedBy=multi-user.target
+EOF
+cat > /etc/systemd/system/cni-dhcp.socket <<EOF
+[Unit]
+Description=CNI DHCP service socket
+Documentation=https://github.com/containernetworking/plugins/tree/master/plugins/ipam/dhcp
+PartOf=cni-dhcp.service
+
+[Socket]
+ListenStream=/run/cni/dhcp.sock
+SocketMode=0660
+SocketUser=root
+SocketGroup=root
+RemoveOnStop=true
+
+[Install]
+WantedBy=sockets.target
+EOF
+
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)
 rm -f /etc/sysconfig/network-scripts/ifcfg-*

--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -325,6 +325,39 @@ echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:
 
 dnf install -y NetworkManager-config-server
 
+# Add CNI DHCP daemon service and socket, disabled by default
+# TODO: remove after switching from kubernetes-cni.rpm to containernetworking-plugins,
+#   as containernetworking-plugins provides these 2 files
+cat > /etc/systemd/system/cni-dhcp.service <<EOF
+[Unit]
+Description=CNI DHCP service
+Documentation=https://github.com/containernetworking/plugins/tree/master/plugins/ipam/dhcp
+After=network.target cni-dhcp.socket
+Requires=cni-dhcp.socket
+
+[Service]
+ExecStart=/opt/cni/bin/dhcp daemon
+
+[Install]
+WantedBy=multi-user.target
+EOF
+cat > /etc/systemd/system/cni-dhcp.socket <<EOF
+[Unit]
+Description=CNI DHCP service socket
+Documentation=https://github.com/containernetworking/plugins/tree/master/plugins/ipam/dhcp
+PartOf=cni-dhcp.service
+
+[Socket]
+ListenStream=/run/cni/dhcp.sock
+SocketMode=0660
+SocketUser=root
+SocketGroup=root
+RemoveOnStop=true
+
+[Install]
+WantedBy=sockets.target
+EOF
+
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)
 rm -f /etc/sysconfig/network-scripts/ifcfg-*

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -50,6 +50,11 @@ function up() {
             $kubectl create -f /opt/cnao/network-addons-config-example.cr.yaml
             $kubectl wait networkaddonsconfig cluster --for condition=Available --timeout=200s
         fi
+
+        # When CNAO is enabled, start the CNI dhcp daemon on every node by default
+        for node in $( seq -w 1 99 | head -n $KUBEVIRT_NUM_NODES ); do
+            ${_cli} --prefix $provider_prefix ssh node$node -- sudo systemctl enable --now cni-dhcp
+        done
     fi
 
     if [ "$KUBEVIRT_DEPLOY_ISTIO" == "true" ] && [[ $KUBEVIRT_PROVIDER =~ k8s-1\.1.* ]]; then


### PR DESCRIPTION
That will allow admins to define network-attachment-definitions that use the DHCP IPAM plugin.