### PR TITLE
vm-image-builder: small fixes

### DIFF
--- a/cluster-provision/images/vm-image-builder/create-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/create-containerdisk.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -exuo pipefail
 
+# dnf -y install bridge-utils libvirt virt-install qemu-kvm cloud-utils guestfs-tools
 
 if [ "$#" -ne 1 ]; then
-    echo "Usage: create-containerdisk.sh image-directory"
-    echo "Run `create-continerdisk.sh example` to build the `example` image in the `example` folder"
+    echo 'Usage: create-containerdisk.sh image-directory'
+    echo 'Run `create-continerdisk.sh example` to build the `example` image in the `example` folder'
+    exit 1
 fi
 
 SCRIPT_PATH=$(dirname "$(realpath "$0")")

--- a/cluster-provision/images/vm-image-builder/customize-image.sh
+++ b/cluster-provision/images/vm-image-builder/customize-image.sh
@@ -8,7 +8,7 @@ function cleanup() {
 
   rm -rf "${CLOUD_INIT_ISO}"
   virsh destroy "${DOMAIN_NAME}" || true
-  virsh undefine "${DOMAIN_NAME}" || true
+  virsh undefine "${DOMAIN_NAME}" --nvram --remove-all-storage || true
 }
 
 SOURCE_IMAGE_PATH=$1
@@ -47,7 +47,7 @@ virsh destroy $DOMAIN_NAME || true
 virt-sysprep -d $DOMAIN_NAME --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr
 
 # Remove VM
-virsh undefine $DOMAIN_NAME
+virsh undefine $DOMAIN_NAME --nvram
 
 # Convert image
 qemu-img convert -c -O qcow2 "${SOURCE_IMAGE_PATH}" "${CUSTOMIZE_IMAGE_PATH}"


### PR DESCRIPTION
- Add a comment with the necessary packages
- Prevent backticks in `usage` from running commands
- Exit at the end of `usage`
- Add `--nvram` to `virsh undefine` which is needed on aarch64