### PR TITLE
cluster-up, kind: add kind-1.23

### DIFF
--- a/cluster-up/cluster/kind-1.23/README.md
+++ b/cluster-up/cluster/kind-1.23/README.md
@@ -1,0 +1,45 @@
+# K8S 1.23.3 with mdev support in a Kind cluster
+
+Provides a pre-deployed k8s cluster with version 1.23.3 that runs using [kind](https://github.com/kubernetes-sigs/kind) The cluster is completely ephemeral and is recreated on every cluster restart.
+The KubeVirt containers are built on the local machine and are then pushed to a registry which is exposed at
+`localhost:5000`.
+
+## Bringing the cluster up
+
+The following needs to be executed as root.
+
+```bash
+export KUBEVIRT_PROVIDER=kind-1.23
+make cluster-up
+```
+
+The cluster can be accessed as usual:
+
+```bash
+$ cluster-up/kubectl.sh get nodes
+NAME                  STATUS   ROLES    AGE     VERSION
+kind-1.23-control-plane   Ready    master   6m14s   v1.23.3
+```
+
+## Bringing the cluster down
+
+```bash
+make cluster-down
+```
+
+This destroys the whole cluster.
+
+## Setting a custom kind version
+
+In order to use a custom kind image / kind version,
+export KIND_NODE_IMAGE, KIND_VERSION, KUBECTL_PATH before running cluster-up.
+For example in order to use kind 0.9.0 (which is based on k8s-1.19.1) use:
+```bash
+export KIND_NODE_IMAGE="kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600"
+export KIND_VERSION="0.9.0"
+export KUBECTL_PATH="/usr/bin/kubectl"
+```
+This allows users to test or use custom images / different kind versions before making them official.
+See https://github.com/kubernetes-sigs/kind/releases for details about node images according to the kind version.
+
+- In order to use `make cluster-down` please make sure the right `CLUSTER_NAME` is exported.

--- a/cluster-up/cluster/kind-1.23/provider.sh
+++ b/cluster-up/cluster/kind-1.23/provider.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+DEFAULT_CLUSTER_NAME="kind-1.23"
+DEFAULT_HOST_PORT=5000
+ALTERNATE_HOST_PORT=5001
+export CLUSTER_NAME=${CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}
+
+if [ $CLUSTER_NAME == $DEFAULT_CLUSTER_NAME ]; then
+    export HOST_PORT=$DEFAULT_HOST_PORT
+else
+    export HOST_PORT=$ALTERNATE_HOST_PORT
+fi
+
+function set_kind_params() {
+    export KIND_VERSION="${KIND_VERSION:-0.12.0}"
+    export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-quay.io/kubevirtci/kindest-node:v1.23.4}"
+    export KUBECTL_PATH="${KUBECTL_PATH:-/bin/kubectl}"
+}
+
+function configure_registry_proxy() {
+    [ "$CI" != "true" ] && return
+
+    echo "Configuring cluster nodes to work with CI mirror-proxy..."
+
+    local -r ci_proxy_hostname="docker-mirror-proxy.kubevirt-prow.svc"
+    local -r kind_binary_path="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind"
+    local -r configure_registry_proxy_script="${KUBEVIRTCI_PATH}/cluster/kind/configure-registry-proxy.sh"
+
+    KIND_BIN="$kind_binary_path" PROXY_HOSTNAME="$ci_proxy_hostname" $configure_registry_proxy_script
+}
+
+function up() {
+    cp $KIND_MANIFESTS_DIR/kind.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+    _add_worker_kubeadm_config_patch
+    _add_worker_extra_mounts
+    kind_up
+
+    configure_registry_proxy
+
+    # remove the rancher.io kind default storageClass
+    _kubectl delete sc standard
+
+    echo "$KUBEVIRT_PROVIDER cluster '$CLUSTER_NAME' is ready"
+}
+
+set_kind_params
+
+source ${KUBEVIRTCI_PATH}/cluster/kind/common.sh


### PR DESCRIPTION
This is necessary for testing kubeVirt on Arm64 server, as, currently, Arm64 server does not support nested virtualization.

I update the default `KIND_VERSION` to 0.12.0, because kind 0.12.0 support multi-arch kindest/node:v1.23.4 image. https://github.com/kubernetes-sigs/kind/releases
~~The default `KIND_NODE_IMAGE`, quay.io/kubevirtci/kindest_node:v1.23.3, does not support Arm64~~
Update the default KIND_NODE_IMAGE to `quay.io/kubevirtci/kindest_node:v1.23.4` which support both x86_64 and Arm64
Signed-off-by: Howard Zhang <howard.zhang@arm.com>