### PR TITLE
cluster-up: Use podman.socket's default path

### DIFF
--- a/PODMAN.md
+++ b/PODMAN.md
@@ -3,7 +3,7 @@
 Install podman 3.1+, then run it in docker compatible mode:
 
 ```
-podman system service -t 0 unix:///${HOME}/podman.sock
+systemctl start --user podman.socket
 ```
 
 After this command, you can use kubevirtci with the typical `make cluster-*`
@@ -13,5 +13,11 @@ This will use `fuse-overlayfs` as storage layer. If the performance is not
 satisfactory, consider running podman as root to use plain `overlayfs2`:
 
 ```
-sudo podman system service -t 0 unix:///${HOME}/podman.sock
+mkdir -p $XDG_RUNTIME_DIR/podman
+sudo podman system service -t 0 unix:///$XDG_RUNTIME_DIR/podman/podman.sock
+sudo chown $USER $XDG_RUNTIME_DIR/podman/podman.sock
 ```
+
+Note that `podman system service` will keep running in the foreground so the
+current terminal must be kept open and the last command must be executed in a
+new terminal.

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -16,16 +16,16 @@ fi
 
 if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
     _cri_bin=podman
-    _docker_socket="${HOME}/podman.sock"
+    _docker_socket="${XDG_RUNTIME_DIR}/podman.sock"
 elif [ "${KUBEVIRTCI_RUNTIME}" = "docker" ]; then
     _cri_bin=docker
     _docker_socket="/var/run/docker.sock"
 else
-    if curl --unix-socket /${HOME}/podman.sock http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
+    if curl --unix-socket "${XDG_RUNTIME_DIR}/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
         _cri_bin=podman
-        _docker_socket="${HOME}/podman.sock"
+        _docker_socket="${XDG_RUNTIME_DIR}/podman/podman.sock"
         >&2 echo "selecting podman as container runtime"
-    elif docker ps >/dev/null; then
+    elif docker ps >/dev/null 2>&1; then
         _cri_bin=docker
         _docker_socket="/var/run/docker.sock"
         >&2 echo "selecting docker as container runtime"


### PR DESCRIPTION
These changes set the path of the podman's socket to
'${XDG_RUNTIME_DIR}/podman/podman.socket' so podman can be started with
'systemctl start --user podman.socket' which is the standard way of
starting podman as user on distributions using systemd.

Also silence stderr output of `docker ps` command so behavior is uniform.