### PR TITLE
Fix deploy-manifests by excluding ip-reconciler pod from ready check

### DIFF
--- a/cluster-provision/k8s/deploy-manifests.sh
+++ b/cluster-provision/k8s/deploy-manifests.sh
@@ -22,7 +22,9 @@ find "$DIR/${provision_dir}/manifests/" -type f -name '*.yaml' \
     -not -name 'local-volume.yaml' \
     -not -name 'cni*.yaml' \
     -not -name 'cdi*-cr.yaml' \
+    -not -name 'cdi*-operator.yaml' \
+    -not -name 'whereabouts-*.yaml' \
     -print -exec ${ksh} create -f {} \;
 
 # wait for pods to get ready (we do this repeatedly to give the pods created by the operators time to come up)
-timeout 300s bash -c "until ${ksh} wait --for=condition=Ready pod --timeout=60s --all --all-namespaces; do ${ksh} get pods --all-namespaces; sleep 10; done"
+timeout 300s bash -c "until ${ksh} wait --for=condition=Ready pod --timeout=60s --all --all-namespaces -l app!=whereabouts; do ${ksh} get pods --all-namespaces; sleep 10; done"


### PR DESCRIPTION
Also exclude cdi-operator manifest and whereabouts manifest from
deployment.

See https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/701/check-provision-k8s-1.21/1460291447184953344
for failures.

Signed-off-by: Daniel Hiller <dhiller@redhat.com>