### PR TITLE
CI-cluster swap support

### DIFF
--- a/cluster-provision/k8s/1.22/node01.sh
+++ b/cluster-provision/k8s/1.22/node01.sh
@@ -41,7 +41,10 @@ do
     sleep 2
 done
 
-kubeadm init --config /etc/kubernetes/kubeadm.conf --experimental-patches /provision/kubeadm-patches/
+# Disable swap
+sudo swapoff -a
+
+kubeadm init --config /etc/kubernetes/kubeadm.conf --ignore-preflight-errors=SWAP --experimental-patches /provision/kubeadm-patches/
 
 kubectl --kubeconfig=/etc/kubernetes/admin.conf patch deployment coredns -n kube-system -p "$(cat /provision/kubeadm-patches/add-security-context-deployment-patch.yaml)"
 # cni manifest is already configured at provision stage.

--- a/cluster-provision/k8s/1.22/provision.sh
+++ b/cluster-provision/k8s/1.22/provision.sh
@@ -60,9 +60,6 @@ patch $cni_manifest /tmp/cni.diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 
-# Disable swap
-swapoff -a
-sed -i '/ swap / s/^/#/' /etc/fstab
 
 systemctl stop firewalld || :
 systemctl disable firewalld || :
@@ -152,7 +149,7 @@ dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y 
 
 # TODO use config file! this is deprecated
 cat <<EOT >/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --feature-gates="IPv6DualStack=true"
+KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice  --fail-swap-on=false --kubelet-cgroups=/systemd/system.slice --feature-gates="IPv6DualStack=true"
 EOT
 
 # Needed for kubernetes service routing and dns
@@ -263,7 +260,7 @@ EOF
 
 kubeadm_manifest="/etc/kubernetes/kubeadm.conf"
 envsubst < /tmp/kubeadm.conf > $kubeadm_manifest
-kubeadm init --config $kubeadm_manifest --experimental-patches /provision/kubeadm-patches/
+kubeadm init --config $kubeadm_manifest --ignore-preflight-errors=SWAP --experimental-patches /provision/kubeadm-patches/
 
 kubectl --kubeconfig=/etc/kubernetes/admin.conf patch deployment coredns -n kube-system -p "$(cat $kubeadmn_patches_path/add-security-context-deployment-patch.yaml)"
 kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f "$cni_manifest"

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -5,6 +5,38 @@ set -e
 # shellcheck source=cluster-up/cluster/ephemeral-provider-common.sh
 source "${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh"
 
+
+#if UNLIMITEDSWAP is set to true - Kubernetes workloads can use as much swap memory as they request, up to the system limit.
+#otherwise Kubernetes workloads can use as much swap memory as they request, up to the system limit by default
+function configure_swap_memory () {
+  if [ "$KUBEVIRT_SWAP_ON" == "true" ] && [[  ($KUBEVIRT_PROVIDER =~ k8s-1\.1.*) ||  ($KUBEVIRT_PROVIDER =~ k8s-1.20) ||  ($KUBEVIRT_PROVIDER =~ k8s-1.21) ]]; then
+      echo "ERROR: swap is not supported on kubevirtci version < 1.22"
+      exit 1
+
+  elif [ "$KUBEVIRT_SWAP_ON" == "true" ] ;then
+
+    for nodeNum in $(seq -f "%02g" 1 $KUBEVIRT_NUM_NODES); do
+        if [ ! -z $KUBEVIRT_SWAP_SIZE_IN_GB  ]; then
+          $ssh node${nodeNum} -- sudo dd if=/dev/zero of=/swapfile count=$KUBEVIRT_SWAP_SIZE_IN_GB bs=1G
+          $ssh node${nodeNum} -- sudo mkswap /swapfile
+        fi
+
+        $ssh node${nodeNum} -- sudo swapon -a
+
+        if [ ! -z $KUBEVIRT_SWAPPINESS ]; then
+          $ssh node${nodeNum} -- "sudo /bin/su -c \"echo vm.swappiness = $KUBEVIRT_SWAPPINESS >> /etc/sysctl.conf\""
+          $ssh node${nodeNum} -- sudo sysctl vm.swappiness=$KUBEVIRT_SWAPPINESS
+        fi
+
+        if [ $KUBEVIRT_UNLIMITEDSWAP == "true" ]; then
+          $ssh node${nodeNum} -- "sudo sed -i ':a;N;\$!ba;s/memorySwap: {}/memorySwap:\n  swapBehavior: UnlimitedSwap/g'  /var/lib/kubelet/config.yaml"
+          $ssh node${nodeNum} -- sudo systemctl restart kubelet
+        fi
+  done
+fi
+
+}
+
 function deploy_cnao() {
     if [ "$KUBEVIRT_WITH_CNAO" == "true" ] || [ "$KUBVIRT_WITH_CNAO_SKIP_CONFIG" == "true" ]; then
         $kubectl create -f /opt/cnao/namespace.yaml
@@ -101,8 +133,8 @@ function up() {
 
     # Make sure that local config is correct
     prepare_config
-
-    kubectl="${_cli} --prefix $provider_prefix ssh node01 -- sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf"
+    ssh="${_cli} --prefix $provider_prefix ssh"
+    kubectl="$ssh node01 -- sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf"
 
     # For multinode cluster Label all the non master nodes as workers,
     # for one node cluster label master with 'master,worker' roles
@@ -112,6 +144,8 @@ function up() {
         label="node-role.kubernetes.io/master"
     fi
     $kubectl label node -l $label node-role.kubernetes.io/worker=''
+
+    configure_swap_memory
 
     deploy_cnao
     deploy_istio

--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -27,6 +27,8 @@ KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER=${KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGE
 KUBEVIRT_DEPLOY_GRAFANA=${KUBEVIRT_DEPLOY_GRAFANA:-false}
 KUBEVIRT_CGROUPV2=${KUBEVIRT_CGROUPV2:-false}
 KUBEVIRT_DEPLOY_CDI=${KUBEVIRT_DEPLOY_CDI:-false}
+KUBEVIRT_SWAP_ON=${KUBEVIRT_SWAP_ON:-false}
+KUBEVIRT_UNLIMITEDSWAP=${KUBEVIRT_UNLIMITEDSWAP:-false}
 
 # If on a developer setup, expose ocp on 8443, so that the openshift web console can be used (the port is important because of auth redirects)
 # http and https ports are accessed by testing framework and should not be randomized


### PR DESCRIPTION
**_This PR enables swap on the nodes. This can be helpful for a number of use-cases, such as:_**
- Swap available for node-level performance tuning and stability/reducing noisy neighbour issues.
- Prevents failure on memory over commitment cases.
- Can be Useful for live migration of VMs https://github.com/kubernetes/kubernetes/issues/53533#issuecomment-754878431
- Require for further investigation of kubernetes swap https://kubernetes.io/blog/2021/08/09/run-nodes-with-swap-alpha/
(might reduce tests flakiness?)

**_description:_**
- Enable the NodeMemorySwap feature flag on the kubelet
- Set --fail-on-swap flag to false
- Swap is disabled by default 
- Can only work with kubevirtci version > 1.21

**_environment variables:_**
- KUBEVIRT_SWAP_ON-enable swap
- KUBEVIRT_SWAP_SIZE_IN_GB- Setting swap size
- KUBEVIRT_SWAPPINESS- Setting swappiness
- KUBEVIRT_UNLIMITEDSWAP- if set to 'true' Kubernetes workloads can use as much swap memory as they request, up to the system limit otherwise Kubernetes workloads can use as much swap memory as they request, up to the system limit

**_to verify that it works:_**
set the environment variables:
export KUBEVIRT_SWAP_ON=true
export KUBEVIRT_SWAP_SIZE_IN_GB=5

deploy the cluster

label node02:
kubectl label nodes node02 node02=true

create the following manifest : 

```
---
apiVersion: kubevirt.io/v1
kind: VirtualMachineInstance
metadata:
  labels:
    special: vmi-masquerade
  name: vmi-masquerade
spec:
  nodeSelector:
    node02: "true"
  domain:
    devices:
      disks:
      - disk:
          bus: virtio
        name: containerdisk
      - disk:
          bus: virtio
        name: cloudinitdisk
      interfaces:
      - masquerade: {}
        name: testmasquerade
        ports:
        - name: http
          port: 80
          protocol: TCP
      rng: {}
    resources:
      overcommitGuestOverhead: true
      requests:
        memory: 3Gi
    memory:
      guest: 6Gi
  networks:
  - name: testmasquerade
    pod: {}
  terminationGracePeriodSeconds: 0
  volumes:
  - containerDisk:
      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
    name: containerdisk
  - cloudInitNoCloud:
      networkData: |
        version: 2
        ethernets:
          eth0:
            addresses: [ fd10:0:2::2/120 ]
            dhcp4: true
            gateway6: fd10:0:2::1
      userData: |-
        #cloud-config
        password: fedora
        chpasswd: { expire: False }
        packages:
          - nginx
        runcmd:
          - [ "systemctl", "enable", "--now", "nginx" ]
    name: cloudinitdisk

```
and run the following command inside the vmi:

`stress-ng --vm-bytes $(awk '/MemAvailable/{printf "%d\n", $2 * 0.92;}' < /proc/meminfo)k --vm-keep -m 1 &`

wait untill memory usage is above 5 Gib which is more than the node's memory size ( can be verified using `free -h`)

you can migrate the vm as well

