### PR TITLE
SR-IOV Provider: Raise Multus Log Verbosity

### DIFF
--- a/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/multus/kustomization.yaml
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/multus/kustomization.yaml
@@ -5,3 +5,10 @@ resources:
 images:
 - name: nfvpe/multus
   newName: quay.io/kubevirtci/multus
+patchesJson6902:
+- path: patch-args.yaml
+  target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: kube-multus-ds-amd64

--- a/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/multus/patch-args.yaml
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/multus/patch-args.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--multus-log-level=verbose"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--multus-log-file=/var/log/multus.log"


### PR DESCRIPTION
Raising Multus log verbosity will make debugging CNI plugins (e.g sriov-cni) more effective.
The log file is exported in order to make it easier to work with by other components (e.g: Kubevirt test suite reporter).

Signed-off-by: Or Mergi <ormergi@redhat.com>