### PR TITLE
k8s: Patch CNI before fetching

### DIFF
--- a/cluster-provision/k8s/1.21/k8s_provision.sh
+++ b/cluster-provision/k8s/1.21/k8s_provision.sh
@@ -4,11 +4,7 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
-mkdir -p /provision
-
 cni_manifest="/provision/cni.yaml"
-mv /tmp/cni.do-not-change.yaml $cni_manifest
-patch $cni_manifest /tmp/cni.diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 

--- a/cluster-provision/k8s/1.21/provision.sh
+++ b/cluster-provision/k8s/1.21/provision.sh
@@ -146,6 +146,11 @@ kubeadm config images pull --kubernetes-version ${version}
 dnf install -y centos-release-nfv-openvswitch
 dnf install -y openvswitch2.16
 
+mkdir -p /provision
+cni_manifest="/provision/cni.yaml"
+mv /tmp/cni.do-not-change.yaml $cni_manifest
+patch $cni_manifest /tmp/cni.diff
+
 # Pre pull all images from the manifests
 for image in $(/tmp/fetch-images.sh /tmp); do
     pull_container_retry "${image}"

--- a/cluster-provision/k8s/1.22-ipv6/k8s_provision.sh
+++ b/cluster-provision/k8s/1.22-ipv6/k8s_provision.sh
@@ -4,11 +4,7 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
-mkdir -p /provision
-
 cni_manifest="/provision/cni.yaml"
-mv /tmp/cni.do-not-change.yaml $cni_manifest
-patch $cni_manifest /tmp/cni.diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 

--- a/cluster-provision/k8s/1.22-ipv6/provision.sh
+++ b/cluster-provision/k8s/1.22-ipv6/provision.sh
@@ -146,6 +146,11 @@ kubeadm config images pull --kubernetes-version ${version}
 dnf install -y centos-release-nfv-openvswitch
 dnf install -y openvswitch2.16
 
+mkdir -p /provision
+cni_manifest="/provision/cni.yaml"
+mv /tmp/cni.do-not-change.yaml $cni_manifest
+patch $cni_manifest /tmp/cni.diff
+
 # Pre pull all images from the manifests
 for image in $(/tmp/fetch-images.sh /tmp); do
     pull_container_retry "${image}"

--- a/cluster-provision/k8s/1.22/k8s_provision.sh
+++ b/cluster-provision/k8s/1.22/k8s_provision.sh
@@ -4,11 +4,7 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
-mkdir -p /provision
-
 cni_manifest="/provision/cni.yaml"
-mv /tmp/cni.do-not-change.yaml $cni_manifest
-patch $cni_manifest /tmp/cni.diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 

--- a/cluster-provision/k8s/1.22/provision.sh
+++ b/cluster-provision/k8s/1.22/provision.sh
@@ -142,6 +142,11 @@ kubeadm config images pull --kubernetes-version ${version}
 dnf install -y centos-release-nfv-openvswitch
 dnf install -y openvswitch2.16
 
+mkdir -p /provision
+cni_manifest="/provision/cni.yaml"
+mv /tmp/cni.do-not-change.yaml $cni_manifest
+patch $cni_manifest /tmp/cni.diff
+
 # Pre pull all images from the manifests
 for image in $(/tmp/fetch-images.sh /tmp); do
     pull_container_retry "${image}"

--- a/cluster-provision/k8s/1.23/k8s_provision.sh
+++ b/cluster-provision/k8s/1.23/k8s_provision.sh
@@ -4,11 +4,7 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
-mkdir -p /provision
-
 cni_manifest="/provision/cni.yaml"
-mv /tmp/cni.do-not-change.yaml $cni_manifest
-patch $cni_manifest /tmp/cni.diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 

--- a/cluster-provision/k8s/1.23/provision.sh
+++ b/cluster-provision/k8s/1.23/provision.sh
@@ -142,6 +142,12 @@ kubeadm config images pull --kubernetes-version ${version}
 dnf install -y centos-release-nfv-openvswitch
 dnf install -y openvswitch2.16
 
+mkdir -p /provision
+cni_manifest="/provision/cni.yaml"
+mv /tmp/cni.do-not-change.yaml $cni_manifest
+patch $cni_manifest /tmp/cni.diff
+
+
 # Pre pull all images from the manifests
 for image in $(/tmp/fetch-images.sh /tmp); do
     pull_container_retry "${image}"


### PR DESCRIPTION
The CNI manifests should be patched before images are fetch so they are
taken from quay.io.

Signed-off-by: Enrique Llorente <ellorent@redhat.com>