### PR TITLE
sig-storage flake fix: report that our storage is fast

### DIFF
--- a/cluster-provision/k8s/1.19/provision.sh
+++ b/cluster-provision/k8s/1.19/provision.sh
@@ -60,6 +60,10 @@ dnf -y install yum-utils \
     device-mapper-persistent-data \
     lvm2
 
+# Convince ceph our storage is fast (not a rotational disk)
+echo 'ACTION=="add|change", SUBSYSTEM=="block", KERNEL=="vd[a-z]", ATTR{queue/rotational}="0"' \
+	> /etc/udev/rules.d/60-force-ssd-rotational.rules
+
 # Add Docker repository.
 dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 

--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -66,6 +66,9 @@ yum -y install iscsi-initiator-utils
 
 # for rook ceph
 dnf -y install lvm2
+# Convince ceph our storage is fast (not a rotational disk)
+echo 'ACTION=="add|change", SUBSYSTEM=="block", KERNEL=="vd[a-z]", ATTR{queue/rotational}="0"' \
+	> /etc/udev/rules.d/60-force-ssd-rotational.rules
 
 # To prevent preflight issue related to tc not found
 dnf install -y tc

--- a/cluster-provision/k8s/1.21/provision.sh
+++ b/cluster-provision/k8s/1.21/provision.sh
@@ -75,6 +75,10 @@ yum -y install iscsi-initiator-utils
 
 # for rook ceph
 dnf -y install lvm2
+# Convince ceph our storage is fast (not a rotational disk)
+echo 'ACTION=="add|change", SUBSYSTEM=="block", KERNEL=="vd[a-z]", ATTR{queue/rotational}="0"' \
+	> /etc/udev/rules.d/60-force-ssd-rotational.rules
+
 
 # To prevent preflight issue related to tc not found
 dnf install -y tc


### PR DESCRIPTION
Use udevd to report that virtio-blk isn't a rotational (slow) disk.

VirtIO doesn't have a way to report whether it is an SSD or slow rotational disk[1],
so it reports being a rotational disk[2].
This piece of information is read by ceph and results in degraded performance[3],
and also has the symptoms of error messages such as:
volume deletion failed: persistentvolume pvc-800d9f50-2620-4583-a48b-39d80ebe6a63 is still attached to node node0
seen in the logs here:
https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6238/pull-kubevirt-e2e-k8s-1.20-sig-storage/1431869971553587200/artifacts/k8s-reporter/3/pods/1_rook-ceph_csi-rbdplugin-provisioner-6bc6766db-xnqkv-csi-provisioner.log

These errors were also spotted as tests to flake in https://bugzilla.redhat.com/show_bug.cgi?id=1915706

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1498042#c1
[2] Can confirm by running the following and see:
$ cat /sys/block/vdb/queue/rotational
1
[3] https://bugzilla.redhat.com/show_bug.cgi?id=1873161