### PR TITLE
Add cdi deployment to kubevirtci clusters

### DIFF
--- a/cluster-provision/k8s/1.19/manifests/cdi-1.36.0-cr.yaml
+++ b/cluster-provision/k8s/1.19/manifests/cdi-1.36.0-cr.yaml
@@ -1,0 +1,15 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: CDI
+metadata:
+  name: cdi
+spec:
+  imagePullPolicy: IfNotPresent
+  infra:
+    nodeSelector:
+      kubernetes.io/os: linux
+    tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  workload:
+    nodeSelector:
+      kubernetes.io/os: linux

--- a/cluster-provision/k8s/1.19/manifests/cdi-1.36.0-operator.yaml
+++ b/cluster-provision/k8s/1.19/manifests/cdi-1.36.0-operator.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: CDI
-metadata:
-  name: cdi
-spec:
-  imagePullPolicy: IfNotPresent
-  infra:
-    nodeSelector:
-      kubernetes.io/os: linux
-    tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  workload:
-    nodeSelector:
-      kubernetes.io/os: linux
----
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster-provision/k8s/1.19/provision.sh
+++ b/cluster-provision/k8s/1.19/provision.sh
@@ -7,14 +7,14 @@ function docker_pull_retry() {
     maxRetries=5
     retryAfterSeconds=3
     until [ ${retry} -ge ${maxRetries} ]; do
-        docker pull $@ && break
+        docker pull "$@" && break
         retry=$((${retry} + 1))
-        echo "Retrying ${FUNCNAME} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
+        echo "Retrying ${FUNCNAME[0]} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
         sleep ${retryAfterSeconds}
     done
 
     if [ ${retry} -ge ${maxRetries} ]; then
-        echo "${FUNCNAME} Failed after ${maxRetries} attempts!"
+        echo "${FUNCNAME[0]} Failed after ${maxRetries} attempts!"
         exit 1
     fi
 }
@@ -319,7 +319,10 @@ for i in $(grep --no-filename "image:" /opt/whereabouts/*.yaml | awk '{print $2}
 for i in $(grep -A 2 "IMAGE" /provision/local-volume.yaml | grep value | awk -F\" '{print $2}'); do docker_pull_retry $i; done
 
 # Pre pull cdi images
-for i in $(grep "quay.io" /tmp/cdi.do-not-change.yaml | awk '{print $2}'); do docker_pull_retry $i; done
+for i in $(grep "quay.io" /tmp/cdi-*-operator.yaml | awk '{print $2}'); do docker_pull_retry $i; done
+
+# copy cdi manifests
+cp -rf /tmp/cdi*.yaml /opt/
 
 # Create a properly labelled tmp directory for testing
 mkdir -p /var/provision/kubevirt.io/tests

--- a/cluster-provision/k8s/1.20/manifests/cdi-1.36.0-cr.yaml
+++ b/cluster-provision/k8s/1.20/manifests/cdi-1.36.0-cr.yaml
@@ -1,0 +1,15 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: CDI
+metadata:
+  name: cdi
+spec:
+  imagePullPolicy: IfNotPresent
+  infra:
+    nodeSelector:
+      kubernetes.io/os: linux
+    tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  workload:
+    nodeSelector:
+      kubernetes.io/os: linux

--- a/cluster-provision/k8s/1.20/manifests/cdi-1.36.0-operator.yaml
+++ b/cluster-provision/k8s/1.20/manifests/cdi-1.36.0-operator.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: CDI
-metadata:
-  name: cdi
-spec:
-  imagePullPolicy: IfNotPresent
-  infra:
-    nodeSelector:
-      kubernetes.io/os: linux
-    tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  workload:
-    nodeSelector:
-      kubernetes.io/os: linux
----
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -19,14 +19,14 @@ function pull_container_retry() {
     maxRetries=5
     retryAfterSeconds=3
     until [ ${retry} -ge ${maxRetries} ]; do
-        podman pull $@ && break
+        podman pull "$@" && break
         retry=$((${retry} + 1))
-        echo "Retrying ${FUNCNAME} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
+        echo "Retrying ${FUNCNAME[0]} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
         sleep ${retryAfterSeconds}
     done
 
     if [ ${retry} -ge ${maxRetries} ]; then
-        echo "${FUNCNAME} Failed after ${maxRetries} attempts!"
+        echo "${FUNCNAME[0]} Failed after ${maxRetries} attempts!"
         exit 1
     fi
 }
@@ -327,7 +327,10 @@ for i in $(grep -A 2 "IMAGE" /provision/local-volume.yaml | grep value | awk -F\
 for i in $(grep "image:" /tmp/istio-deployment.yaml | grep -v "{{" | awk '{print $2}' | tr -d '"' | sort -u) ; do pull_container_retry $i ; done
 
 # Pre pull cdi images
-for i in $(grep "quay.io" /tmp/cdi.do-not-change.yaml | awk '{print $2}'); do pull_container_retry $i; done
+for i in $(grep "quay.io" /tmp/cdi-*-operator.yaml | awk '{print $2}'); do pull_container_retry $i; done
+
+# copy cdi manifests
+cp -rf /tmp/cdi*.yaml /opt/
 
 # Create a properly labelled tmp directory for testing
 mkdir -p /var/provision/kubevirt.io/tests

--- a/cluster-provision/k8s/1.21/manifests/cdi-1.37.1-cr.yaml
+++ b/cluster-provision/k8s/1.21/manifests/cdi-1.37.1-cr.yaml
@@ -1,0 +1,15 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: CDI
+metadata:
+  name: cdi
+spec:
+  imagePullPolicy: IfNotPresent
+  infra:
+    nodeSelector:
+      kubernetes.io/os: linux
+    tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  workload:
+    nodeSelector:
+      kubernetes.io/os: linux

--- a/cluster-provision/k8s/1.21/manifests/cdi-1.37.1-operator.yaml
+++ b/cluster-provision/k8s/1.21/manifests/cdi-1.37.1-operator.yaml
@@ -1,20 +1,3 @@
----
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: CDI
-metadata:
-  name: cdi
-spec:
-  imagePullPolicy: IfNotPresent
-  infra:
-    nodeSelector:
-      kubernetes.io/os: linux
-    tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  workload:
-    nodeSelector:
-      kubernetes.io/os: linux
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -25,12 +8,10 @@ metadata:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.cdi.kubevirt.io: ""
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: cdis.cdi.kubevirt.io
 spec:
-  conversion:
-    strategy: None
   group: cdi.kubevirt.io
   names:
     kind: CDI
@@ -2005,6 +1986,13 @@ rules:
 - apiGroups:
   - cdi.kubevirt.io
   resources:
+  - datasources
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - cdi.kubevirt.io
+  resources:
   - cdis
   verbs:
   - get
@@ -2231,24 +2219,24 @@ spec:
         - name: DEPLOY_CLUSTER_RESOURCES
           value: "true"
         - name: OPERATOR_VERSION
-          value: v1.36.0
+          value: v1.37.1
         - name: CONTROLLER_IMAGE
-          value: quay.io/kubevirt/cdi-controller:v1.36.0
+          value: quay.io/kubevirt/cdi-controller:v1.37.1
         - name: IMPORTER_IMAGE
-          value: quay.io/kubevirt/cdi-importer:v1.36.0
+          value: quay.io/kubevirt/cdi-importer:v1.37.1
         - name: CLONER_IMAGE
-          value: quay.io/kubevirt/cdi-cloner:v1.36.0
+          value: quay.io/kubevirt/cdi-cloner:v1.37.1
         - name: APISERVER_IMAGE
-          value: quay.io/kubevirt/cdi-apiserver:v1.36.0
+          value: quay.io/kubevirt/cdi-apiserver:v1.37.1
         - name: UPLOAD_SERVER_IMAGE
-          value: quay.io/kubevirt/cdi-uploadserver:v1.36.0
+          value: quay.io/kubevirt/cdi-uploadserver:v1.37.1
         - name: UPLOAD_PROXY_IMAGE
-          value: quay.io/kubevirt/cdi-uploadproxy:v1.36.0
+          value: quay.io/kubevirt/cdi-uploadproxy:v1.37.1
         - name: VERBOSITY
           value: "1"
         - name: PULL_POLICY
           value: IfNotPresent
-        image: quay.io/kubevirt/cdi-operator:v1.36.0
+        image: quay.io/kubevirt/cdi-operator:v1.37.1
         imagePullPolicy: IfNotPresent
         name: cdi-operator
         ports:

--- a/cluster-provision/k8s/1.21/provision.sh
+++ b/cluster-provision/k8s/1.21/provision.sh
@@ -323,6 +323,9 @@ cp -rf /tmp/cnao/ /opt/
 # so we can use them at cluster-up
 cp -rf /tmp/whereabouts/ /opt/
 
+# copy cdi manifests
+cp -rf /tmp/cdi*.yaml /opt/
+
 # Create a properly labelled tmp directory for testing
 mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests

--- a/cluster-provision/k8s/1.22/manifests/cdi-1.37.1-cr.yaml
+++ b/cluster-provision/k8s/1.22/manifests/cdi-1.37.1-cr.yaml
@@ -1,0 +1,15 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: CDI
+metadata:
+  name: cdi
+spec:
+  imagePullPolicy: IfNotPresent
+  infra:
+    nodeSelector:
+      kubernetes.io/os: linux
+    tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  workload:
+    nodeSelector:
+      kubernetes.io/os: linux

--- a/cluster-provision/k8s/1.22/manifests/cdi-1.37.1-operator.yaml
+++ b/cluster-provision/k8s/1.22/manifests/cdi-1.37.1-operator.yaml
@@ -1,20 +1,3 @@
----
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: CDI
-metadata:
-  name: cdi
-spec:
-  imagePullPolicy: IfNotPresent
-  infra:
-    nodeSelector:
-      kubernetes.io/os: linux
-    tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  workload:
-    nodeSelector:
-      kubernetes.io/os: linux
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -25,12 +8,10 @@ metadata:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.cdi.kubevirt.io: ""
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
   name: cdis.cdi.kubevirt.io
 spec:
-  conversion:
-    strategy: None
   group: cdi.kubevirt.io
   names:
     kind: CDI
@@ -2005,6 +1986,13 @@ rules:
 - apiGroups:
   - cdi.kubevirt.io
   resources:
+  - datasources
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - cdi.kubevirt.io
+  resources:
   - cdis
   verbs:
   - get
@@ -2231,24 +2219,24 @@ spec:
         - name: DEPLOY_CLUSTER_RESOURCES
           value: "true"
         - name: OPERATOR_VERSION
-          value: v1.36.0
+          value: v1.37.1
         - name: CONTROLLER_IMAGE
-          value: quay.io/kubevirt/cdi-controller:v1.36.0
+          value: quay.io/kubevirt/cdi-controller:v1.37.1
         - name: IMPORTER_IMAGE
-          value: quay.io/kubevirt/cdi-importer:v1.36.0
+          value: quay.io/kubevirt/cdi-importer:v1.37.1
         - name: CLONER_IMAGE
-          value: quay.io/kubevirt/cdi-cloner:v1.36.0
+          value: quay.io/kubevirt/cdi-cloner:v1.37.1
         - name: APISERVER_IMAGE
-          value: quay.io/kubevirt/cdi-apiserver:v1.36.0
+          value: quay.io/kubevirt/cdi-apiserver:v1.37.1
         - name: UPLOAD_SERVER_IMAGE
-          value: quay.io/kubevirt/cdi-uploadserver:v1.36.0
+          value: quay.io/kubevirt/cdi-uploadserver:v1.37.1
         - name: UPLOAD_PROXY_IMAGE
-          value: quay.io/kubevirt/cdi-uploadproxy:v1.36.0
+          value: quay.io/kubevirt/cdi-uploadproxy:v1.37.1
         - name: VERBOSITY
           value: "1"
         - name: PULL_POLICY
           value: IfNotPresent
-        image: quay.io/kubevirt/cdi-operator:v1.36.0
+        image: quay.io/kubevirt/cdi-operator:v1.37.1
         imagePullPolicy: IfNotPresent
         name: cdi-operator
         ports:

--- a/cluster-provision/k8s/1.22/provision.sh
+++ b/cluster-provision/k8s/1.22/provision.sh
@@ -323,6 +323,9 @@ cp -rf /tmp/cnao/ /opt/
 # so we can use them at cluster-up
 cp -rf /tmp/whereabouts/ /opt/
 
+# copy cdi manifests
+cp -rf /tmp/cdi*.yaml /opt/
+
 # Create a properly labelled tmp directory for testing
 mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests

--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -41,6 +41,7 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
     export KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER=false
     export KUBEVIRT_DEPLOY_GRAFANA=false
   fi
+  export KUBEVIRT_DEPLOY_CDI=true
   trap cleanup EXIT ERR SIGINT SIGTERM SIGQUIT
   bash -x ./cluster-up/up.sh
   timeout 210s bash -c "until ${ksh} wait --for=condition=Ready pod --timeout=30s --all; do sleep 1; done"

--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -44,6 +44,8 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
   export KUBEVIRT_DEPLOY_CDI=true
   trap cleanup EXIT ERR SIGINT SIGTERM SIGQUIT
   bash -x ./cluster-up/up.sh
+  # This is required so that all the completed pods from ip-reconciler are getting removed directly
+  ${ksh} patch cronjob ip-reconciler --type merge -p '{ "spec": { "jobTemplate": { "spec": { "ttlSecondsAfterFinished": 0 } } } }'
   timeout 210s bash -c "until ${ksh} wait --for=condition=Ready pod --timeout=30s --all; do sleep 1; done"
   timeout 210s bash -c "until ${ksh} wait --for=condition=Ready pod --timeout=30s -n kube-system --all; do sleep 1; done"
   ${ksh} get nodes

--- a/cluster-provision/k8s/deploy-manifests.sh
+++ b/cluster-provision/k8s/deploy-manifests.sh
@@ -3,7 +3,7 @@
 
 set -exuo pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ksh="$(cd "$DIR/../.." && pwd)/cluster-up/kubectl.sh"
 provision_dir="$1"
 export KUBEVIRT_PROVIDER="k8s-${provision_dir}"
@@ -21,6 +21,7 @@ find "$DIR/${provision_dir}/manifests/" -type f -name '*.yaml' \
     -not -name 'logging.yaml' \
     -not -name 'local-volume.yaml' \
     -not -name 'cni*.yaml' \
+    -not -name 'cdi*-cr.yaml' \
     -print -exec ${ksh} create -f {} \;
 
 # wait for pods to get ready (we do this repeatedly to give the pods created by the operators time to come up)

--- a/cluster-provision/k8s/fetch-latest-cdi.sh
+++ b/cluster-provision/k8s/fetch-latest-cdi.sh
@@ -2,6 +2,20 @@
 
 set -euo pipefail
 
+function usage() {
+    cat <<EOF
+usage: $0 [-f] [<provision_dir>]
+
+        Downloads the latest containerized-data-importer manifests from the github release page and stores them into the manifests directory of the provision_dir.
+
+        If the provision_dir is omitted, it is assumed that the latest provision_dir should be the target
+
+options:
+    -f
+        forces the download of the manifests, existing manifests are deleted beforehand
+EOF
+}
+
 force=
 while getopts ":f" opt; do
     case "${opt}" in

--- a/cluster-provision/k8s/fetch-latest-cdi.sh
+++ b/cluster-provision/k8s/fetch-latest-cdi.sh
@@ -2,24 +2,60 @@
 
 set -euo pipefail
 
-provision_dir="$1"
-[ ! -d $provision_dir ] && echo "directory $provision_dir does not exist!" && exit 1
-[ ! -d $provision_dir/manifests ] && echo "directory $provision_dir/manifests does not exist!" && exit 1
+force=
+while getopts ":f" opt; do
+    case "${opt}" in
+    f)
+        force=true
+        shift
+        ;;
+    \?)
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+if [ "$#" -gt 0 ]; then
+    provision_dir="$1"
+else
+    provision_dir=$(find "$(readlink --canonicalize "$(dirname "$0")")" -mindepth 1 -maxdepth 1 -type d -regex '^.*[0-9]\.[0-9]+$' -regextype 'posix-extended' | sort -rV | head -1)
+fi
+
+[ ! -d "$provision_dir" ] && echo "directory $provision_dir does not exist!" && exit 1
+[ ! -d "$provision_dir/manifests" ] && echo "directory $provision_dir/manifests does not exist!" && exit 1
 
 tag_name=$(curl -s -L -f https://api.github.com/repos/kubevirt/containerized-data-importer/releases/latest | jq -r '.tag_name')
 
-if [ $(find "$provision_dir/manifests" -name "cdi-*.yaml" | wc -l) -gt 0 ]; then
-    echo "$provision_dir/manifests/cdi-*.yaml already exists!"
+if [ "$(find "$provision_dir/manifests" -name "cdi-*.yaml" | wc -l)" -gt 0 ]; then
     find "$provision_dir/manifests" -name "cdi-*.yaml" -print
-    exit 1
+
+    if [ -z "$force" ]; then
+        echo "$provision_dir/manifests/cdi-*.yaml already exists!"
+        exit 1
+    fi
+
+    echo "Deleting old cdi manifests"
+    find "$provision_dir/manifests" -name "cdi-*.yaml" -delete
 fi
 
+cdi_release_json="$(pwd)/$(mktemp cdi_release_XXXXXXXX.json)"
+curl -o "$cdi_release_json" -s -L -f https://api.github.com/repos/kubevirt/containerized-data-importer/releases/latest
+function cleanup() {
+    rm -f "$cdi_release_json"
+}
+trap cleanup EXIT SIGTERM
+tag_name=$(jq -r '.tag_name' "$cdi_release_json")
+cdi_version="${tag_name/#v/}"
 (
+    cd "$provision_dir/manifests"
     for file in $(
-        latest_release=$(curl -s -L -f https://api.github.com/repos/kubevirt/containerized-data-importer/releases/latest | jq -r '.url')
-        curl -s -L -f $latest_release/assets | jq -r '.[] | select( .name | startswith( "cdi" ) ) | .browser_download_url'
+        jq -r '.assets[] | select( .name | startswith( "cdi" ) ) | .browser_download_url' "$cdi_release_json"
     ); do
-        echo '---'
-        curl -s -L -f $file
+        curl -O -s -L -f "$file"
     done
-) > $provision_dir/manifests/cdi-${tag_name#v}.yaml
+
+    while IFS= read -r -d '' file; do
+        mv "$file" "${file/#\.\/cdi-/\.\/cdi-$cdi_version-}"
+    done < <(find . -type f -name 'cdi*.yaml' -print0)
+)

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -91,6 +91,6 @@ function up() {
             $kubectl get pods --namespace cdi
             sleep 10
         done
-        until $kubectl wait --for=condition=Ready pod --timeout=60s --all --namespace cdi; do sleep 10; done
+        $kubectl wait --for=condition=Ready pod --timeout=60s --all --namespace cdi
     fi
 }

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -65,7 +65,7 @@ function up() {
         else
             $kubectl create -f /opt/istio/istio-operator.cr.yaml
         fi
-        
+
         istio_operator_ns=istio-system
         retries=0
         max_retries=20
@@ -82,5 +82,15 @@ function up() {
             echo "waiting istio-operator to be healthy failed"
             exit 1
         fi
+    fi
+
+    if [ "$KUBEVIRT_DEPLOY_CDI" == "true" ]; then
+        $kubectl create -f /opt/cdi-*-operator.yaml
+        $kubectl create -f /opt/cdi-*-cr.yaml
+        while [ $($kubectl get pods --namespace cdi | grep 'cdi-' | wc -l) -lt 4 ]; do
+            $kubectl get pods --namespace cdi
+            sleep 10
+        done
+        until $kubectl wait --for=condition=Ready pod --timeout=60s --all --namespace cdi; do sleep 10; done
     fi
 }

--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -26,6 +26,7 @@ KUBEVIRT_DEPLOY_PROMETHEUS=${KUBEVIRT_DEPLOY_PROMETHEUS:-false}
 KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER=${KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER-false}
 KUBEVIRT_DEPLOY_GRAFANA=${KUBEVIRT_DEPLOY_GRAFANA:-false}
 KUBEVIRT_CGROUPV2=${KUBEVIRT_CGROUPV2:-false}
+KUBEVIRT_DEPLOY_CDI=${KUBEVIRT_DEPLOY_CDI:-false}
 
 # If on a developer setup, expose ocp on 8443, so that the openshift web console can be used (the port is important because of auth redirects)
 # http and https ports are accessed by testing framework and should not be randomized


### PR DESCRIPTION
# Main change

Add support for environment variable `KUBEVIRT_DEPLOY_CDI`  that triggers
a deployment of bundled cdi if set to `true`. This then uses the bundled cdi manifests
and installs them after the k8s cluster is running.

The aim here is to just `export KUBEVIRT_DEPLOY_CDI=true` before `cluster-up` and then
have cdi deployed when cluster-up is finished. With this change we can get rid of the
kubevirt/kubevirt manifest for cdi which we are using currently during cluster-deploy.

# Further changes

Split the cdi manifests into two files for operator and custom resource
again so we can install cdi in the usual way.

Change `cluster-provision/k8s/fetch-latest-cdi.sh` so that it creates two files again.
Also adds a `-f` flag that removes existing cdi manifests and replaces them
with the newer ones instead.
Also if the provision directory is omitted
the latest provision directory is chosen as default. Together we can now
use it to automate cdi manifest updates.
