### PR TITLE
Add registry volume during provision

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -72,7 +72,7 @@ function _registry_volume() {
 
 function _add_common_params() {
     # shellcheck disable=SC2155
-    local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 6 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) ${KUBEVIRT_PROVIDER} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
+    local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 6 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --random-ports --background --prefix $provider_prefix ${KUBEVIRT_PROVIDER} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
     if [[ $TARGET =~ windows_sysprep.* ]] && [ -n "$WINDOWS_SYSPREP_NFS_DIR" ]; then
         params=" --nfs-data $WINDOWS_SYSPREP_NFS_DIR $params"
     elif [[ $TARGET =~ windows.* ]] && [ -n "$WINDOWS_NFS_DIR" ]; then


### PR DESCRIPTION
Will prevent errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.21-sig-network/1458811162673025024#1:build-log.txt%3A789, using podman as the container runtime makes the registry volume being mounted as readonly, this is the result of an inspect on the container created with the current version of gocli:
```
"Mounts": [
            {
                "Type": "volume",
                "Name": "k8s-1.20-registry",
                "Source": "/var/lib/containers/storage/volumes/k8s-1.20-registry/_data",
                "Destination": "/var/lib/registry",
                "Driver": "local",
                "Mode": "",
                "Options": [
                    "nosuid",
                    "nodev",
                    "rbind"
                ],
                "RW": false,
                "Propagation": "rprivate"
            }
        ],
``` 
Using a bind mount instead gives:
```
"Mounts": [
            {
                "Type": "bind",
                "Source": "/tmp/kubevirt_registry",
                "Destination": "/var/lib/registry",
                "Driver": "",
                "Mode": "",
                "Options": [
                    "rbind"
                ],
                "RW": true,
                "Propagation": "rprivate"
            }
        ],
``` 

/cc @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>