### PR TITLE
Update cluster provisioning image to fedora 36

### DIFF
--- a/cluster-provision/centos8/Dockerfile
+++ b/cluster-provision/centos8/Dockerfile
@@ -1,10 +1,9 @@
 
-#FROM fedora:31
-FROM fedora@sha256:8fa60b88e2a7eac8460b9c0104b877f1aa0cea7fbc03c701b7e545dacccfb433
+FROM quay.io/fedora/fedora@sha256:38813cf0913241b7f13c7057e122f7c3cfa2e7c427dca3194f933d94612e280b
 
 ARG centos_version
 
-RUN dnf -y update nettle && dnf -y install jq iptables iproute dnsmasq qemu openssh-clients screen && dnf clean all
+RUN dnf -y install jq iptables iproute dnsmasq qemu openssh-clients screen && dnf clean all
 
 WORKDIR /
 
@@ -12,7 +11,7 @@ COPY vagrant.key /vagrant.key
 
 RUN chmod 700 vagrant.key
 
-ENV DOCKERIZE_VERSION v0.3.0
+ENV DOCKERIZE_VERSION v0.6.1
 
 RUN curl -LO https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && tar -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \

--- a/cluster-provision/centos8/scripts/vm.sh
+++ b/cluster-provision/centos8/scripts/vm.sh
@@ -99,7 +99,7 @@ if [ $disk_size -lt $default_disk_size ]; then
 fi
 
 echo "Creating disk \"${next} backed by ${last} with size ${disk_size}\"."
-qemu-img create -f qcow2 -o backing_file=${last} ${next} ${disk_size}
+qemu-img create -f qcow2 -o backing_file=${last} -F qcow2 ${next} ${disk_size}
 
 echo ""
 echo "SSH will be available on container port 22${n}."

--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -234,6 +234,11 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 
+	err = _cmd(cli, nodeContainer(prefix, nodeName), "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i vagrant.key vagrant@192.168.66.101 'mkdir -p /tmp/ceph /tmp/cnao /tmp/nfs-csi /tmp/nodeports /tmp/prometheus /tmp/whereabouts'", "Create required manifest directories before copy")
+	if err != nil {
+		return err
+	}
+
 	// Copy scripts to the VM
 	err = _cmd(cli, nodeContainer(prefix, nodeName), "scp -r -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i vagrant.key -P 22 /scripts/manifests/* vagrant@192.168.66.101:/tmp", "copying scripts to the VM")
 	if err != nil {


### PR DESCRIPTION
Fedora 31 is no longer supported so we should update to use Fedora 36.
This change also includes a bump to the dockerize version to the latest
release.

Signed-off-by: Brian Carey <bcarey@redhat.com>