### PR TITLE
alpine: Install iputils

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
@@ -2,3 +2,4 @@ qemu-guest-agent
 cloud-init
 e2fsprogs-extra
 util-linux
+iputils


### PR DESCRIPTION
The vanilla alpine image is using light ip utils version from busybox,
this change add the full feature tools to it.