### PR TITLE
Add kind-1.23-vgpu provider

### DIFF
--- a/cluster-up/cluster/kind-1.23-vgpu/README.md
+++ b/cluster-up/cluster/kind-1.23-vgpu/README.md
@@ -1,0 +1,45 @@
+# K8S 1.23.3 with mdev support in a Kind cluster
+
+Provides a pre-deployed k8s cluster with version 1.23.3 that runs using [kind](https://github.com/kubernetes-sigs/kind) The cluster is completely ephemeral and is recreated on every cluster restart. 
+The KubeVirt containers are built on the local machine and are then pushed to a registry which is exposed at
+`localhost:5000`.
+
+## Bringing the cluster up
+
+The following needs to be executed as root.
+
+```bash
+export KUBEVIRT_PROVIDER=kind-1.23-vgpu
+make cluster-up
+```
+
+The cluster can be accessed as usual:
+
+```bash
+$ cluster-up/kubectl.sh get nodes
+NAME                  STATUS   ROLES    AGE     VERSION
+vgpu-control-plane   Ready    master   6m14s   v1.23.3
+```
+
+## Bringing the cluster down
+
+```bash
+make cluster-down
+```
+
+This destroys the whole cluster. 
+
+## Setting a custom kind version
+
+In order to use a custom kind image / kind version,
+export KIND_NODE_IMAGE, KIND_VERSION, KUBECTL_PATH before running cluster-up.
+For example in order to use kind 0.9.0 (which is based on k8s-1.19.1) use:
+```bash
+export KIND_NODE_IMAGE="kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600"
+export KIND_VERSION="0.9.0"
+export KUBECTL_PATH="/usr/bin/kubectl"
+```
+This allows users to test or use custom images / different kind versions before making them official.
+See https://github.com/kubernetes-sigs/kind/releases for details about node images according to the kind version.
+
+- In order to use `make cluster-down` please make sure the right `CLUSTER_NAME` is exported.

--- a/cluster-up/cluster/kind-1.23-vgpu/config_vgpu_cluster.sh
+++ b/cluster-up/cluster/kind-1.23-vgpu/config_vgpu_cluster.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+[ $(id -u) -ne 0 ] && echo "FATAL: this script requires sudo privileges" >&2 && exit 1
+
+set -xe
+
+SCRIPT_PATH=$(dirname "$(realpath "$0")")
+
+source ${SCRIPT_PATH}/vgpu-node/node.sh
+echo "_kubectl: " ${_kubectl}
+echo "KUBECTL_PATH: " $KUBECTL_PATH
+echo "KUBEVIRTCI_PATH: " ${KUBEVIRTCI_PATH}
+source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh
+echo "_kubectl: " ${_kubectl}
+
+nodes=($(_kubectl get nodes -o custom-columns=:.metadata.name --no-headers))
+node::remount_sysfs "${nodes[*]}"
+node::discover_host_gpus
+
+_kubectl get nodes

--- a/cluster-up/cluster/kind-1.23-vgpu/provider.sh
+++ b/cluster-up/cluster/kind-1.23-vgpu/provider.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+DEFAULT_CLUSTER_NAME="vgpu"
+DEFAULT_HOST_PORT=5000
+ALTERNATE_HOST_PORT=5001
+export CLUSTER_NAME=${CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}
+
+if [ $CLUSTER_NAME == $DEFAULT_CLUSTER_NAME ]; then
+    export HOST_PORT=$DEFAULT_HOST_PORT
+else
+    export HOST_PORT=$ALTERNATE_HOST_PORT
+fi
+
+function set_kind_params() {
+    export KIND_VERSION="${KIND_VERSION:-0.11.1}"
+    export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-quay.io/kubevirtci/kindest_node:v1.23.3@sha256:0df8215895129c0d3221cda19847d1296c4f29ec93487339149333bd9d899e5a}"
+    export KUBECTL_PATH="${KUBECTL_PATH:-/bin/kubectl}"
+}
+
+function up() {
+    # load the vfio_mdev module
+    /usr/sbin/modprobe vfio_mdev
+    
+    # print hardware info for easier debugging based on logs
+    echo 'Available cards'
+    docker run --rm --cap-add=SYS_RAWIO quay.io/phoracek/lspci@sha256:0f3cacf7098202ef284308c64e3fc0ba441871a846022bb87d65ff130c79adb1 sh -c "lspci -k | grep -EA2 'VGA|3D'"
+    echo ""
+
+    cp $KIND_MANIFESTS_DIR/kind.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+    _add_worker_kubeadm_config_patch
+    _add_worker_extra_mounts
+    kind_up
+
+    # remove the rancher.io kind default storageClass
+    _kubectl delete sc standard
+
+    ${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/config_vgpu_cluster.sh
+
+    echo "$KUBEVIRT_PROVIDER cluster '$CLUSTER_NAME' is ready"
+}
+
+set_kind_params
+
+source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh

--- a/cluster-up/cluster/kind-1.23-vgpu/vgpu-node/node.sh
+++ b/cluster-up/cluster/kind-1.23-vgpu/vgpu-node/node.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function node::discover_host_gpus() {
+  local -r gpu_types=( $(find /sys/class/mdev_bus/*/mdev_supported_types) )
+  [ "${#gpu_types[@]}" -eq 0 ] && echo "FATAL: Could not find available GPUs on host" >&2 && return 1
+
+  local gpu_addr
+  local gpu_addresses=()
+  for path in "${gpu_types}"; do
+    gpu_addr="${gpu_types#/sys/class/mdev_bus/}"
+    gpu_addr=${gpu_addr%/*}
+
+    gpu_addresses+=( $gpu_addr )
+  done
+
+  echo "${gpu_addresses[@]}"
+}
+
+function node::remount_sysfs() {
+  local -r nodes_array=($1)
+  local node_exec
+
+  for node in "${nodes_array[@]}"; do
+
+    # KIND mounts sysfs as read-only by default, remount as R/W"
+    node_exec="docker exec $node"
+    $node_exec mount -o remount,rw /sys
+    $node_exec chmod 666 /dev/vfio/vfio
+
+  done
+}
+


### PR DESCRIPTION
Since k8s 1.23 has been released, we could add a provider kind-1.23-vgpu to use instead of kind-1.19-vgpu