### PR TITLE
Add setup to emulate SCSI devices

### DIFF
--- a/cluster-provision/centos8/scripts/vm.sh
+++ b/cluster-provision/centos8/scripts/vm.sh
@@ -21,6 +21,7 @@ while true; do
     -b | --block-device ) BLOCK_DEV="$2"; shift 2 ;;
     -s | --block-device-size ) BLOCK_DEV_SIZE="$2"; shift 2 ;;
     -n | --nvme-device-size ) NVME_DISK_SIZES+="$2 "; shift 2 ;;
+    -t | --scsi-device-size ) SCSI_DISK_SIZES+="$2 "; shift 2 ;;
     -- ) shift; break ;;
     * ) break ;;
   esac
@@ -113,6 +114,14 @@ disk_num=0
 for size in ${NVME_DISK_SIZES[@]}; do
   echo "Creating disk "$size" for NVMe disk emulation"
   disk="/nvme-"${disk_num}".img"
+  qemu-img create -f raw $disk $size
+  let "disk_num+=1"
+done
+
+disk_num=0
+for size in ${SCSI_DISK_SIZES[@]}; do
+  echo "Creating disk "$size" for SCSI disk emulation"
+  disk="/scsi-"${disk_num}".img"
   qemu-img create -f raw $disk $size
   let "disk_num+=1"
 done


### PR DESCRIPTION
Use emulated scsi devices in the provisioned nodes for development and testing.

Set the variable KUBEVIRT_PROVIDER_EXTRA_ARGS="--scsi 1G" for creating a SCSI disk during the node creation.

This PR adds a similar setup for SCSI devices like  #672 for NVMe devices.
Example
```bash
$ export KUBEVIRT_PROVIDER_EXTRA_ARGS="--scsi 1G" 
$ make cluster-up
[...]
$ cluster-up/ssh.sh node01
WARNING: KUBEVIRTCI_GOCLI_CONTAINER is set and will take precedence over the also set KUBEVIRTCI_TAG
selecting docker as container runtime
2021/10/12 10:08:26 Waiting for host: 192.168.66.101:22
2021/10/12 10:08:26 Connected to tcp://192.168.66.101:22
$ lsscsi
[0:0:0:0]    disk    QEMU     QEMU HARDDISK    2.5+  /dev/sda
$ lsblk /dev/sda 
NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
sda    8:0    0   1G  0 disk 
```