### PR TITLE
Configure the nodes and kubeadm to avoid failure when swap is enabled with version 1.23

### DIFF
--- a/cluster-provision/k8s/1.23/node01.sh
+++ b/cluster-provision/k8s/1.23/node01.sh
@@ -41,6 +41,9 @@ do
     sleep 2
 done
 
+# Disable swap
+sudo swapoff -a
+
 # 1.23 has deprecated --experimental-patches /provision/kubeadm-patches/, we now mention the patch directory in kubeadm.conf
 kubeadm init --config /etc/kubernetes/kubeadm.conf
 

--- a/cluster-provision/k8s/1.23/provision.sh
+++ b/cluster-provision/k8s/1.23/provision.sh
@@ -60,9 +60,6 @@ patch $cni_manifest /tmp/cni.diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 
-# Disable swap
-swapoff -a
-sed -i '/ swap / s/^/#/' /etc/fstab
 
 systemctl stop firewalld || :
 systemctl disable firewalld || :
@@ -152,7 +149,7 @@ dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y 
 
 # TODO use config file! this is deprecated
 cat <<EOT >/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --feature-gates="IPv6DualStack=true"
+KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice  --fail-swap-on=false --kubelet-cgroups=/systemd/system.slice --feature-gates="IPv6DualStack=true"
 EOT
 
 # Needed for kubernetes service routing and dns


### PR DESCRIPTION
Signed-off-by: Barak Mordehai <bmordeha@redhat.com>

The 1.23 provider landed before the following PR:
https://github.com/kubevirt/kubevirtci/pull/723
, so we should copy those changes to the 1.23 provider as well.

I removed the --ignore-preflight-errors=SWAP flags because according to:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#:~:text=Lifecycle%20and%20Windows%5D-,Kubeadm%3A%20switch%20the%20preflight%20check%20(called%20%27Swap%27)%20that%20verifies%20if,via%20--ignore-preflight-errors%20or%20the%20kubeadm%20config.%20(%23104854%2C%20%40pacoxu),-Kubelet%20did%20not
it is no longer needed on versions >= 1.23.