### PR TITLE
cluster-up: Unify usage of rootless or rootful podman

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -15,14 +15,14 @@ if [ -n "${KUBEVIRTCI_TAG}" ] && [ -n "${KUBEVIRTCI_GOCLI_CONTAINER}" ]; then
 fi
 
 if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
-    _cri_bin=podman
-    _docker_socket="${XDG_RUNTIME_DIR}/podman.sock"
+    _cri_bin="podman --remote --url=unix://${XDG_RUNTIME_DIR}/podman/podman.sock"
+    _docker_socket="${XDG_RUNTIME_DIR}/podman/podman.sock"
 elif [ "${KUBEVIRTCI_RUNTIME}" = "docker" ]; then
     _cri_bin=docker
     _docker_socket="/var/run/docker.sock"
 else
     if curl --unix-socket "${XDG_RUNTIME_DIR}/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
-        _cri_bin=podman
+        _cri_bin="podman --remote --url=unix://${XDG_RUNTIME_DIR}/podman/podman.sock"
         _docker_socket="${XDG_RUNTIME_DIR}/podman/podman.sock"
         >&2 echo "selecting podman as container runtime"
     elif docker ps >/dev/null 2>&1; then
@@ -44,7 +44,7 @@ if [ -d /lib/modules ]; then
 fi
 
 # Workaround https://github.com/containers/conmon/issues/315 by not dumping file content to stdout
-if [ ${_cri_bin} == "podman" ]; then
+if [[ ${_cri_bin} = podman* ]]; then
     _cli="${_cli} -v ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER:/kubevirtci_config"
 fi
 

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -123,7 +123,7 @@ function up() {
 
     # Copy k8s config and kubectl
     # Workaround https://github.com/containers/conmon/issues/315 by not dumping the file to stdout for the time being
-    if [ ${_cri_bin} == "podman" ]; then
+    if [[ ${_cri_bin} = podman* ]]; then
         ${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl /kubevirtci_config/.kubectl
         ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf /kubevirtci_config/.kubeconfig
     else


### PR DESCRIPTION
This adds the '--remote' and '--url' argument to every podman call to
unify the usage of rootless or rootful podman. By using the same socket
everywhere it is guaranteed that rootless and rootful podman are not mixed.
Prior providing a socket to a rootful podman would still leave some
instances where a rootless podman (without socket) was used.