### PR TITLE
Improve PodPreset enablement validation

### DIFF
--- a/cluster-up/cluster/kind/podpreset.sh
+++ b/cluster-up/cluster/kind/podpreset.sh
@@ -1,10 +1,10 @@
  #!/usr/bin/env bash
 
-set -e
+set -ex
 
 source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
 
-VALIDATE_PODPRESET_TIMEOUT="60"
+VALIDATE_PODPRESET_TIMEOUT="3m"
 
 function podpreset::enable_admission_plugin() {
     local -r cluster_name=$1
@@ -20,7 +20,7 @@ function podpreset::validate_admission_plugin_is_enabled() {
     local -r wait_time=$2
     local -r control_plane_container="$cluster_name-control-plane"
 
-    if ! timeout "${wait_time}s" bash <<EOT
+    if ! timeout "${wait_time}" bash <<EOT
 function is_admission_plugin_enabled() {
     docker top $control_plane_container |
         grep -Po "kube-apiserver.*--enable-admission-plugins=.*\KPodPreset"


### PR DESCRIPTION
Kubevirt SRIOV and GPU lanes fails more often during cluster-up due to 
PodPreset enablement failures [link](https://search.ci.kubevirt.io/?search=FATAL%3A+failed+to+enable+PodPreset+admission+plugin&maxAge=336h&context=1&type=all&name=.*sriov%7C.*vgpu&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)

This PR intent is to improve how we validate that PodPreset is enabled in order
to prevent such failures:
- Increase validation timeout
  It seems that when kube-apiserver is under pressure it takes 
  more than 60 seconds for new configurations to propagate.

- Wait for kube-system pods to be ready
   PodPreset is enabled changing by changing kube-apiserver pod
   manifest, which when changed triggers kube-system pods to restart
   along with the kube-apiserver pod.