### PR TITLE
alpine: Create cloud-init aware alpine

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+_step_counter=0
+step() {
+	_step_counter=$(( _step_counter + 1 ))
+	printf '\n\033[1;36m%d) %s\033[0m\n' $_step_counter "$@" >&2  # bold cyan
+}
+
+step 'Set up qemu-guest-agent'
+cat > /etc/conf.d/qemu-guest-agent <<-EOF
+GA_METHOD="virtio-serial"
+GA_PATH="/dev/vport1p1"
+EOF
+
+step 'Set up timezone'
+setup-timezone -z Europe/Prague
+
+step 'Adjust rc.conf'
+sed -Ei \
+	-e 's/^[# ](rc_depend_strict)=.*/\1=NO/' \
+	-e 's/^[# ](rc_logger)=.*/\1=YES/' \
+	-e 's/^[# ](unicode)=.*/\1=YES/' \
+	/etc/rc.conf
+
+step 'Enable services'
+rc-update add acpid default
+rc-update add chronyd default
+rc-update add crond default
+rc-update add termencoding boot
+rc-update add qemu-guest-agent default
+rc-update add cloud-init default

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -exuo pipefail
+
+curl -L  https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image -o alpine-make-vm-image
+chmod 755 alpine-make-vm-image
+
+./alpine-make-vm-image --image-format qcow2 --image-size 5G \
+    --repositories-file repositories \
+    --packages "$(cat packages)" \
+    --serial-console \
+    --script-chroot $1 -- configure.sh

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -1,11 +1,23 @@
 #!/bin/sh
-set -exuo pipefail
+set -ex
 
-curl -L  https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image -o alpine-make-vm-image
-chmod 755 alpine-make-vm-image
+if [ "${ARCHITECTURE}" != ""  ]; then
+    PLATFORM=linux/$ARCHITECTURE
+fi
 
-./alpine-make-vm-image --image-format qcow2 --image-size 5G \
-    --repositories-file repositories \
-    --packages "$(cat packages)" \
-    --serial-console \
-    --script-chroot $1 -- configure.sh
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+if [ ! -f alpine-make-vm-image ]; then
+    curl  https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image -o alpine-make-vm-image
+    chmod 755 alpine-make-vm-image
+fi
+
+docker run --platform=$PLATFORM --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
+./alpine-make-vm-image \
+	--image-format qcow2 \
+	--image-size 5G \
+	--repositories-file repositories \
+	--packages \"$(cat packages)\" \
+	--serial-console \
+	--script-chroot \
+	$1 -- configure.sh"

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -16,7 +16,7 @@ docker run --platform=$PLATFORM --privileged -v $(pwd):$(pwd):z alpine ash -c "c
 ./alpine-make-vm-image \
 	--image-format qcow2 \
 	--image-size 5G \
-	--repositories-file repositories \
+    --branch v3.15 \
 	--packages \"$(cat packages)\" \
 	--serial-console \
 	--script-chroot \

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
@@ -1,0 +1,10 @@
+chrony
+less
+logrotate
+openssh
+ssmtp
+sudo
+cloud-init
+qemu-guest-agent
+e2fsprogs-extra
+util-linux

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/repositories
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/repositories
@@ -1,0 +1,2 @@
+http://dl-cdn.alpinelinux.org/alpine/latest-stable/main
+http://dl-cdn.alpinelinux.org/alpine/latest-stable/community

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/repositories
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/repositories
@@ -1,2 +1,0 @@
-http://dl-cdn.alpinelinux.org/alpine/latest-stable/main
-http://dl-cdn.alpinelinux.org/alpine/latest-stable/community


### PR DESCRIPTION
Create the alpine image using the official [tool](https://github.com/alpinelinux/alpine-make-vm-image) it does not set networking since it depends on kubevirt tests and it can be set with cloud-init, the idea is to set as minimal stuff as possible and then customize with cloud-init at kubevirt tests.

This has to work with https://github.com/kubevirt/kubevirtci/pull/732