### PR TITLE
Kind infra, Increase PodPreset enabled validation timeout

### DIFF
--- a/cluster-up/cluster/kind/podpreset.sh
+++ b/cluster-up/cluster/kind/podpreset.sh
@@ -4,6 +4,8 @@ set -e
 
 source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
 
+VALIDATE_PODPRESET_TIMEOUT="60"
+
 function podpreset::enable_admission_plugin() {
     local -r cluster_name=$1
 
@@ -50,6 +52,6 @@ function podpreset::expose_unique_product_uuid_per_node() {
     local -r namespace=$2
 
     podpreset::enable_admission_plugin "$cluster_name"
-    podpreset::validate_admission_plugin_is_enabled "$cluster_name" "30"
+    podpreset::validate_admission_plugin_is_enabled "$cluster_name" "$VALIDATE_PODPRESET_TIMEOUT"
     podpreset::create_virt_launcher_fake_product_uuid_podpreset "$namespace"
 }


### PR DESCRIPTION
Since we upgraded kind node image to k8s-1.19, 
it seems that it takes more time for changes on `kube-apiserver.yaml` to propagate (e.g: enabling `PodPreset`).

Unfortunately there is no API to enable and verify that the `PodPreset` feature-gate is enabled.
As for today we check `kube-apiserver` process command on control-plane node to validate that the `PodPeset` feature is enabled.

This workaround is temporary, once  https://github.com/kubernetes-sigs/kind/issues/2318 will land at kubevirtci we can stop using `PodPreset`.

Signed-off-by: Or Mergi <ormergi@redhat.com>