### PR TITLE
ks8-1.22, provision:add podSecurity feature

### DIFF
--- a/cluster-provision/k8s/1.22/provision.sh
+++ b/cluster-provision/k8s/1.22/provision.sh
@@ -17,7 +17,7 @@ cat << EOF > $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
 #!/bin/bash
 set -ex
 export KUBELET_CGROUP_ARGS="--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice"
-export KUBELET_FEATURE_GATES="IPv6DualStack=true"
+export KUBELET_FEATURE_GATES="IPv6DualStack=true,PodSecurity=true"
 export ISTIO_VERSION=1.10.0
 export ISTIO_BIN_DIR=/opt/istio-$ISTIO_VERSION/bin
 EOF


### PR DESCRIPTION
podSecurity feature allows to enorce pod security standarts[1]
as an admission controller. In order to properly test this with
a kubevirtCi cluster this has to be enabled.

This commit adds this feature to the 1.22 lane.(the feature is only
available since 1.22)

This feature takes affect on the namesapce level, on namespaces that
are labeled with: `pod-security.kubernetes.io/<MODE>: <LEVEL>`.
So this change should have no side effects on tests that don't explicitly
ask for it.

Signed-off-by: alonsadan <asadan@redhat.com>