### PR TITLE
Bump kube-state-metrics to enable usage of some advanced metrics

### DIFF
--- a/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRoleBinding.yaml
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
+        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]
         image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0
         name: kube-state-metrics
         resources:

--- a/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.1.0
     spec:
       containers:
       - args:
@@ -31,7 +31,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0
         name: kube-state-metrics
         resources:
           limits:

--- a/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-prometheusRule.yaml
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-prometheusRule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
     prometheus: k8s
     role: alert-rules
   name: kube-state-metrics-rules

--- a/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-service.yaml
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceAccount.yaml
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceAccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring

--- a/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceMonitor.yaml
+++ b/cluster-provision/k8s/1.21/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
+++ b/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRoleBinding.yaml
+++ b/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
+        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]
         image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0
         name: kube-state-metrics
         resources:

--- a/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.1.0
     spec:
       containers:
       - args:
@@ -31,7 +31,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0
         name: kube-state-metrics
         resources:
           limits:

--- a/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-prometheusRule.yaml
+++ b/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-prometheusRule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
     prometheus: k8s
     role: alert-rules
   name: kube-state-metrics-rules

--- a/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-service.yaml
+++ b/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceAccount.yaml
+++ b/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceAccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring

--- a/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceMonitor.yaml
+++ b/cluster-provision/k8s/1.22-ipv6/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
+++ b/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRoleBinding.yaml
+++ b/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
+        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]
         image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0
         name: kube-state-metrics
         resources:

--- a/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.1.0
     spec:
       containers:
       - args:
@@ -31,7 +31,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0
         name: kube-state-metrics
         resources:
           limits:

--- a/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-prometheusRule.yaml
+++ b/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-prometheusRule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
     prometheus: k8s
     role: alert-rules
   name: kube-state-metrics-rules

--- a/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-service.yaml
+++ b/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceAccount.yaml
+++ b/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceAccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring

--- a/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceMonitor.yaml
+++ b/cluster-provision/k8s/1.22/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
+++ b/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRoleBinding.yaml
+++ b/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
+        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]
         image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0
         name: kube-state-metrics
         resources:

--- a/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.1.0
     spec:
       containers:
       - args:
@@ -31,7 +31,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0
         name: kube-state-metrics
         resources:
           limits:

--- a/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-prometheusRule.yaml
+++ b/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-prometheusRule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
     prometheus: k8s
     role: alert-rules
   name: kube-state-metrics-rules

--- a/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-service.yaml
+++ b/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceAccount.yaml
+++ b/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceAccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring

--- a/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceMonitor.yaml
+++ b/cluster-provision/k8s/1.23/manifests/prometheus/kube-state-metrics/kube-state-metrics-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.0
   name: kube-state-metrics
   namespace: monitoring
 spec:


### PR DESCRIPTION
Allows usage of advanced kube-state-metrics in kubevirt which are enabled by default on OpenShift like
kube_persistentvolumeclaim_labels/kube_pod_labels.

The second commit adds an allow list, without this these object label metrics are denied by default.