### PR TITLE
Use slightly newer snapshotter with ceph (3.0.0 -> 3.0.3)

### DIFF
--- a/cluster-provision/k8s/1.21/manifests/ceph/operator.yaml
+++ b/cluster-provision/k8s/1.21/manifests/ceph/operator.yaml
@@ -68,7 +68,7 @@ data:
   # ROOK_CSI_REGISTRAR_IMAGE: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1"
   # ROOK_CSI_RESIZER_IMAGE: "k8s.gcr.io/sig-storage/csi-resizer:v1.0.0"
   # ROOK_CSI_PROVISIONER_IMAGE: "k8s.gcr.io/sig-storage/csi-provisioner:v2.0.0"
-  # ROOK_CSI_SNAPSHOTTER_IMAGE: "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.0"
+  ROOK_CSI_SNAPSHOTTER_IMAGE: "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3"
   # ROOK_CSI_ATTACHER_IMAGE: "k8s.gcr.io/sig-storage/csi-attacher:v3.0.0"
 
   # (Optional) set user created priorityclassName for csi plugin pods.

--- a/cluster-provision/k8s/1.22-ipv6/manifests/ceph/operator.yaml
+++ b/cluster-provision/k8s/1.22-ipv6/manifests/ceph/operator.yaml
@@ -68,7 +68,7 @@ data:
   # ROOK_CSI_REGISTRAR_IMAGE: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1"
   # ROOK_CSI_RESIZER_IMAGE: "k8s.gcr.io/sig-storage/csi-resizer:v1.0.0"
   # ROOK_CSI_PROVISIONER_IMAGE: "k8s.gcr.io/sig-storage/csi-provisioner:v2.0.0"
-  # ROOK_CSI_SNAPSHOTTER_IMAGE: "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.0"
+  ROOK_CSI_SNAPSHOTTER_IMAGE: "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3"
   # ROOK_CSI_ATTACHER_IMAGE: "k8s.gcr.io/sig-storage/csi-attacher:v3.0.0"
 
   # (Optional) set user created priorityclassName for csi plugin pods.

--- a/cluster-provision/k8s/1.22/manifests/ceph/operator.yaml
+++ b/cluster-provision/k8s/1.22/manifests/ceph/operator.yaml
@@ -68,7 +68,7 @@ data:
   # ROOK_CSI_REGISTRAR_IMAGE: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1"
   # ROOK_CSI_RESIZER_IMAGE: "k8s.gcr.io/sig-storage/csi-resizer:v1.0.0"
   # ROOK_CSI_PROVISIONER_IMAGE: "k8s.gcr.io/sig-storage/csi-provisioner:v2.0.0"
-  # ROOK_CSI_SNAPSHOTTER_IMAGE: "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.0"
+  ROOK_CSI_SNAPSHOTTER_IMAGE: "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3"
   # ROOK_CSI_ATTACHER_IMAGE: "k8s.gcr.io/sig-storage/csi-attacher:v3.0.0"
 
   # (Optional) set user created priorityclassName for csi plugin pods.

--- a/cluster-provision/k8s/1.23/manifests/ceph/operator.yaml
+++ b/cluster-provision/k8s/1.23/manifests/ceph/operator.yaml
@@ -68,7 +68,7 @@ data:
   # ROOK_CSI_REGISTRAR_IMAGE: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1"
   # ROOK_CSI_RESIZER_IMAGE: "k8s.gcr.io/sig-storage/csi-resizer:v1.0.0"
   # ROOK_CSI_PROVISIONER_IMAGE: "k8s.gcr.io/sig-storage/csi-provisioner:v2.0.0"
-  # ROOK_CSI_SNAPSHOTTER_IMAGE: "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.0"
+  ROOK_CSI_SNAPSHOTTER_IMAGE: "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3"
   # ROOK_CSI_ATTACHER_IMAGE: "k8s.gcr.io/sig-storage/csi-attacher:v3.0.0"
 
   # (Optional) set user created priorityclassName for csi plugin pods.


### PR DESCRIPTION
We see https://github.com/kubernetes-csi/external-snapshotter/issues/349 quite often in CI:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/1905/pull-containerized-data-importer-e2e-k8s-1.19-ceph/1430164282548424704

Luckily, the fix is in 3.0.3 which is not a major bump, so let's use that.

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>