### PR TITLE
push alpine-cloud-init to quay.io/kubevirt/

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -6,6 +6,7 @@ KUBEVIRTCI_TAG=$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)
 export KUBEVIRTCI_TAG
 
 TARGET_REPO="quay.io/kubevirtci"
+TARGET_KUBEVIRT_REPO="quay.io/kubevirt"
 TARGET_GIT_REMOTE="https://kubevirt-bot@github.com/kubevirt/kubevirtci.git"
 
 # Build gocli
@@ -25,6 +26,7 @@ done
 # Provision alpine container disk and tag it
 (cd cluster-provision/images/vm-image-builder && ./create-containerdisk.sh alpine-cloud-init)
 docker tag  alpine-cloud-init:devel ${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}
+docker tag  alpine-cloud-init:devel ${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel
 
 # Push all images
 
@@ -44,6 +46,8 @@ done
 TARGET_IMAGE="${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}"
 skopeo copy "docker-daemon:${TARGET_IMAGE}" "docker://${TARGET_IMAGE}"
 #docker push ${TARGET_IMAGE}
+TARGET_KUBEVIRT_IMAGE="${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel"
+skopeo copy "docker-daemon:${TARGET_KUBEVIRT_IMAGE}" "docker://${TARGET_KUBEVIRT_IMAGE}"
 
 git config user.name "kubevirt-bot"
 git config user.email "rmohr+kubebot@redhat.com"


### PR DESCRIPTION
quay.io/kubevirt/alpine-with-test-tooling-container-disk:devel is used
by the comformace and tear 2 tests (unlike the regular e2e test lanes
which are using a local registry).