### PR TITLE
Add support for realtime tuning kernel arguments

### DIFF
--- a/cluster-provision/centos8/scripts/kernel.args
+++ b/cluster-provision/centos8/scripts/kernel.args
@@ -1,1 +1,1 @@
-root=/dev/vda1 ro no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop spectre_v2=off nopti hugepagesz=2M hugepages=64 intel_iommu=on modprobe.blacklist=nouveau
+root=/dev/vda1 ro no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop spectre_v2=off nopti intel_iommu=on modprobe.blacklist=nouveau

--- a/cluster-provision/k8s/1.19/node01.sh
+++ b/cluster-provision/k8s/1.19/node01.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-# Ensure that hugepages are there
-cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
-
 timeout=30
 interval=5
 while ! hostnamectl  |grep Transient ; do

--- a/cluster-provision/k8s/1.19/nodes.sh
+++ b/cluster-provision/k8s/1.19/nodes.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-# Ensure that hugepages are there
-cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
-
 timeout=30
 interval=5
 while ! hostnamectl  |grep Transient ; do

--- a/cluster-provision/k8s/1.20/node01.sh
+++ b/cluster-provision/k8s/1.20/node01.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-# Ensure that hugepages are there
-cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
-
 timeout=30
 interval=5
 while ! hostnamectl  |grep Transient ; do

--- a/cluster-provision/k8s/1.20/nodes.sh
+++ b/cluster-provision/k8s/1.20/nodes.sh
@@ -4,9 +4,6 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
-# Ensure that hugepages are there
-cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
-
 timeout=30
 interval=5
 while ! hostnamectl  |grep Transient ; do

--- a/cluster-provision/k8s/1.21/node01.sh
+++ b/cluster-provision/k8s/1.21/node01.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-# Ensure that hugepages are there
-cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
-
 timeout=30
 interval=5
 while ! hostnamectl  |grep Transient ; do

--- a/cluster-provision/k8s/1.21/nodes.sh
+++ b/cluster-provision/k8s/1.21/nodes.sh
@@ -4,9 +4,6 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
-# Ensure that hugepages are there
-cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
-
 timeout=30
 interval=5
 while ! hostnamectl  |grep Transient ; do

--- a/cluster-provision/k8s/1.22/node01.sh
+++ b/cluster-provision/k8s/1.22/node01.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-# Ensure that hugepages are there
-cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
-
 timeout=30
 interval=5
 while ! hostnamectl  |grep Transient ; do

--- a/cluster-provision/k8s/1.22/nodes.sh
+++ b/cluster-provision/k8s/1.22/nodes.sh
@@ -4,9 +4,6 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
-# Ensure that hugepages are there
-cat /proc/meminfo | sed -e "s/ //g" | grep "HugePages_Total:64"
-
 timeout=30
 interval=5
 while ! hostnamectl  |grep Transient ; do

--- a/cluster-provision/k8s/1.22/realtime.sh
+++ b/cluster-provision/k8s/1.22/realtime.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -xe
+
+echo kernel.sched_rt_runtime_us=-1 > /etc/sysctl.d/realtime.conf
+sysctl --system

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -121,7 +121,13 @@ function _add_common_params() {
             params=" --enable-grafana $params"
         fi
     fi
+    if [ -n "$KUBEVIRT_HUGEPAGES_COUNT" ]; then
+        params=" --hugepages-count $KUBEVIRT_HUGEPAGES_COUNT $params"
+    fi
 
+    if [ -n "$KUBEVIRT_REALTIME_SCHEDULER" ]; then
+        params=" --enable-realtime-scheduler $params"
+    fi
     echo $params
 }
 


### PR DESCRIPTION
This PR allows to define the amount of hugepages to be passed on to the kernel. The current implementation has the value hardcoded to 64 pages, which translate into 128Mi per node. This change is required to successfully boot up the fedora container disk used in the realtime functional tests in kubevirt, since the kernel is unable to boot with the 128Mi available in any node.

This PR adds 3 new flags to the `gocli run` cmd:
*  `hugepages-count`: Determines the number of hugepages to create. Defaults to 64. The value of this flag is captured via the environment variable `KUBEVIRT_HUGEPAGES_COUNT`
* `hugepages-2m`: When enabled, it uses `2M` page sizes. Defaults to true.
* `enable-realtime-scheduler`: When enabled, it configures each node to allow processes to be scheduled in realtime without time constrains by running the command: `sysctl kernel.sched_rt_runtime_us=-1`. Without this change, it is not possible to change the scheduling of the VM to use type FIFO and set the process priority to 1. The value of this flag is captured via the environment variable `KUBEVIRT_REALTIME_SCHEDULER`

/cc @vladikr @rmohr @davidvossel @pkliczewski 
