### PR TITLE
dnsmasq: listen to DHCP requests on secondary networks too

### DIFF
--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -432,7 +432,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 	wg := sync.WaitGroup{}
 	wg.Add(int(nodes))
 	// start one vm after each other
-	macCounter := 0
+	macCounter := 1
 	for x := 0; x < int(nodes); x++ {
 
 		nodeQemuArgs := qemuArgs


### PR DESCRIPTION
Also, start mac addresses on secondary networks at 1 instead of 0, to match the primary network