### PR TITLE
cluster-up: Avoid a known comon issue when using podman

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -42,6 +42,12 @@ _cli="${_cri_bin} run --privileged --net=host --rm ${USE_TTY} -v ${_docker_socke
 if [ -d /lib/modules ]; then
     _cli="${_cli} -v /lib/modules/:/lib/modules/"
 fi
+
+# Workaround https://github.com/containers/conmon/issues/315 by not dumping file content to stdout
+if [ ${_cri_bin} == "podman" ]; then
+    _cli="${_cli} -v ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER:/kubevirtci_config"
+fi
+
 _cli="${_cli} ${_cli_container}"
 
 function _main_ip() {


### PR DESCRIPTION
There is currently a known conmon issue [1] when podman based containers
dump large amounts of data to stdout. gocli would previously do this
when copying the kubectl binary to the host machine.

This change replaces that with a simple volume mount workaround when
using podman until the underlying conmon issue is resolved.

[1] https://github.com/containers/conmon/issues/315

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>