### PR TITLE
alpine: Bump alpine image to 3.16

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
@@ -19,6 +19,14 @@ sed -Ei \
 	-e 's/^[# ](unicode)=.*/\1=YES/' \
 	/etc/rc.conf
 
+step 'Boot without wait'
+sed -Ei \
+	-e "s|^[# ]*(timeout)=.*|\1=0|" \
+	/etc/update-extlinux.conf
+
+update-extlinux --warn-only 2>&1 \
+    | grep -Fv 'extlinux: cannot open device /dev' >&2
+
 step 'Enable services'
 rc-update add qemu-guest-agent default
 rc-update add cloud-init default

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -15,8 +15,8 @@ fi
 docker run --rm --platform=$PLATFORM -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
 ./alpine-make-vm-image \
 	--image-format qcow2 \
-	--image-size 144M \
-    --branch v3.15 \
+	--image-size 200M \
+    --branch v3.16 \
 	--packages \"$(cat packages)\" \
 	--serial-console \
 	--script-chroot \

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
@@ -3,3 +3,4 @@ cloud-init
 e2fsprogs-extra
 util-linux
 iputils
+openssh


### PR DESCRIPTION
It also contains the following improvements:
- Install openssh to ssh access
- Increase size to 200m, some "no space left" errors appears at kubevirt/kubevirt tests.
- Remove boot menu timeout

Signed-off-by: Enrique Llorente <ellorent@redhat.com>