### PR TITLE
console: Use screen instead of socat

### DIFF
--- a/K8S.md
+++ b/K8S.md
@@ -37,14 +37,8 @@ SSH into a node
 cluster-up/ssh.sh node01                                                   
 ```                                                                        
                                                                            
-Attach to node console with socat and pty (non okd4 providers)             
+Attach to node console with screen and pty
 ```                                                  
-# Get node01 container id                            
-node01_id=$(docker ps |grep node01 |awk '{print $1}')
-                                                     
-# Install socat                                      
-docker exec $node01_id yum install -y socat          
-                                                     
 # Attach to node01 console                           
-docker exec -it $node01_id socat - /dev/pts/0        
+docker exec -it ${KUBEVIRT_PROVIDER}-node01 screen /dev/pts/0
 ```                                                 

--- a/cluster-provision/centos8/Dockerfile
+++ b/cluster-provision/centos8/Dockerfile
@@ -4,7 +4,7 @@ FROM fedora@sha256:8fa60b88e2a7eac8460b9c0104b877f1aa0cea7fbc03c701b7e545dacccfb
 
 ARG centos_version
 
-RUN dnf -y update nettle && dnf -y install jq iptables iproute dnsmasq qemu openssh-clients socat && dnf clean all
+RUN dnf -y update nettle && dnf -y install jq iptables iproute dnsmasq qemu openssh-clients screen && dnf clean all
 
 WORKDIR /
 

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -366,7 +366,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		}
 	}
 
-	// Add serial pty so we can do stuff like 'socat - /dev/pts0' to access
+	// Add serial pty so we can do stuff like 'screen /dev/pts0' to access
 	// the VM console from the container without ssh
 	qemuArgs += " -serial pty"
 


### PR DESCRIPTION
To connect the nodes using the qemu pty console we were using socat, but
socat is very basic and it does not handle well the shell input. This
change replace socat with screen to have a proper shell over the pty and
also alow you to open multiple panes on it.

Signed-off-by: Quique Llorente <ellorent@redhat.com>