### PR TITLE
conformance: Dump k8s reporter output to artifacts

### DIFF
--- a/hack/conformance.sh
+++ b/hack/conformance.sh
@@ -24,6 +24,8 @@ export KUBECONFIG
 teardown() {
     rv=$?
 
+    cp -r /tmp/results/k8s-reporter "${ARTIFACTS}"
+
     ./sonobuoy status --json
     ./sonobuoy logs > "${ARTIFACTS}/sonobuoy.log"
 


### PR DESCRIPTION
Currently we only store the results obtained from sonobuoy, that however
only contains a snapshot of the cluster after all tests are done.

This patch makes sure that we also collect all data reported by
k8s-reporter on every failed test.

This should make debugging of kubevirtci e2e failures easier.

Signed-off-by: Petr Horáček <phoracek@redhat.com>