### PR TITLE
Avoid `make cluster-down` failures

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -303,7 +303,8 @@ function down() {
     if [ -z "$($KIND get clusters | grep ${CLUSTER_NAME})" ]; then
         return
     fi
-    $KIND delete cluster --name=${CLUSTER_NAME}
+    # On CI, avoid failing an entire test run just because of a deletion error
+    $KIND delete cluster --name=${CLUSTER_NAME} || [ "$CI" = "true" ]
     docker rm -f $REGISTRY_NAME >> /dev/null
     rm -f ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
 }


### PR DESCRIPTION
I keep seeing test lanes failing on `make cluster-down`, even if all the tests succeeded.
That leads to a lot of unnecessary retests and therefore a lot of pressure on the CI infrastructure.
Example: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7103/pull-kubevirt-e2e-kind-1.23-vgpu-nonroot/1511039474501423104