### PR TITLE
rename env var for hugepages count

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -121,8 +121,8 @@ function _add_common_params() {
             params=" --enable-grafana $params"
         fi
     fi
-    if [ -n "$KUBEVIRT_HUGEPAGES_2M" ]; then
-        params=" --hugepages-2m $KUBEVIRT_HUGEPAGES_2M $params"
+    if [ -n "$KUBEVIRT_HUGEPAGES2M_COUNT" ]; then
+        params=" --hugepages-2m $KUBEVIRT_HUGEPAGES2M_COUNT $params"
     fi
 
     if [ -n "$KUBEVIRT_REALTIME_SCHEDULER" ]; then


### PR DESCRIPTION
Renames the environment variable to define the number of hugepages to allocate to be more meaningful with its purpose:
`KUBEVIRT_HUGEPAGES_2M` -> `KUBEVIRT_HUGEPAGES2M_COUNT`

@rmohr @vladikr can you take a look? I forgot to rename the variable in my last PR.