### PR TITLE
dnsmasq: Don't use ipv6 local address a dns server

### DIFF
--- a/cluster-provision/centos8/scripts/dnsmasq.sh
+++ b/cluster-provision/centos8/scripts/dnsmasq.sh
@@ -40,4 +40,4 @@ ip6tables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 ip6tables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 ip6tables -A FORWARD -i br0 -o eth0 -j ACCEPT
 
-exec dnsmasq --interface=br0 --enable-ra -d ${DHCP_HOSTS} --dhcp-range=192.168.66.10,192.168.66.200,infinite --dhcp-range=::10,::200,constructor:br0,static
+exec dnsmasq --interface=br0 --enable-ra --dhcp-option=option6:dns-server,[::] -d ${DHCP_HOSTS} --dhcp-range=192.168.66.10,192.168.66.200,infinite --dhcp-range=::10,::200,constructor:br0,static


### PR DESCRIPTION
At some envs[1] having a resolv.conf with an entry referencing the
interface name is not supported, this happend when a IPv6 link local
address is used as DNS server. This change instruct dnsmasq to only use
global addresses.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2095207

Signed-off-by: Enrique Llorente <ellorent@redhat.com>