### PR TITLE
provision: Clean CNI folder before cluster creation

### DIFF
--- a/cluster-provision/k8s/1.21/k8s_provision.sh
+++ b/cluster-provision/k8s/1.21/k8s_provision.sh
@@ -35,6 +35,13 @@ echo bridge >> /etc/modules-load.d/k8s.conf
 echo br_netfilter >> /etc/modules-load.d/k8s.conf
 echo overlay >> /etc/modules-load.d/k8s.conf
 
+# Delete conf files created by crio / podman
+# so calico will create the interfaces by its own according the right configuration.
+# See https://github.com/cri-o/cri-o/issues/2411#issuecomment-540006558
+# It should happen before crio start, see https://github.com/cri-o/cri-o/issues/4276
+# About podman see https://github.com/kubernetes/kubernetes/issues/107687
+rm -f /etc/cni/net.d/*
+
 systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet

--- a/cluster-provision/k8s/1.22-ipv6/k8s_provision.sh
+++ b/cluster-provision/k8s/1.22-ipv6/k8s_provision.sh
@@ -35,16 +35,12 @@ echo bridge >> /etc/modules-load.d/k8s.conf
 echo br_netfilter >> /etc/modules-load.d/k8s.conf
 echo overlay >> /etc/modules-load.d/k8s.conf
 
-# Delete conf files created by crio install before starting crio
+# Delete conf files created by crio / podman
 # so calico will create the interfaces by its own according the right configuration.
 # See https://github.com/cri-o/cri-o/issues/2411#issuecomment-540006558
 # It should happen before crio start, see https://github.com/cri-o/cri-o/issues/4276
-rm -f /etc/cni/net.d/100-crio-bridge.conf
-rm -f /etc/cni/net.d/200-loopback.conf
-
-# Delete conf files created by podman, so they won't interfere with calico
-# See https://github.com/kubernetes/kubernetes/issues/107687
-rm -rf /etc/cni/net.d/87-podman.conflist
+# About podman see https://github.com/kubernetes/kubernetes/issues/107687
+rm -f /etc/cni/net.d/*
 
 systemctl daemon-reload
 systemctl enable crio && systemctl start crio

--- a/cluster-provision/k8s/1.22/k8s_provision.sh
+++ b/cluster-provision/k8s/1.22/k8s_provision.sh
@@ -35,6 +35,13 @@ echo bridge >> /etc/modules-load.d/k8s.conf
 echo br_netfilter >> /etc/modules-load.d/k8s.conf
 echo overlay >> /etc/modules-load.d/k8s.conf
 
+# Delete conf files created by crio / podman
+# so calico will create the interfaces by its own according the right configuration.
+# See https://github.com/cri-o/cri-o/issues/2411#issuecomment-540006558
+# It should happen before crio start, see https://github.com/cri-o/cri-o/issues/4276
+# About podman see https://github.com/kubernetes/kubernetes/issues/107687
+rm -f /etc/cni/net.d/*
+
 systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet

--- a/cluster-provision/k8s/1.23/k8s_provision.sh
+++ b/cluster-provision/k8s/1.23/k8s_provision.sh
@@ -35,6 +35,13 @@ echo bridge >> /etc/modules-load.d/k8s.conf
 echo br_netfilter >> /etc/modules-load.d/k8s.conf
 echo overlay >> /etc/modules-load.d/k8s.conf
 
+# Delete conf files created by crio / podman
+# so calico will create the interfaces by its own according the right configuration.
+# See https://github.com/cri-o/cri-o/issues/2411#issuecomment-540006558
+# It should happen before crio start, see https://github.com/cri-o/cri-o/issues/4276
+# About podman see https://github.com/kubernetes/kubernetes/issues/107687
+rm -f /etc/cni/net.d/*
+
 systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet


### PR DESCRIPTION
Crio and podman creates their own files under the CNI folder.
Having a file in this folder will make k8s cluster use it
without waiting for the CNI to be installed (calico for example).
For now we see errors without cleaning the folder only for ipv6,
but a good practice is just to have this folder clean,
so calico will be the one creating the config.

It is also safer in case some installation would update the folder,
and cause unknown effect on the cluster.

Signed-off-by: Or Shoval <oshoval@redhat.com>