### PR TITLE
enable vm-image-builder to build Arm64 images

### DIFF
--- a/cluster-provision/images/vm-image-builder/README.md
+++ b/cluster-provision/images/vm-image-builder/README.md
@@ -40,6 +40,19 @@ then publish it to a registry. In this case a local registry:
 publish-containerdisk.sh example localhost:1234/myimage:mytag
 ```
 
+To build for aarch64(arm64), you need to set the following environment
+variable.
+```
+export ARCHITECTURE=aarch64
+```
+
+To build the Virtual Machine without console output, only need to set the
+environment variable `CONSOLE`. This is useful when the build script is
+run in a CICD pipeline.
+```
+export CONSOLE=no
+```
+Then follow the previous step.
 ## Create a new containerdisk
 
 Every directory contains build instructions for virt-customize. The build
@@ -47,9 +60,10 @@ instructions are distributed between the following three files:
 
 ```
 $ ls -1 example/
-cloud-config #cloud-init configuration for virt-customize
-image-url    #download URL of the base image
-os-variant   #operating system variant (for example fedora32)
+cloud-config		#cloud-init configuration for virt-customize
+image-url		#download URL of the base image
+image-url-aarch64	#download URL of the base image for aarch64
+os-variant		#operating system variant (for example fedora32)
 ```
 
 To create a completely new containerdisk, best copy the `example` folder and
@@ -58,7 +72,7 @@ customize the three files.
 ## Push the new image to local cluster registry:
 ```bash
 # From kubevirtci / kubevirt directory
-$ ./build-containerdisk.sh example
+$ ./create-containerdisk.sh example
 $ ./publish-containerdisk.sh example "localhost:$(./cluster-up/cli.sh ports registry | tr -d '\r')"
 ```
 

--- a/cluster-provision/images/vm-image-builder/README.md
+++ b/cluster-provision/images/vm-image-builder/README.md
@@ -23,7 +23,7 @@ The following RPM packages need to be present on your machine:
 - qemu-img
 - virt-install
 
-To cross build for the Arm64 image on x86_64 machines, the following RPM needs to be installed:
+To cross build for the Arm64 image on AMD64 machines, the following RPM needs to be installed:
 - qemu-system-aarch64
 
 ## Quickstart: Build and publish an existing containerdisk
@@ -43,10 +43,10 @@ then publish it to a registry. In this case a local registry:
 publish-containerdisk.sh example localhost:1234/myimage:mytag
 ```
 
-To build for aarch64(arm64), you need to set the following environment
+To build for arm64(aarch64), you need to set the following environment
 variable.
 ```
-export ARCHITECTURE=aarch64
+export ARCHITECTURE=arm64
 ```
 
 To build the Virtual Machine without console output, only need to set the
@@ -62,11 +62,11 @@ Every directory contains build instructions for virt-customize. The build
 instructions are distributed between the following three files:
 
 ```
-$ ls -1 example/
-cloud-config		#cloud-init configuration for virt-customize
-image-url		#download URL of the base image
-image-url-aarch64	#download URL of the base image for aarch64
-os-variant		#operating system variant (for example fedora32)
+$ ls -l example/
+cloud-config    # cloud-init configuration for virt-customize
+image-url       # download URL of the base image
+image-url-arm64 # download URL of the base image for Arm64
+os-variant      # operating system variant (for example fedora32)
 ```
 
 To create a completely new containerdisk, best copy the `example` folder and
@@ -93,7 +93,7 @@ $ virtctl console testvm1
 
 ### Build and publish multi-arch images
 The multi-arch publish does not support building alpine-cloud-init because the [alpine-make-vm-image](https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image) project does not support building Arm64 images.
-The `publish-multiarch-containerdisk.sh` script now supports building Arm64 and x86_64 images.
+The `publish-multiarch-containerdisk.sh` script now supports building Arm64 and AMD64 images.
 The script primarily performs the following tasks:
 1. Use `create-containerdisk.sh` to build images.
 2. Upload the resulting images to a specific registry.
@@ -115,9 +115,9 @@ The script primarily performs the following tasks:
 ./ publish-multiarch-containerdisk.sh example myregistry registry_org
 
 # The script will do following things:
-# 1. Build both Arm64 and x86_64 example image.
+# 1. Build both Arm64 and AMD64 example image.
 # 2. Generate a tag based on the current time.
-# 3. Push the registry_org/myregistry/example:tag-aarch64 and registry_org/myregistry/example:tag-x86_64.
+# 3. Push the registry_org/myregistry/example:tag-arm64 and registry_org/myregistry/example:tag-amd64.
 # 4. Generate a multi-arch manifest for the image, registry_org/myregistry/example:tag.
 ```
 

--- a/cluster-provision/images/vm-image-builder/README.md
+++ b/cluster-provision/images/vm-image-builder/README.md
@@ -23,6 +23,9 @@ The following RPM packages need to be present on your machine:
 - qemu-img
 - virt-install
 
+To cross build for the Arm64 image on x86_64 machines, the following RPM needs to be installed:
+- qemu-system-aarch64
+
 ## Quickstart: Build and publish an existing containerdisk
 
 Choose one of the configuration directories in this folder which you want to
@@ -86,4 +89,39 @@ It is possible to use an image from local cluster registry.
 $ kubectl apply -f <VMI yaml file>
 $ kubectl wait --for=condition=AgentConnected vmi $VMI_NAME --timeout 5m
 $ virtctl console testvm1
+```
+
+### Build and publish multi-arch images
+The multi-arch publish does not support building alpine-cloud-init because the [alpine-make-vm-image](https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image) project does not support building Arm64 images.
+The `publish-multiarch-containerdisk.sh` script now supports building Arm64 and x86_64 images.
+The script primarily performs the following tasks:
+1. Use `create-containerdisk.sh` to build images.
+2. Upload the resulting images to a specific registry.
+3. Upload multi-arch image manifest.
+
+```
+./publish-multiarch-containerdisk.sh -h
+    Usage:
+        ./publish_multiarch_image.sh [OPTIONS] BUILD_TARGET REGISTRY REGISTRY_ORG
+
+    Build and publish multiarch infra images.
+
+    OPTIONS
+        -n  (native build) Only build image for host CPU Arch.
+        -h  Show this help message and exit.
+        -b  Only build the image and exit. Do not publish the built image.
+
+# build and push multi-arch example image
+./ publish-multiarch-containerdisk.sh example myregistry registry_org
+
+# The script will do following things:
+# 1. Build both Arm64 and x86_64 example image.
+# 2. Generate a tag based on the current time.
+# 3. Push the registry_org/myregistry/example:tag-aarch64 and registry_org/myregistry/example:tag-x86_64.
+# 4. Generate a multi-arch manifest for the image, registry_org/myregistry/example:tag.
+```
+
+To use your own tag for the image, you need to set the environment variable `KUBEVIRTCI_TAG`.
+```
+export KUBEVIRTCI_TAG=mytag
 ```

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -ex
 
+# Currently, the build tool, alpine-make-vm-image, only support amd64
+# So we disable build for non-x86 architectures
+# https://github.com/alpinelinux/alpine-make-vm-image/issues/10
+if [[ ${ARCHITECTURE} != "" && ${ARCHITECTURE} != "amd64" || $(uname -m) != "x86_64" ]]; then
+   echo "only support native build for amd64 platform"
+   exit 1
+fi
+
 if [ "${ARCHITECTURE}" != ""  ]; then
     PLATFORM=linux/$ARCHITECTURE
 fi

--- a/cluster-provision/images/vm-image-builder/common.sh
+++ b/cluster-provision/images/vm-image-builder/common.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Formating the architecture name to adapt to Go style
+go_style_arch_name() {
+    local arch=$1
+    case ${arch} in
+    x86_64|amd64)
+        echo "amd64"
+        ;;
+    aarch64|arm64)
+        echo "arm64"
+        ;;
+    *)
+        echo "ERROR: invalid Arch, ${arch}"
+        exit 1
+        ;;
+    esac
+}
+
+# Formating the architecture name to adapt to Linux style
+linux_style_arch_name() {
+    local arch=$1
+    case ${arch} in
+    x86_64|amd64)
+        echo "x86_64"
+        ;;
+    aarch64|arm64)
+        echo "aarch64"
+        ;;
+    *)
+        echo "ERROR: invalid Arch, ${arch}"
+        exit 1
+        ;;
+    esac
+}
+
+go_style_local_arch() {
+   local arch=$(uname -m)
+   go_style_arch_name $arch
+}

--- a/cluster-provision/images/vm-image-builder/create-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/create-containerdisk.sh
@@ -6,10 +6,32 @@ if [ "$#" -ne 1 ]; then
     echo "Usage: create-containerdisk.sh image-directory"
     echo "Run `create-continerdisk.sh example` to build the `example` image in the `example` folder"
 fi
-
+ARCH="${ARCHITECTURE:-"$(uname -m)"}"
 SCRIPT_PATH=$(dirname "$(realpath "$0")")
 
 export CUSTOMIZE_IMAGE_SCRIPT=${CUSTOMIZE_IMAGE_SCRIPT:-"${SCRIPT_PATH}/customize-image.sh"}
+
+function download_base_image() {
+    local -r arch=$1
+    local -r image_name=$2
+
+    local url
+    local file_name
+    if [[ ${ARCH} = "aarch64" ]]; then
+        url="$(cat ${SCRIPT_PATH}/${IMAGE_NAME}/image-url-arm64)"
+        file_name="${image_name}-image-arm64.qcow2"
+    else
+        url="$(cat ${SCRIPT_PATH}/${IMAGE_NAME}/image-url)"
+        file_name="${image_name}-image.qcow2"
+    fi
+
+    if ! [ -e "${file_name}" ]; then
+        # Download base VM image
+        curl -L "${url}" -o "${file_name}"
+    fi
+
+    echo "${file_name}"
+}
 
 function customize_image() {
   local source_image=$1
@@ -29,67 +51,75 @@ function customize_image() {
   rm -f "${vm_image_copy}"
 }
 
+function build_container() {
+    local -r build_directory=$1
+    local -r new_vm_image_name=$2
+    local -r arch=$3
+    local -r image_name=$4
+    local -r tag=$5-$arch
+
+    if [ $arch = "aarch64" ]; then
+        docker_build="docker buildx build --platform "linux/arm64" . -t ${image_name}:${tag}"
+    else
+        docker_build="docker build . -t ${image_name}:${tag}"
+    fi
+    DOCKER_CLI_EXPERIMENTAL=enabled $docker_build -f - <<END
+FROM scratch
+ADD --chown=107:107 ${build_directory}/${new_vm_image_name} /disk/
+END
+}
+
 function cleanup() {
   if [ $? -ne 0 ]; then
     rm -rf "${build_directory}"
   fi
 
-  rm -f "copy-${VM_IMAGE}"
+  rm -f "copy-${customized_image}"
 }
+
+trap 'cleanup' EXIT SIGINT
 
 export IMAGE_NAME=$1
 
 if [ -f "${SCRIPT_PATH}/${IMAGE_NAME}/create-image.sh" ]; then
     export TAG="devel"
-    readonly VM_IMAGE="provisioned-image.qcow2"
+    readonly customized_image="customized-image.qcow2"
     readonly build_directory="${SCRIPT_PATH}/${IMAGE_NAME}/build"
-    
+
     trap 'cleanup' EXIT SIGINT
-    
     mkdir -p "${build_directory}"
 
     pushd "${SCRIPT_PATH}/${IMAGE_NAME}"
       cleanup
       echo "Creating the image"
-      ./create-image.sh "${build_directory}/${VM_IMAGE}" 
+      ./create-image.sh "${build_directory}/${customized_image}"
 
       echo "Creating the containerdisk ..."
       docker build . -t ${IMAGE_NAME}:${TAG} -f - <<END
 FROM scratch
-ADD --chown=107:107 build/${VM_IMAGE} /disk/
+ADD --chown=107:107 build/${customized_image} /disk/
 END
     popd
-
-else 
-    export TAG=devel
+else
     export OS_VARIANT="$(cat ${SCRIPT_PATH}/${IMAGE_NAME}/os-variant)"
     export CLOUD_CONFIG_PATH="${SCRIPT_PATH}/${IMAGE_NAME}/cloud-config"
-    export VM_IMAGE_URL="$(cat ${SCRIPT_PATH}/${IMAGE_NAME}/image-url)"
-
-    readonly VM_IMAGE="source-image.qcow2"
-    readonly build_directory="${IMAGE_NAME}_build"
-    readonly new_vm_image_name="provisioned-image.qcow2"
+    export TAG=devel
+    build_directory="${IMAGE_NAME}_build"
+    customized_image="customized-image.qcow2"
 
     trap 'cleanup' EXIT SIGINT
 
     pushd "${SCRIPT_PATH}"
       cleanup
       echo "Downloading the base image ..."
+      base_image=$(download_base_image "${ARCH}" "${IMAGE_NAME}")
 
-       if ! [ -e "${VM_IMAGE}" ]; then
-        # Download base VM image
-        curl -L "${VM_IMAGE_URL}" -o "${VM_IMAGE}"
-      fi
-
-      mkdir "${build_directory}"
+      mkdir -p "${build_directory}"
 
       echo "Running the image customization ..."
-      customize_image "${VM_IMAGE}" "${OS_VARIANT}" "${build_directory}/${new_vm_image_name}" "${CLOUD_CONFIG_PATH}"
+      ARCH="${ARCH}" customize_image "${base_image}" "${OS_VARIANT}" "${build_directory}/${customized_image}" "${CLOUD_CONFIG_PATH}"
 
       echo "Creating the containerdisk ..."
-      docker build . -t ${IMAGE_NAME}:${TAG} -f - <<END
-FROM scratch
-ADD --chown=107:107 ${build_directory}/${new_vm_image_name} /disk/
-END
+      build_container "${build_directory}" "${customized_image}" "${ARCH}" "${IMAGE_NAME}" "${TAG}"
     popd
 fi

--- a/cluster-provision/images/vm-image-builder/create-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/create-containerdisk.sh
@@ -34,21 +34,21 @@ function download_base_image() {
 }
 
 function customize_image() {
-  local source_image=$1
-  local os_variant=$2
-  local customized_image=$3
-  local cloud_config=$4
+    local source_image=$1
+    local os_variant=$2
+    local customized_image=$3
+    local cloud_config=$4
 
-  # Backup the VM image and pass copy of the original image
-  # in case customizing script fail.
-  vm_image_copy="$(dirname "${customized_image}")/copy-${source_image}"
-  cp "${source_image}" "${vm_image_copy}"
+    # Backup the VM image and pass copy of the original image
+    # in case customizing script fail.
+    vm_image_copy="$(dirname "${customized_image}")/copy-${source_image}"
+    cp "${source_image}" "${vm_image_copy}"
 
-  # TODO: convert this script and its dependencies to container
-  ${CUSTOMIZE_IMAGE_SCRIPT} "${vm_image_copy}" "${os_variant}" "${customized_image}" "${cloud_config}"
+    # TODO: convert this script and its dependencies to container
+    ${CUSTOMIZE_IMAGE_SCRIPT} "${vm_image_copy}" "${os_variant}" "${customized_image}" "${cloud_config}"
 
-  # Backup no longer needed.
-  rm -f "${vm_image_copy}"
+    # Backup no longer needed.
+    rm -f "${vm_image_copy}"
 }
 
 function build_container() {
@@ -70,11 +70,11 @@ END
 }
 
 function cleanup() {
-  if [ $? -ne 0 ]; then
-    rm -rf "${build_directory}"
-  fi
+    if [ $? -ne 0 ]; then
+        rm -rf "${build_directory}"
+    fi
 
-  rm -f "copy-${customized_image}"
+    rm -f "copy-${customized_image}"
 }
 
 trap 'cleanup' EXIT SIGINT

--- a/cluster-provision/images/vm-image-builder/customize-image.sh
+++ b/cluster-provision/images/vm-image-builder/customize-image.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -exuo pipefail
 
-ARCH=${ARCH:-"x86_64"}
+SCRIPT_PATH=$(dirname "$(realpath "$0")")
+source ${SCRIPT_PATH}/common.sh
+ARCH=${ARCHITECTURE:-"$(go_style_local_arch)"}
 CONSOLE=${CONSOLE:-"yes"}
 
 function cleanup() {
@@ -38,10 +40,10 @@ echo "Customize image by booting a VM with
 
 # Check if it is native build, if true use kvm
 # otherwise use emulation
-if [[ ${ARCH} = $(uname -m) ]]; then
+if [[ ${ARCH} = $(go_style_local_arch) ]]; then
   buildconfig="--virt-type kvm"
 else
-  buildconfig="--arch ${ARCH}"
+  buildconfig="--arch $(linux_style_arch_name ${ARCH})"
 fi
 
 

--- a/cluster-provision/images/vm-image-builder/example/image-url-arm64
+++ b/cluster-provision/images/vm-image-builder/example/image-url-arm64
@@ -1,0 +1,1 @@
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/32/Cloud/aarch64/images/Fedora-Cloud-Base-32-1.6.aarch64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url-arm64
+++ b/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url-arm64
@@ -1,0 +1,1 @@
+https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/aarch64/images/Fedora-Cloud-Base-35-1.2.aarch64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-kubeadm/os-variant
+++ b/cluster-provision/images/vm-image-builder/fedora-kubeadm/os-variant
@@ -1,1 +1,1 @@
-fedora-unknown
+fedora35

--- a/cluster-provision/images/vm-image-builder/fedora-realtime/image-url-arm64
+++ b/cluster-provision/images/vm-image-builder/fedora-realtime/image-url-arm64
@@ -1,0 +1,1 @@
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/32/Cloud/aarch64/images/Fedora-Cloud-Base-32-1.6.aarch64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-arm64
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-arm64
@@ -1,0 +1,1 @@
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/35/Cloud/aarch64/images/Fedora-Cloud-Base-35-1.2.aarch64.qcow2

--- a/cluster-provision/images/vm-image-builder/publish-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/publish-containerdisk.sh
@@ -6,8 +6,8 @@ if [ "$#" -ne 2 ]; then
     echo "Run `publish-continerdisk.sh example quay.io/kubevirtci/example:mytag` to push the local `example:devel` image to `quay.io/kubevirtci/example:mytag`."
 fi
 
-if [[ "${ARCHITECTURE}" = "aarch64" ]]; then
-	export TAG="devel-aarch64"
+if [[ "${ARCHITECTURE}" = "arm64" ]]; then
+	export TAG="devel-arm64"
 else
 	export TAG="devel"
 fi

--- a/cluster-provision/images/vm-image-builder/publish-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/publish-containerdisk.sh
@@ -6,8 +6,13 @@ if [ "$#" -ne 2 ]; then
     echo "Run `publish-continerdisk.sh example quay.io/kubevirtci/example:mytag` to push the local `example:devel` image to `quay.io/kubevirtci/example:mytag`."
 fi
 
+if [[ "${ARCHITECTURE}" = "aarch64" ]]; then
+	export TAG="devel-aarch64"
+else
+	export TAG="devel"
+fi
+
 export IMAGE_NAME=$1
-export TAG=devel
 export FULL_IMAGE_NAME=$2
 
 docker tag "${IMAGE_NAME}:${TAG}" "${FULL_IMAGE_NAME}"

--- a/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
@@ -88,7 +88,7 @@ publish_image() {
     local full_image_name="${1:?}"
     for arch in ${archs[*]};do
         docker tag ${build_target}:devel-${arch} ${full_image_name}-${arch}
-        docker push ${full_image_name}-${arch}
+        skopeo copy "docker-daemon:${full_image_name}-${arch}" "docker://${full_image_name}-${arch}"
     done
 }
 

--- a/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
@@ -2,14 +2,15 @@
 set -exuo pipefail
 
 SCRIPT_PATH=$(dirname "$(realpath "$0")")
-archs=(aarch64 x86_64)
+source ${SCRIPT_PATH}/common.sh
+archs=(amd64 arm64)
 
 main() {
     local build_only=""
     while getopts "nbh" opt; do
         case "$opt" in
             n)
-		archs=("$(uname -m)")
+		archs=("$(go_style_local_arch)")
                 ;;
             b)
                 build_only=true
@@ -87,7 +88,7 @@ build_image() {
 publish_image() {
     local full_image_name="${1:?}"
     for arch in ${archs[*]};do
-        docker tag ${build_target}:devel-${arch} ${full_image_name}-${arch}
+        docker tag ${build_target}:${arch} ${full_image_name}-${arch}
         skopeo copy "docker-daemon:${full_image_name}-${arch}" "docker://${full_image_name}-${arch}"
     done
 }

--- a/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+SCRIPT_PATH=$(dirname "$(realpath "$0")")
+archs=(aarch64 x86_64)
+
+main() {
+    local build_only=""
+    while getopts "nbh" opt; do
+        case "$opt" in
+            n)
+		archs=("$(uname -m)")
+                ;;
+            b)
+                build_only=true
+                ;;
+            h)
+                help
+                exit 0
+                ;;
+            *)
+                echo "Invalid argument: $opt"
+                help
+                exit 1
+        esac
+    done
+    shift $((OPTIND-1))
+    local build_target="${1:?}"
+    local registry="${2:?}"
+    local registry_org="${3:?}"
+    local full_image_name image_tag base_image
+    local tag=${KUBEVIRTCI_TAG:-"$(get_image_tag)"}
+
+    full_image_name="$(
+        get_full_image_name \
+            "$registry" \
+            "$registry_org" \
+            "${build_target##*/}" \
+            "${tag}"
+    )"
+
+    build_image "$build_target"
+
+    [[ $build_only ]] && return
+    publish_image "$full_image_name"
+    publish_manifest "$full_image_name"
+}
+
+help() {
+    cat <<EOF
+    Usage:
+        ./publish_multiarch_image.sh [OPTIONS] BUILD_TARGET REGISTRY REGISTRY_ORG
+
+    Build and publish multiarch infra images.
+
+    OPTIONS
+        -n  (native build) Only build image for host CPU Arch.
+        -h  Show this help message and exit.
+        -b  Only build the image and exit. Do not publish the built image.
+EOF
+}
+
+get_image_tag() {
+    local current_commit today
+    current_commit="$(git rev-parse HEAD)"
+    today="$(date +%Y%m%d)"
+    echo "v${today}-${current_commit:0:7}"
+}
+
+get_full_image_name() {
+    local registry="${1:?}"
+    local registry_org="${2:?}"
+    local image_name="${3:?}"
+    local tag="${4:?}"
+
+    echo "${registry_org}/${registry}/${image_name}:${tag}"
+}
+
+build_image() {
+    local build_target="${1:?}"
+    # build multi-arch images
+    for arch in ${archs[*]};do
+        ARCHITECTURE=${arch} ${SCRIPT_PATH}/create-containerdisk.sh ${build_target}
+    done
+}
+
+publish_image() {
+    local full_image_name="${1:?}"
+    for arch in ${archs[*]};do
+        docker tag ${build_target}:devel-${arch} ${full_image_name}-${arch}
+        docker push ${full_image_name}-${arch}
+    done
+}
+
+publish_manifest() {
+    local amend
+    local full_image_name="${1:?}"
+    amend=""
+    for arch in ${archs[*]};do
+        amend+=" --amend ${full_image_name}-${arch}"
+    done
+    docker manifest create ${full_image_name} ${amend}
+    docker manifest push ${full_image_name} "docker://${full_image_name}"
+}
+
+main "$@"


### PR DESCRIPTION
Currently, the images, fedora-with-test-tooling and fedora-realtime, are used in kubevirt e2e tests.
We need these images support multiarch, thus we can verify more e2e tests on Arm64.
~~This PR is used to support build multiarch images in vm-image-builder expect fedora-realtime, because the repository
http://ccrma.stanford.edu/planetccrma/mirror/fedora does not have package for aarch64~~

The package planetccrma-repo-1.1-3.fc32.ccrma.noarch.rpm is a noarch rpm package which can be install in Arm64 VM.

This PR does not support to build multiarch alpine-cloud-init, because the build tool https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image does not support to build Arm64 version image, please refer to https://github.com/alpinelinux/alpine-make-vm-image/issues/10

Signed-off-by: Howard Zhang <howard.zhang@arm.com>