### PR TITLE
KinD providers: Mount the host audit logs dir to cluster nodes

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -219,9 +219,14 @@ function setup_kind() {
 }
 
 function _add_worker_extra_mounts() {
+  cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+  extraMounts:
+  - containerPath: /var/log/audit
+    hostPath: /var/log/audit
+EOF
+
     if [[ "$KUBEVIRT_PROVIDER" =~ sriov.* || "$KUBEVIRT_PROVIDER" =~ vgpu.* ]]; then
         cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
-  extraMounts:
   - containerPath: /dev/vfio/
     hostPath: /dev/vfio/
 EOF


### PR DESCRIPTION
On Kubevirt test suite we dump various cluster object
stats, guest VM and cluster nodes logs, including auditd logs.
Currently we can't dump the audit log for KinD providers
since the cluster nodes are containers (no auditd).

In order to have audit log on KinD providers as well it
is necessary to mount the host /var/log/audit to the
cluster nodes.

Then on a test failure we will get the audit log for
the time the test were running.

Hopefully this PR will help resolving https://github.com/kubevirt/kubevirt/issues/6771 and https://github.com/kubevirt/kubevirt/issues/6776 as well

Signed-off-by: Or Mergi <ormergi@redhat.com>