### PR TITLE
alpine: Use vport2p1 ga path

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
@@ -9,7 +9,7 @@ step() {
 step 'Set up qemu-guest-agent'
 cat > /etc/conf.d/qemu-guest-agent <<-EOF
 GA_METHOD="virtio-serial"
-GA_PATH="/dev/vport1p1"
+GA_PATH="/dev/virtio-ports/org.qemu.guest_agent.0"
 EOF
 
 step 'Adjust rc.conf'


### PR DESCRIPTION
At kubevirt the GA path is different. This adapt the alpine image to use
the kubevirt one.