### PR TITLE
Clean up and fix errors in the centos8 `vm.sh` script

### DIFF
--- a/cluster-provision/centos8/scripts/vm.sh
+++ b/cluster-provision/centos8/scripts/vm.sh
@@ -12,36 +12,66 @@ BLOCK_DEV=""
 BLOCK_DEV_SIZE=""
 
 while true; do
-  case "$1" in
-    -m | --memory ) MEMORY="$2"; shift 2 ;;
-    -c | --cpu ) CPU="$2"; shift 2 ;;
-    -q | --qemu-args ) QEMU_ARGS="${2}"; shift 2 ;;
-    -k | --additional-kernel-args ) KERNEL_ARGS="${2}"; shift 2 ;;
-    -n | --next-disk ) NEXT_DISK="$2"; shift 2 ;;
-    -b | --block-device ) BLOCK_DEV="$2"; shift 2 ;;
-    -s | --block-device-size ) BLOCK_DEV_SIZE="$2"; shift 2 ;;
-    -n | --nvme-device-size ) NVME_DISK_SIZES+="$2 "; shift 2 ;;
-    -t | --scsi-device-size ) SCSI_DISK_SIZES+="$2 "; shift 2 ;;
-    -- ) shift; break ;;
-    * ) break ;;
-  esac
+    case "$1" in
+    -m | --memory)
+        MEMORY="$2"
+        shift 2
+        ;;
+    -c | --cpu)
+        CPU="$2"
+        shift 2
+        ;;
+    -q | --qemu-args)
+        QEMU_ARGS="${2}"
+        shift 2
+        ;;
+    -k | --additional-kernel-args)
+        KERNEL_ARGS="${2}"
+        shift 2
+        ;;
+    -n | --next-disk)
+        NEXT_DISK="$2"
+        shift 2
+        ;;
+    -b | --block-device)
+        BLOCK_DEV="$2"
+        shift 2
+        ;;
+    -s | --block-device-size)
+        BLOCK_DEV_SIZE="$2"
+        shift 2
+        ;;
+    -n | --nvme-device-size)
+        NVME_DISK_SIZES+="$2 "
+        shift 2
+        ;;
+    -t | --scsi-device-size)
+        SCSI_DISK_SIZES+="$2 "
+        shift 2
+        ;;
+    --)
+        shift
+        break
+        ;;
+    *) break ;;
+    esac
 done
 
-function calc_next_disk {
-  last="$(ls -t disk* | head -1 | sed -e 's/disk//' -e 's/.qcow2//')"
-  last="${last:-00}"
-  next=$((last+1))
-  next=$(printf "/disk%02d.qcow2" $next)
-  if [ -n "$NEXT_DISK" ]; then next=${NEXT_DISK}; fi
-  if [ "$last" = "00" ]; then
-    last="box.qcow2"
-  else
-    last=$(printf "/disk%02d.qcow2" $last)
-  fi
+function calc_next_disk() {
+    last="$(ls -t disk* | head -1 | sed -e 's/disk//' -e 's/.qcow2//')"
+    last="${last:-00}"
+    next=$((last + 1))
+    next=$(printf "/disk%02d.qcow2" $next)
+    if [ -n "$NEXT_DISK" ]; then next=${NEXT_DISK}; fi
+    if [ "$last" = "00" ]; then
+        last="box.qcow2"
+    else
+        last=$(printf "/disk%02d.qcow2" $last)
+    fi
 }
 
 NODE_NUM=${NODE_NUM-1}
-n="$(printf "%02d" $(( 10#${NODE_NUM} )))"
+n="$(printf "%02d" $((10#${NODE_NUM})))"
 
 cat >/usr/local/bin/ssh.sh <<EOL
 #!/bin/bash
@@ -54,8 +84,8 @@ echo "done" >/ssh_ready
 
 sleep 0.1
 until ip link show tap${n}; do
-  echo "Waiting for tap${n} to become ready"
-  sleep 0.1
+    echo "Waiting for tap${n} to become ready"
+    sleep 0.1
 done
 
 # Route SSH
@@ -64,15 +94,15 @@ iptables -A FORWARD --in-interface eth0 -j ACCEPT
 iptables -t nat -A PREROUTING -p tcp -i eth0 -m tcp --dport 22${n} -j DNAT --to-destination 192.168.66.1${n}:22
 
 # Route ports from container to VM for first node
-if [ "$n" = "01" ] ; then
-  for port in 6443 8443 80 443 30007 30008 31001; do
-    iptables -t nat -A PREROUTING -p tcp -i eth0 -m tcp --dport ${port} -j DNAT --to-destination 192.168.66.1${n}:${port}
-  done
+if [ "$n" = "01" ]; then
+    for port in 6443 8443 80 443 30007 30008 31001; do
+        iptables -t nat -A PREROUTING -p tcp -i eth0 -m tcp --dport ${port} -j DNAT --to-destination 192.168.66.1${n}:${port}
+    done
 fi
 
 # For backward compatibility, so that we can just copy over the newer files
 if [ -f provisioned.qcow2 ]; then
-  ln -sf provisioned.qcow2 disk01.qcow2
+    ln -sf provisioned.qcow2 disk01.qcow2
 fi
 
 calc_next_disk
@@ -95,7 +125,7 @@ echo "VM hostname will be node${n}"
 
 # Try to create /dev/kvm if it does not exist
 if [ ! -e /dev/kvm ]; then
-   mknod /dev/kvm c 10 $(grep '\<kvm\>' /proc/misc | cut -f 1 -d' ')
+    mknod /dev/kvm c 10 $(grep '\<kvm\>' /proc/misc | cut -f 1 -d' ')
 fi
 
 # Prevent the emulated soundcard from messing with host sound
@@ -104,37 +134,37 @@ export QEMU_AUDIO_DRV=none
 block_dev_arg=""
 
 if [ -n "${BLOCK_DEV}" ]; then
-  # 10Gi default
-  block_device_size="${BLOCK_DEV_SIZE:-10737418240}"
-  qemu-img create -f qcow2 ${BLOCK_DEV} ${block_device_size}
-  block_dev_arg="-drive format=qcow2,file=${BLOCK_DEV},if=virtio,cache=unsafe"
+    # 10Gi default
+    block_device_size="${BLOCK_DEV_SIZE:-10737418240}"
+    qemu-img create -f qcow2 ${BLOCK_DEV} ${block_device_size}
+    block_dev_arg="-drive format=qcow2,file=${BLOCK_DEV},if=virtio,cache=unsafe"
 fi
 
 disk_num=0
 for size in ${NVME_DISK_SIZES[@]}; do
-  echo "Creating disk "$size" for NVMe disk emulation"
-  disk="/nvme-"${disk_num}".img"
-  qemu-img create -f raw $disk $size
-  let "disk_num+=1"
+    echo "Creating disk "$size" for NVMe disk emulation"
+    disk="/nvme-"${disk_num}".img"
+    qemu-img create -f raw $disk $size
+    let "disk_num+=1"
 done
 
 disk_num=0
 for size in ${SCSI_DISK_SIZES[@]}; do
-  echo "Creating disk "$size" for SCSI disk emulation"
-  disk="/scsi-"${disk_num}".img"
-  qemu-img create -f raw $disk $size
-  let "disk_num+=1"
+    echo "Creating disk "$size" for SCSI disk emulation"
+    disk="/scsi-"${disk_num}".img"
+    qemu-img create -f raw $disk $size
+    let "disk_num+=1"
 done
 
 exec qemu-system-x86_64 -enable-kvm -drive format=qcow2,file=${next},if=virtio,cache=unsafe ${block_dev_arg} \
-  -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n} \
-  -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
-  -device virtio-rng-pci \
-  -initrd /initrd.img \
-  -kernel /vmlinuz \
-  -append "$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}" \
-  -vnc :${n} -cpu host,migratable=no,+invtsc -m ${MEMORY} -smp ${CPU} \
-  -serial pty -M q35,accel=kvm,kernel_irqchip=split \
-  -device intel-iommu,intremap=on,caching-mode=on -soundhw hda \
-  -uuid $(cat /proc/sys/kernel/random/uuid) \
-  ${QEMU_ARGS}
+    -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n} \
+    -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
+    -device virtio-rng-pci \
+    -initrd /initrd.img \
+    -kernel /vmlinuz \
+    -append "$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}" \
+    -vnc :${n} -cpu host,migratable=no,+invtsc -m ${MEMORY} -smp ${CPU} \
+    -serial pty -M q35,accel=kvm,kernel_irqchip=split \
+    -device intel-iommu,intremap=on,caching-mode=on -soundhw hda \
+    -uuid $(cat /proc/sys/kernel/random/uuid) \
+    ${QEMU_ARGS}


### PR DESCRIPTION
While working on fixing issues in the centos8 vm.sh script, I discovered that the current argument parsing is not supposed to work with short parameters (`-n` is used twice i.e.). Also the `NEXT_DISK` seems to be not used any more, at least I didn't find any hint on usage in the gocli.