### PR TITLE
alpine: Reduce size and startup time

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
@@ -6,15 +6,6 @@ step() {
 	printf '\n\033[1;36m%d) %s\033[0m\n' $_step_counter "$@" >&2  # bold cyan
 }
 
-step 'Set up qemu-guest-agent'
-cat > /etc/conf.d/qemu-guest-agent <<-EOF
-GA_METHOD="virtio-serial"
-GA_PATH="/dev/vport1p1"
-EOF
-
-step 'Set up timezone'
-setup-timezone -z Europe/Prague
-
 step 'Adjust rc.conf'
 sed -Ei \
 	-e 's/^[# ](rc_depend_strict)=.*/\1=NO/' \
@@ -23,9 +14,4 @@ sed -Ei \
 	/etc/rc.conf
 
 step 'Enable services'
-rc-update add acpid default
-rc-update add chronyd default
-rc-update add crond default
-rc-update add termencoding boot
-rc-update add qemu-guest-agent default
 rc-update add cloud-init default

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -12,10 +12,10 @@ if [ ! -f alpine-make-vm-image ]; then
     chmod 755 alpine-make-vm-image
 fi
 
-docker run --platform=$PLATFORM --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
+docker run --rm --platform=$PLATFORM -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
 ./alpine-make-vm-image \
 	--image-format qcow2 \
-	--image-size 5G \
+	--image-size 144M \
     --branch v3.15 \
 	--packages \"$(cat packages)\" \
 	--serial-console \

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
@@ -1,10 +1,3 @@
-chrony
-less
-logrotate
-openssh
-ssmtp
-sudo
 cloud-init
-qemu-guest-agent
 e2fsprogs-extra
 util-linux


### PR DESCRIPTION
The alpine qcow2 image can be reduced by reserving less space and removing packages also the startup time can be reduced by removing guest agent