### PR TITLE
k8s-1.2x, provision: mv original cni manifest

### DIFF
--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -46,7 +46,7 @@ mkdir -p /provision
 
 dnf install -y patch
 cni_manifest="/provision/cni.yaml"
-cp /tmp/cni.do-not-change.yaml $cni_manifest
+mv /tmp/cni.do-not-change.yaml $cni_manifest
 patch $cni_manifest /tmp/cni.diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml

--- a/cluster-provision/k8s/1.21/provision.sh
+++ b/cluster-provision/k8s/1.21/provision.sh
@@ -55,7 +55,7 @@ mkdir -p /provision
 
 dnf install -y patch
 cni_manifest="/provision/cni.yaml"
-cp /tmp/cni.do-not-change.yaml $cni_manifest
+mv /tmp/cni.do-not-change.yaml $cni_manifest
 patch $cni_manifest /tmp/cni.diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml

--- a/cluster-provision/k8s/1.22/provision.sh
+++ b/cluster-provision/k8s/1.22/provision.sh
@@ -55,7 +55,7 @@ mkdir -p /provision
 
 dnf install -y patch
 cni_manifest="/provision/cni.yaml"
-cp /tmp/cni.do-not-change.yaml $cni_manifest
+mv /tmp/cni.do-not-change.yaml $cni_manifest
 patch $cni_manifest /tmp/cni.diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml


### PR DESCRIPTION
Since fetch-images.sh runs on /tmp folder,
it will try to fetch images that we mirrored to quay
from their original image repository docker.io.

Once we move the original manifest before patching it
instead of copying it, it will not exist anymore in the
/tmp folder and won't cause for unneeded pull request
that might fail due to rate limit.

Signed-off-by: Or Shoval <oshoval@redhat.com>