### PR TITLE
add get_kubectl to external provider

### DIFF
--- a/cluster-up/cluster/external/README.md
+++ b/cluster-up/cluster/external/README.md
@@ -11,6 +11,7 @@ The build machine should be a client of the cluster.
 export KUBEVIRT_PROVIDER=external
 export DOCKER_PREFIX=myregistry:5000/kubevirt
 export KUBECONFIG=mycluster.conf
+export KUBEVERSION=v1.19.7
 export IMAGE_PULL_POLICY=Always
 make cluster-up
 ```


### PR DESCRIPTION
As kubectl binary is not always provided in the host machine,
add get_kubectl function, which can facilitate e2e test on
external provider.

Signed-off-by: Howard Zhang <howard.zhang@arm.com>