### PR TITLE
Use calico images from Quay

### DIFF
--- a/cluster-provision/k8s/1.19/manifests/cni.diff
+++ b/cluster-provision/k8s/1.19/manifests/cni.diff
@@ -14,6 +14,42 @@
            },
            "policy": {
                "type": "k8s"
+@@ -3533,7 +3538,7 @@ spec:
+         # It can be deleted if this is a fresh installation, or if you have already
+         # upgraded to use calico-ipam.
+         - name: upgrade-ipam
+-          image: docker.io/calico/cni:v3.18.0
++          image: quay.io/calico/cni:v3.18.0
+           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+           envFrom:
+           - configMapRef:
+@@ -3560,7 +3565,7 @@ spec:
+         # This container installs the CNI binaries
+         # and CNI network config file on each node.
+         - name: install-cni
+-          image: docker.io/calico/cni:v3.18.0
++          image: quay.io/calico/cni:v3.18.0
+           command: ["/opt/cni/bin/install"]
+           envFrom:
+           - configMapRef:
+@@ -3601,7 +3606,7 @@ spec:
+         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
+         # to communicate with Felix over the Policy Sync API.
+         - name: flexvol-driver
+-          image: docker.io/calico/pod2daemon-flexvol:v3.18.0
++          image: quay.io/calico/pod2daemon-flexvol:v3.18.0
+           volumeMounts:
+           - name: flexvol-driver-host
+             mountPath: /host/driver
+@@ -3612,7 +3617,7 @@ spec:
+         # container programs network policy and routes on each
+         # host.
+         - name: calico-node
+-          image: docker.io/calico/node:v3.18.0
++          image: quay.io/calico/node:v3.18.0
+           envFrom:
+           - configMapRef:
+               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
 @@ -3671,6 +3676,8 @@ spec:
              # no effect. This should fall within `--cluster-cidr`.
              # - name: CALICO_IPV4POOL_CIDR
@@ -39,7 +75,7 @@
            securityContext:
              privileged: true
            resources:
-@@ -3820,6 +3829,9 @@ spec:
+@@ -3820,9 +3829,12 @@ spec:
            effect: NoSchedule
        serviceAccountName: calico-kube-controllers
        priorityClassName: system-cluster-critical
@@ -48,4 +84,8 @@
 +          type: spc_t
        containers:
          - name: calico-kube-controllers
-           image: docker.io/calico/kube-controllers:v3.18.0
+-          image: docker.io/calico/kube-controllers:v3.18.0
++          image: quay.io/calico/kube-controllers:v3.18.0
+           env:
+             # Choose which controllers to run.
+             - name: ENABLED_CONTROLLERS

--- a/cluster-provision/k8s/1.20/manifests/cni.diff
+++ b/cluster-provision/k8s/1.20/manifests/cni.diff
@@ -14,6 +14,42 @@
            },
            "policy": {
                "type": "k8s"
+@@ -3533,7 +3538,7 @@ spec:
+         # It can be deleted if this is a fresh installation, or if you have already
+         # upgraded to use calico-ipam.
+         - name: upgrade-ipam
+-          image: docker.io/calico/cni:v3.18.0
++          image: quay.io/calico/cni:v3.18.0
+           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+           envFrom:
+           - configMapRef:
+@@ -3560,7 +3565,7 @@ spec:
+         # This container installs the CNI binaries
+         # and CNI network config file on each node.
+         - name: install-cni
+-          image: docker.io/calico/cni:v3.18.0
++          image: quay.io/calico/cni:v3.18.0
+           command: ["/opt/cni/bin/install"]
+           envFrom:
+           - configMapRef:
+@@ -3601,7 +3606,7 @@ spec:
+         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
+         # to communicate with Felix over the Policy Sync API.
+         - name: flexvol-driver
+-          image: docker.io/calico/pod2daemon-flexvol:v3.18.0
++          image: quay.io/calico/pod2daemon-flexvol:v3.18.0
+           volumeMounts:
+           - name: flexvol-driver-host
+             mountPath: /host/driver
+@@ -3612,7 +3617,7 @@ spec:
+         # container programs network policy and routes on each
+         # host.
+         - name: calico-node
+-          image: docker.io/calico/node:v3.18.0
++          image: quay.io/calico/node:v3.18.0
+           envFrom:
+           - configMapRef:
+               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
 @@ -3671,6 +3676,8 @@ spec:
              # no effect. This should fall within `--cluster-cidr`.
              # - name: CALICO_IPV4POOL_CIDR
@@ -39,7 +75,7 @@
            securityContext:
              privileged: true
            resources:
-@@ -3820,6 +3829,9 @@ spec:
+@@ -3820,9 +3829,12 @@ spec:
            effect: NoSchedule
        serviceAccountName: calico-kube-controllers
        priorityClassName: system-cluster-critical
@@ -48,4 +84,8 @@
 +          type: spc_t
        containers:
          - name: calico-kube-controllers
-           image: docker.io/calico/kube-controllers:v3.18.0
+-          image: docker.io/calico/kube-controllers:v3.18.0
++          image: quay.io/calico/kube-controllers:v3.18.0
+           env:
+             # Choose which controllers to run.
+             - name: ENABLED_CONTROLLERS

--- a/cluster-provision/k8s/1.21/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.21/extra-pre-pull-images
@@ -5,3 +5,7 @@ docker.io/istio/operator:1.10.0
 docker.io/istio/pilot:1.10.0
 docker.io/istio/proxyv2:1.10.0
 quay.io/prometheus-operator/prometheus-config-reloader:v0.47.0
+quay.io/calico/cni:v3.18.0
+quay.io/calico/kube-controllers:v3.18.0
+quay.io/calico/node:v3.18.0
+quay.io/calico/pod2daemon-flexvol:v3.18.0

--- a/cluster-provision/k8s/1.21/manifests/cni.diff
+++ b/cluster-provision/k8s/1.21/manifests/cni.diff
@@ -14,6 +14,42 @@
            },
            "policy": {
                "type": "k8s"
+@@ -3533,7 +3538,7 @@ spec:
+         # It can be deleted if this is a fresh installation, or if you have already
+         # upgraded to use calico-ipam.
+         - name: upgrade-ipam
+-          image: docker.io/calico/cni:v3.18.0
++          image: quay.io/calico/cni:v3.18.0
+           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+           envFrom:
+           - configMapRef:
+@@ -3560,7 +3565,7 @@ spec:
+         # This container installs the CNI binaries
+         # and CNI network config file on each node.
+         - name: install-cni
+-          image: docker.io/calico/cni:v3.18.0
++          image: quay.io/calico/cni:v3.18.0
+           command: ["/opt/cni/bin/install"]
+           envFrom:
+           - configMapRef:
+@@ -3601,7 +3606,7 @@ spec:
+         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
+         # to communicate with Felix over the Policy Sync API.
+         - name: flexvol-driver
+-          image: docker.io/calico/pod2daemon-flexvol:v3.18.0
++          image: quay.io/calico/pod2daemon-flexvol:v3.18.0
+           volumeMounts:
+           - name: flexvol-driver-host
+             mountPath: /host/driver
+@@ -3612,7 +3617,7 @@ spec:
+         # container programs network policy and routes on each
+         # host.
+         - name: calico-node
+-          image: docker.io/calico/node:v3.18.0
++          image: quay.io/calico/node:v3.18.0
+           envFrom:
+           - configMapRef:
+               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
 @@ -3671,6 +3676,8 @@ spec:
              # no effect. This should fall within `--cluster-cidr`.
              # - name: CALICO_IPV4POOL_CIDR
@@ -39,7 +75,7 @@
            securityContext:
              privileged: true
            resources:
-@@ -3820,6 +3829,9 @@ spec:
+@@ -3820,9 +3829,12 @@ spec:
            effect: NoSchedule
        serviceAccountName: calico-kube-controllers
        priorityClassName: system-cluster-critical
@@ -48,4 +84,8 @@
 +          type: spc_t
        containers:
          - name: calico-kube-controllers
-           image: docker.io/calico/kube-controllers:v3.18.0
+-          image: docker.io/calico/kube-controllers:v3.18.0
++          image: quay.io/calico/kube-controllers:v3.18.0
+           env:
+             # Choose which controllers to run.
+             - name: ENABLED_CONTROLLERS

--- a/cluster-provision/k8s/1.22/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.22/extra-pre-pull-images
@@ -5,3 +5,7 @@ docker.io/istio/operator:1.10.0
 docker.io/istio/pilot:1.10.0
 docker.io/istio/proxyv2:1.10.0
 quay.io/prometheus-operator/prometheus-config-reloader:v0.47.0
+quay.io/calico/cni:v3.18.0
+quay.io/calico/kube-controllers:v3.18.0
+quay.io/calico/node:v3.18.0
+quay.io/calico/pod2daemon-flexvol:v3.18.0

--- a/cluster-provision/k8s/1.22/manifests/cni.diff
+++ b/cluster-provision/k8s/1.22/manifests/cni.diff
@@ -14,6 +14,42 @@
            },
            "policy": {
                "type": "k8s"
+@@ -3533,7 +3538,7 @@ spec:
+         # It can be deleted if this is a fresh installation, or if you have already
+         # upgraded to use calico-ipam.
+         - name: upgrade-ipam
+-          image: docker.io/calico/cni:v3.18.0
++          image: quay.io/calico/cni:v3.18.0
+           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+           envFrom:
+           - configMapRef:
+@@ -3560,7 +3565,7 @@ spec:
+         # This container installs the CNI binaries
+         # and CNI network config file on each node.
+         - name: install-cni
+-          image: docker.io/calico/cni:v3.18.0
++          image: quay.io/calico/cni:v3.18.0
+           command: ["/opt/cni/bin/install"]
+           envFrom:
+           - configMapRef:
+@@ -3601,7 +3606,7 @@ spec:
+         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
+         # to communicate with Felix over the Policy Sync API.
+         - name: flexvol-driver
+-          image: docker.io/calico/pod2daemon-flexvol:v3.18.0
++          image: quay.io/calico/pod2daemon-flexvol:v3.18.0
+           volumeMounts:
+           - name: flexvol-driver-host
+             mountPath: /host/driver
+@@ -3612,7 +3617,7 @@ spec:
+         # container programs network policy and routes on each
+         # host.
+         - name: calico-node
+-          image: docker.io/calico/node:v3.18.0
++          image: quay.io/calico/node:v3.18.0
+           envFrom:
+           - configMapRef:
+               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
 @@ -3671,6 +3676,8 @@ spec:
              # no effect. This should fall within `--cluster-cidr`.
              # - name: CALICO_IPV4POOL_CIDR
@@ -39,7 +75,7 @@
            securityContext:
              privileged: true
            resources:
-@@ -3820,6 +3829,9 @@ spec:
+@@ -3820,9 +3829,12 @@ spec:
            effect: NoSchedule
        serviceAccountName: calico-kube-controllers
        priorityClassName: system-cluster-critical
@@ -48,4 +84,8 @@
 +          type: spc_t
        containers:
          - name: calico-kube-controllers
-           image: docker.io/calico/kube-controllers:v3.18.0
+-          image: docker.io/calico/kube-controllers:v3.18.0
++          image: quay.io/calico/kube-controllers:v3.18.0
+           env:
+             # Choose which controllers to run.
+             - name: ENABLED_CONTROLLERS


### PR DESCRIPTION
Will prevent rate limit errors from Docker Hub like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirtci/1440042970488246272

/cc @dhiller @qinqon 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>