### PR TITLE
Downgrade cri-o to 1.22 due to intermittent issue with cri-o 1.24

### DIFF
--- a/cluster-provision/k8s/1.24/provision.sh
+++ b/cluster-provision/k8s/1.24/provision.sh
@@ -80,7 +80,7 @@ export PATH=$ISTIO_BIN_DIR:$PATH
 # generate Istio manifests for pre-pulling images
 istioctl manifest generate --set profile=demo --set components.cni.enabled=true | tee /tmp/istio-deployment.yaml
 
-export CRIO_VERSION=1.24
+export CRIO_VERSION=1.22
 cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo
 [devel_kubic_libcontainers_stable]
 name=Stable Releases of Upstream github.com/containers packages (CentOS_8_Stream)


### PR DESCRIPTION
The 1.24 k8s provider can intermittently hit the following cri-o issue when
using version 1.24.
https://github.com/cri-o/cri-o/issues/5889

This can cause the check provision jobs to hang indefinitely waiting for the CNAO pods to reach a ready state. 
Example failed job: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/808/check-provision-k8s-1.24/1534076604731363328

This provider should return to using cri-o 1.24 once this issue has been resolved.

/cc @oshoval @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>