### PR TITLE
Update instruction to use K8s 1.21 since 1.16 already been deprecated.

### DIFF
--- a/K8S.md
+++ b/K8S.md
@@ -13,12 +13,13 @@ make cluster-up
 ```                                                                                   
                                                                                       
 Stop k8s cluster                                                                      
-```                                                                                   
+```
 make cluster-down                                                                     
 ```
 
 Use provider's kubectl client with kubectl.sh wrapper script               
-```                                                                        
+```
+export KUBEVIRTCI_TAG=`curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest`
 cluster-up/kubectl.sh get nodes                                            
 cluster-up/kubectl.sh get pods --all-namespaces                            
 ```                                                                        

--- a/K8S.md
+++ b/K8S.md
@@ -8,7 +8,7 @@ cd kubevirtci
                                                                                       
 Start multi node k8s cluster with 2 nics                                              
 ```                                                                                   
-export KUBEVIRT_PROVIDER=k8s-1.16 KUBEVIRT_NUM_NODES=2 KUBEVIRT_NUM_SECONDARY_NICS=1
+export KUBEVIRT_PROVIDER=k8s-1.21 KUBEVIRT_NUM_NODES=2 KUBEVIRT_NUM_SECONDARY_NICS=1
 make cluster-up                                                                       
 ```                                                                                   
                                                                                       

--- a/cluster-up/README.md
+++ b/cluster-up/README.md
@@ -10,3 +10,9 @@ which can be found on the github release page.
 Then, before calling one of the make targets, the environment variable
 `KUBEVIRTCI_TAG` must be exported and set to the tag which was used to vendor
 kubevirtci. It allow the content to find the right `gocli` version.
+
+```
+export KUBEVIRTCI_TAG=`curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest`
+```
+
+Find more kubevirtci tags at https://quay.io/repository/kubevirtci/gocli?tab=tags.


### PR DESCRIPTION
Update instruction to use K8s 1.21 since 1.16 already been deprecated.
With more info about how to specify KUBEVIRTCI_TAG.

Signed-off-by: Chuanying Du <cydu@google.com>
