### PR TITLE
Forward ports from container to VM

### DIFF
--- a/cluster-provision/centos8/scripts/vm.sh
+++ b/cluster-provision/centos8/scripts/vm.sh
@@ -61,13 +61,9 @@ iptables -t nat -A POSTROUTING ! -s 192.168.66.0/16 --out-interface br0 -j MASQU
 iptables -A FORWARD --in-interface eth0 -j ACCEPT
 iptables -t nat -A PREROUTING -p tcp -i eth0 -m tcp --dport 22${n} -j DNAT --to-destination 192.168.66.1${n}:22
 
-# Route 6443, 8443, 80, 443 and 31001 for first node
+# Route x->x from the container to the VM for first node
 if [ "$n" = "01" ] ; then
-  iptables -t nat -A PREROUTING -p tcp -i eth0 -m tcp --dport 6443 -j DNAT --to-destination 192.168.66.1${n}:6443
-  iptables -t nat -A PREROUTING -p tcp -i eth0 -m tcp --dport 8443 -j DNAT --to-destination 192.168.66.1${n}:8443
-  iptables -t nat -A PREROUTING -p tcp -i eth0 -m tcp --dport 80 -j DNAT --to-destination 192.168.66.1${n}:80
-  iptables -t nat -A PREROUTING -p tcp -i eth0 -m tcp --dport 443 -j DNAT --to-destination 192.168.66.1${n}:443
-  iptables -t nat -A PREROUTING -p tcp -i eth0 -m tcp --dport 31001 -j DNAT --to-destination 192.168.66.1${n}:31001
+  iptables -t nat -A PREROUTING -p tcp -i eth0 -m tcp -j DNAT --to-destination 192.168.66.1${n}
 fi
 
 # For backward compatibility, so that we can just copy over the newer files


### PR DESCRIPTION
https://github.com/kubevirt/kubevirtci/pull/608, https://github.com/kubevirt/kubevirtci/pull/614 introduce prometheus interaction from outside the container,
however, I am not sure what is responsible for forwarding from the container->VM.

I might be missing something but:
```bash
[root@hera04 kubevirtci]# ./cluster-up/ssh.sh node01
selecting docker as container runtime
2021/08/03 14:09:53 Waiting for host: 192.168.66.101:22
2021/08/03 14:09:53 Connected to tcp://192.168.66.101:22
Last login: Tue Aug  3 14:08:50 2021 from 192.168.66.2
[vagrant@node01 ~]$ curl http://localhost:30007
<a href="/graph">Found</a>.
[vagrant@node01 ~]$ ^C
[vagrant@node01 ~]$ logout
[root@hera04 kubevirtci]# ./cluster-up/cli.sh ports prometheus
selecting docker as container runtime
49413
[root@hera04 kubevirtci]# curl http://localhost:49413
curl: (56) Recv failure: Connection reset by peer
```

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>