### PR TITLE
Use container registry from Quay

### DIFF
--- a/cluster-provision/gocli/cmd/utils/images.go
+++ b/cluster-provision/gocli/cmd/utils/images.go
@@ -4,7 +4,7 @@ const (
 	// NFSGaneshaImage contains the reference to NFS docker image
 	NFSGaneshaImage = "docker.io/janeczku/nfs-ganesha@sha256:17fe1813fd20d9fdfa497a26c8a2e39dd49748cd39dbb0559df7627d9bcf4c53"
 	// DockerRegistryImage contains the reference to docker registry docker image
-	DockerRegistryImage = "docker.io/library/registry:2.7.1"
+	DockerRegistryImage = "quay.io/libpod/registry:2.7"
 	// FluentdImage contains the reference to fluentd docker image
 	FluentdImage = "docker.io/fluent/fluentd:v1.2-debian"
 )


### PR DESCRIPTION
According to this docker proxy log https://gist.github.com/fgimenez/35c4fae7d994b55875b7ba6582311773 the registry image is the only one that we are pulling from docker hub on kubevirt's `make cluster-up && make cluster-sync`

/cc @dhiller @dankenigsberg 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>