### PR TITLE
Run conformance tests on IPv6 only cluster

### DIFF
--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -34,10 +34,6 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
         export KUBEVIRT_DEPLOY_ISTIO=false
     fi
 
-    if [[ $KUBEVIRT_PROVIDER =~ k8s-.*-ipv6 ]]; then
-        RUN_KUBEVIRT_CONFORMANCE=false
-    fi
-
     export KUBEVIRT_DEPLOY_PROMETHEUS=true
     export KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER=true
     export KUBEVIRT_DEPLOY_GRAFANA=true


### PR DESCRIPTION
Kubevirt supports IPv6 only since PR https://github.com/kubevirt/kubevirt/pull/7158 was merged.
Conformance tests can run on IPv6 only cluster.

Signed-off-by: Alona Kaplan <alkaplan@redhat.com>