### PR TITLE
provision: Install NetworkManager-ovs

### DIFF
--- a/cluster-provision/k8s/1.21/k8s_provision.sh
+++ b/cluster-provision/k8s/1.21/k8s_provision.sh
@@ -39,7 +39,7 @@ systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet
 
-dnf install -y NetworkManager
+dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf

--- a/cluster-provision/k8s/1.22-ipv6/k8s_provision.sh
+++ b/cluster-provision/k8s/1.22-ipv6/k8s_provision.sh
@@ -50,7 +50,7 @@ systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet
 
-dnf install -y NetworkManager
+dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf

--- a/cluster-provision/k8s/1.22/k8s_provision.sh
+++ b/cluster-provision/k8s/1.22/k8s_provision.sh
@@ -39,7 +39,7 @@ systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet
 
-dnf install -y NetworkManager
+dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf

--- a/cluster-provision/k8s/1.23/k8s_provision.sh
+++ b/cluster-provision/k8s/1.23/k8s_provision.sh
@@ -39,7 +39,7 @@ systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet
 
-dnf install -y NetworkManager
+dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf


### PR DESCRIPTION
As part of including openvswitch at kubevirtci the NetworkManager-ovs
rpm was missing. This change install the missing package.