### PR TITLE
Fix container disk create script to run in a prow job

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-realtime/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-realtime/cloud-config
@@ -35,17 +35,18 @@ write_files:
           [Install]
           WantedBy=cloud-init.service
 runcmd:
-  - sudo systemctl daemon-reload
+  - sudo -i
+  - systemctl daemon-reload
   - export FEDORA_VERSION=$(cat /etc/redhat-release |awk '{print $3}')
-  - sudo -E dnf install -y http://ccrma.stanford.edu/planetccrma/mirror/fedora/linux/planetccrma/$FEDORA_VERSION/x86_64/planetccrma-repo-1.1-3.fc$FEDORA_VERSION.ccrma.noarch.rpm
-  - sudo dnf install -y kernel-rt tuned-profiles-realtime realtime-tests
-  - sudo grubby --set-default=$(ls /boot/vmlinuz-*rt*)
-  - sudo echo -e "isolated_cores=0,1\nisolate_managed_irq=Y" >/etc/tuned/realtime-variables.conf
-  - sudo dnf clean all
-  - sudo systemctl enable wait-for-cloud-init
-  - sudo systemctl enable qemu-guest-agent.service
-  - sudo hostnamectl set-hostname ""
-  - sudo hostnamectl set-hostname "" --transient
-  - sudo sed -i /users-groups/d /etc/cloud/cloud.cfg
-  - sudo sed -i 's/^SELINUX=.*/SELINUX=permissive/' /etc/selinux/config
-  - sudo shutdown
+  - dnf install -y http://ccrma.stanford.edu/planetccrma/mirror/fedora/linux/planetccrma/$FEDORA_VERSION/x86_64/planetccrma-repo-1.1-3.fc$FEDORA_VERSION.ccrma.noarch.rpm
+  - dnf install -y kernel-rt tuned-profiles-realtime realtime-tests
+  - grubby --set-default=$(ls /boot/vmlinuz-*rt*)
+  - grub2-mkconfig -o /boot/grub2/grub.cfg
+  - echo -e "isolated_cores=0,1\nisolate_managed_irq=Y" >/etc/tuned/realtime-variables.conf
+  - dnf clean all
+  - systemctl enable wait-for-cloud-init
+  - hostnamectl set-hostname ""
+  - hostnamectl set-hostname "" --transient
+  - sed -i /users-groups/d /etc/cloud/cloud.cfg
+  - sed -i 's/^SELINUX=.*/SELINUX=permissive/' /etc/selinux/config
+  - shutdown


### PR DESCRIPTION
This PR adds a waiting condition right after the `virt-install` command is triggered before it continues with the execution in the `customize-image.sh` script. 

The wait condition is needed when running this script as part of a prow job because the `virt-install` [command fails to attach to the VM's console](https://storage.googleapis.com/kubevirt-prow/logs/publish-fedora-realtime-container-image/1443601489757999104/build-log.txt) and reverts to running in the background. 

```
+ virt-install --memory 2048 --vcpus 2 --name provision-vm --disk fedora-realtime_build/copy-source-image.qcow2,device=disk --disk cloudinit.iso,device=cdrom --os-type Linux --os-variant fedora32 --virt-type kvm --graphics none --network default --import
error: Cannot run interactive console without a controlling TTY
```

Since the script was designed to expect the command to hang in the install process while executing, the script resumes the execution considering the installation command as completed, long before it is done.

You can test the behaviour in your local environment by using this additional flag option in `virt-install`:
```
  --autoconsole none
```

Using this flag, it will render an output similar to [this](https://storage.googleapis.com/kubevirt-prow/logs/publish-fedora-realtime-container-image/1446485605511860224/build-log.txt):
```
Customize image by booting a VM with
 the image and cloud-init disk
 press ctrl+] to exit
+ virt-install --memory 2048 --vcpus 2 --name provision-vm --disk fedora-realtime_build/copy-source-image.qcow2,device=disk --disk cloudinit.iso,device=cdrom --os-type Linux --os-variant fedora32 --virt-type kvm --graphics none --network default --import
error: Cannot run interactive console without a controlling TTY


Starting install...
Domain creation completed.
+ wait_for_install_to_complete
+ count=0
+ retries=100
++ virsh list --state-running --name
++ grep provision-vm
+ [[ provision-vm == '' ]]
+ [[ 0 -gt 100 ]]
+ sleep 5
...
...
++ virsh list --state-running --name
++ grep provision-vm
+ [[ provision-vm == '' ]]
+ [[ 35 -gt 100 ]]
+ sleep 5
+ count=36
++ virsh list --state-running --name
++ grep provision-vm
+ [[ '' == '' ]]
+ [[ 36 -gt 100 ]]
+ echo done
done
+ virsh destroy provision-vm
error: Failed to destroy domain provision-vm
error: Requested operation is not valid: domain is not running

+ true
+ virt-sysprep -d provision-vm --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr
[   0.0] Examining the guest ...
...
...
+ virsh undefine provision-vm
Domain 'provision-vm' has been undefined

+ qemu-img convert -c -O qcow2 fedora-realtime_build/copy-source-image.qcow2 fedora-realtime_build/provisioned-image.qcow2
+ cleanup
...
...
+ FULL_IMAGE_NAME=quay.io/kubevirt/fedora-realtime-container-disk:v20211008-22109a3
+ docker tag fedora-realtime:devel quay.io/kubevirt/fedora-realtime-container-disk:v20211008-22109a3
+ docker push quay.io/kubevirt/fedora-realtime-container-disk:v20211008-22109a3
```

@dhiller @fgimenez can you take a look? If you're OK with the changes, can you trigger the job to generate the fedora-realtime container disk? I'll test the generated image to see if it fixed the issue. 
