### PR TITLE
Do not double mount /lib/modules for kind

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -222,9 +222,6 @@ function _add_worker_extra_mounts() {
     if [[ "$KUBEVIRT_PROVIDER" =~ sriov.* || "$KUBEVIRT_PROVIDER" =~ vgpu.* ]]; then
         cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
   extraMounts:
-  - containerPath: /lib/modules
-    hostPath: /lib/modules
-    readOnly: true
   - containerPath: /dev/vfio/
     hostPath: /dev/vfio/
 EOF


### PR DESCRIPTION
Kind by default mounts `/lib/modules`, here for docker https://github.com/kubernetes-sigs/kind/blob/a3076d6118bb01a65bc06839b4f7b98ee92ed139/pkg/cluster/internal/providers/docker/provision.go#L236 and here for podman https://github.com/kubernetes-sigs/kind/blob/a3076d6118bb01a65bc06839b4f7b98ee92ed139/pkg/cluster/internal/providers/podman/provision.go#L199. When running kind we were instructing the CRI to mount /lib/modules, this was ok for docker but podman complains about double mounts like here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.19-sriov/1447596047848181760#1:build-log.txt%3A443

These changes remove the unnecessary configuration to mount `/lib/modules` (it is already done by default anyway).

/cc @ormergi @oshoval @dhiller  

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>