### PR TITLE
KinD providers: Mount audit logs as read-only

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -228,6 +228,7 @@ function _add_worker_extra_mounts() {
   extraMounts:
   - containerPath: /var/log/audit
     hostPath: /var/log/audit
+    readOnly: true
 EOF
 
     if [[ "$KUBEVIRT_PROVIDER" =~ sriov.* || "$KUBEVIRT_PROVIDER" =~ vgpu.* ]]; then


### PR DESCRIPTION
Following #716 

On Kind clusters auditing at the node level is not supported.
We mount the host audit logs dir in order to enable Kubevirt test
suite reporter to dump the logs at the time a test fails.

The mount is misconfigured and should be mounted as read-only
to prevent logs corruption.

Signed-off-by: Or Mergi <ormergi@redhat.com>