### PR TITLE
Revert "kind: Use quay registry image"

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -94,7 +94,7 @@ function _run_registry() {
         docker rm $REGISTRY_NAME || true
         sleep 5
     done
-    docker run -d --network=${network} -p $HOST_PORT:5000  --restart=always --name $REGISTRY_NAME quay.io/libpod/registry:2.7
+    docker run -d --network=${network} -p $HOST_PORT:5000  --restart=always --name $REGISTRY_NAME registry:2
 }
 
 function _configure_registry_on_node() {


### PR DESCRIPTION
This reverts commit 42b307938d0bb771119d1bab8255dc4f072e6fc7.

The image doesn't support arm64.

Follow effort will be to fix https://github.com/kubevirt/project-infra/pull/1762
by using docker pull and push instead of skopeo copy,
which might cause the problem (we checked and the source image that we mirrored
does support arm64 where the target doesn't, tried source `library/registry:2.7.1`). 
See discussion on https://github.com/kubevirt/kubevirtci/pull/755

Signed-off-by: Or Shoval <oshoval@redhat.com>