### PR TITLE
SR-IOV cluster config: Print /dev/vfio mode

### DIFF
--- a/cluster-up/cluster/kind-1.19-sriov/sriov-node/node.sh
+++ b/cluster-up/cluster/kind-1.19-sriov/sriov-node/node.sh
@@ -60,11 +60,17 @@ function node::configure_sriov_pfs_and_vfs() {
     # KIND mounts sysfs as read-only by default, remount as R/W"
     node_exec="docker exec $node"
     $node_exec mount -o remount,rw /sys
+
+    ls_node_dev_vfio="${node_exec} ls -la -Z /dev/vfio"
+    $ls_node_dev_vfio
     $node_exec chmod 666 /dev/vfio/vfio
+    $ls_node_dev_vfio
+
 
     # Create and configure SRIOV Virtual Functions on SRIOV node
     docker cp "$CONFIGURE_VFS_SCRIPT_PATH" "$node:/"
     $node_exec bash -c "DRIVER=$VFS_DRIVER DRIVER_KMODULE=$VFS_DRIVER_KMODULE ./$config_vf_script"
+    $ls_node_dev_vfio
 
     _kubectl label node $node $SRIOV_NODE_LABEL
   done

--- a/cluster-up/cluster/kind-1.19-sriov/sriov-node/node.sh
+++ b/cluster-up/cluster/kind-1.19-sriov/sriov-node/node.sh
@@ -63,9 +63,8 @@ function node::configure_sriov_pfs_and_vfs() {
 
     ls_node_dev_vfio="${node_exec} ls -la -Z /dev/vfio"
     $ls_node_dev_vfio
-    $node_exec chmod 666 /dev/vfio/vfio
+    $node_exec chmod 0666 /dev/vfio/vfio
     $ls_node_dev_vfio
-
 
     # Create and configure SRIOV Virtual Functions on SRIOV node
     docker cp "$CONFIGURE_VFS_SCRIPT_PATH" "$node:/"

--- a/cluster-up/cluster/kind-1.22-sriov/sriov-node/node.sh
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-node/node.sh
@@ -60,11 +60,16 @@ function node::configure_sriov_pfs_and_vfs() {
     # KIND mounts sysfs as read-only by default, remount as R/W"
     node_exec="docker exec $node"
     $node_exec mount -o remount,rw /sys
+
+    ls_node_dev_vfio="${node_exec} ls -la -Z /dev/vfio"
+    $ls_node_dev_vfio
     $node_exec chmod 666 /dev/vfio/vfio
+    $ls_node_dev_vfio
 
     # Create and configure SRIOV Virtual Functions on SRIOV node
     docker cp "$CONFIGURE_VFS_SCRIPT_PATH" "$node:/"
     $node_exec bash -c "DRIVER=$VFS_DRIVER DRIVER_KMODULE=$VFS_DRIVER_KMODULE ./$config_vf_script"
+    $ls_node_dev_vfio
 
     _kubectl label node $node $SRIOV_NODE_LABEL
   done

--- a/cluster-up/cluster/kind-1.22-sriov/sriov-node/node.sh
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-node/node.sh
@@ -63,7 +63,7 @@ function node::configure_sriov_pfs_and_vfs() {
 
     ls_node_dev_vfio="${node_exec} ls -la -Z /dev/vfio"
     $ls_node_dev_vfio
-    $node_exec chmod 666 /dev/vfio/vfio
+    $node_exec chmod 0666 /dev/vfio/vfio
     $ls_node_dev_vfio
 
     # Create and configure SRIOV Virtual Functions on SRIOV node


### PR DESCRIPTION
Following https://github.com/kubevirt/kubevirt/issues/6771 discussion.
As part of SRIOV provider cluster-up we change `/dev/vfio/vfio` permissions, but there is no indication that it worked.

With this This PR,  `/dev/vfio/` content mode is printed before and after changing it.
It will help when debugging is needed.

This PR also add the first digit of the chmod `/dev/vfio/vfio` command,
according to vfio docs [1].

[1] https://www.kernel.org/doc/html/latest/driver-api/vfio.html?highlight=vfio#vfio-usage-example

Signed-off-by: Or Mergi <ormergi@redhat.com>