### PR TITLE
vm based providers, prometheus: Fix copy paste typo

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -112,7 +112,7 @@ function _add_common_params() {
         params=" --enable-prometheus $params"
 
         if [[ $KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER == "true" ]] &&
-            [[ $KUBEVIRT_PROVIDER_EXTRA_ARGS != *"--enable-grafana"* ]]; then
+            [[ $KUBEVIRT_PROVIDER_EXTRA_ARGS != *"--enable-prometheus-alertmanager"* ]]; then
             params=" --enable-prometheus-alertmanager $params"
         fi
 


### PR DESCRIPTION
The condition of `KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER`
should be according to the value it will potentially set
`--enable-prometheus-alertmanager`.

Signed-off-by: Or Shoval <oshoval@redhat.com>