### PR TITLE
alpine image: Install iputils

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
@@ -2,3 +2,4 @@ qemu-guest-agent
 cloud-init
 e2fsprogs-extra
 util-linux
+iputils


### PR DESCRIPTION
Take 2 of https://github.com/kubevirt/kubevirtci/pull/801

Alpine base image includes BusyBox 'ping' implementation so called 'MiniPing'.
It lacks few statistics from its output we used to have with iputils version,
such as packets dropped count and ping overall duration, which are useful and
may come in handy for debugging.

Signed-off-by: Or Mergi <ormergi@redhat.com>