### PR TITLE
Update 1.23 cluster provision to use cri-o version 1.23

### DIFF
--- a/cluster-provision/k8s/1.23/provision.sh
+++ b/cluster-provision/k8s/1.23/provision.sh
@@ -80,7 +80,7 @@ export PATH=$ISTIO_BIN_DIR:$PATH
 # generate Istio manifests for pre-pulling images
 istioctl manifest generate --set profile=demo --set components.cni.enabled=true | tee /tmp/istio-deployment.yaml
 
-export CRIO_VERSION=1.22
+export CRIO_VERSION=1.23
 cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo
 [devel_kubic_libcontainers_stable]
 name=Stable Releases of Upstream github.com/containers packages (CentOS_8_Stream)


### PR DESCRIPTION
Signed-off-by: Brian Carey <bcarey@redhat.com>