### PR TITLE
provision: Install ovs

### DIFF
--- a/cluster-provision/k8s/1.20/provision.sh
+++ b/cluster-provision/k8s/1.20/provision.sh
@@ -191,6 +191,9 @@ nmcli connection modify "System eth0" \
    ipv6.addr-gen-mode eui64
 nmcli connection up "System eth0"
 
+dnf install -y centos-release-nfv-openvswitch
+dnf install -y openvswitch2.16
+
 mkdir -p $kubeadmn_patches_path
 
 cat >$kubeadmn_patches_path/kube-apiserver.yaml <<EOF

--- a/cluster-provision/k8s/1.21/provision.sh
+++ b/cluster-provision/k8s/1.21/provision.sh
@@ -201,6 +201,9 @@ nmcli connection modify "System eth0" \
    ipv6.addr-gen-mode eui64
 nmcli connection up "System eth0"
 
+dnf install -y centos-release-nfv-openvswitch
+dnf install -y openvswitch2.16
+
 mkdir -p $kubeadmn_patches_path
 
 cat >$kubeadmn_patches_path/kube-apiserver.yaml <<EOF

--- a/cluster-provision/k8s/1.22-ipv6/provision.sh
+++ b/cluster-provision/k8s/1.22-ipv6/provision.sh
@@ -208,6 +208,9 @@ nmcli connection modify "System eth0" \
    ipv6.addr-gen-mode eui64
 nmcli connection up "System eth0"
 
+dnf install -y centos-release-nfv-openvswitch
+dnf install -y openvswitch2.16
+
 mkdir -p $kubeadmn_patches_path
 
 cat >$kubeadmn_patches_path/kube-apiserver.yaml <<EOF

--- a/cluster-provision/k8s/1.22/provision.sh
+++ b/cluster-provision/k8s/1.22/provision.sh
@@ -198,6 +198,9 @@ nmcli connection modify "System eth0" \
    ipv6.addr-gen-mode eui64
 nmcli connection up "System eth0"
 
+dnf install -y centos-release-nfv-openvswitch
+dnf install -y openvswitch2.16
+
 mkdir -p $kubeadmn_patches_path
 
 cat >$kubeadmn_patches_path/kube-apiserver.yaml <<EOF

--- a/cluster-provision/k8s/1.23/provision.sh
+++ b/cluster-provision/k8s/1.23/provision.sh
@@ -198,6 +198,9 @@ nmcli connection modify "System eth0" \
    ipv6.addr-gen-mode eui64
 nmcli connection up "System eth0"
 
+dnf install -y centos-release-nfv-openvswitch
+dnf install -y openvswitch2.16
+
 mkdir -p $kubeadmn_patches_path
 
 cat >$kubeadmn_patches_path/kube-apiserver.yaml <<EOF


### PR DESCRIPTION
Some projects at networking need ovs at kubevirtci and they install as
part of cluster-up, provisioning it make things more stable and reduce
CI time.

Signed-off-by: Quique Llorente <ellorent@redhat.com>