### PR TITLE
Move logic to enable realtime scheduling on all nodes

### DIFF
--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -618,6 +618,20 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			}
 		}
 
+		if realtimeSchedulingEnabled {
+			success, err := docker.Exec(cli, nodeContainer(prefix, nodeName), []string{
+				"/bin/bash",
+				"-c",
+				"ssh.sh sudo /bin/bash < /scripts/realtime.sh",
+			}, os.Stdout)
+			if err != nil {
+				return err
+			}
+			if !success {
+				return errors.New("provisioning kernel to allow unlimited runtime realtime scheduler failed")
+			}
+		}
+
 		//check if we have a special provision script
 		success, err = docker.Exec(cli, nodeContainer(prefix, nodeName), []string{"/bin/bash", "-c", fmt.Sprintf("test -f /scripts/%s.sh", nodeName)}, os.Stdout)
 		if err != nil {
@@ -732,20 +746,6 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		}
 	}
 
-	if realtimeSchedulingEnabled {
-		nodeName := nodeNameFromIndex(1)
-		success, err := docker.Exec(cli, nodeContainer(prefix, nodeName), []string{
-			"/bin/bash",
-			"-c",
-			"ssh.sh sudo /bin/bash < /scripts/realtime.sh",
-		}, os.Stdout)
-		if err != nil {
-			return err
-		}
-		if !success {
-			return errors.New("provisioning kernel to allow unlimited runtime realtime scheduler failed")
-		}
-	}
 	// If background flag was specified, we don't want to clean up if we reach that state
 	if !background {
 		wg.Wait()


### PR DESCRIPTION
This PR migrates the logic that allows for processes in a node to run with realtime scheduling (FIFO and priority 1) with unlimited time, to all nodes instead of just the control-plane node (node01) as it currently does.

@jean-edouard @vladikr @rmohr can you please take a look at this PR? 

/Jordi