### PR TITLE
alpine: Revert boot timeout removal

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
@@ -19,14 +19,6 @@ sed -Ei \
 	-e 's/^[# ](unicode)=.*/\1=YES/' \
 	/etc/rc.conf
 
-step 'Boot without wait'
-sed -Ei \
-	-e "s|^[# ]*(timeout)=.*|\1=0|" \
-	/etc/update-extlinux.conf
-
-update-extlinux --warn-only 2>&1 \
-    | grep -Fv 'extlinux: cannot open device /dev' >&2
-
 step 'Enable services'
 rc-update add qemu-guest-agent default
 rc-update add cloud-init default


### PR DESCRIPTION
At alpine with tooling containerdisk if timeout is set to 0 it waits
human intervention, this change go back to default. Follow up PR will
investigate how to remove menu so it directly boot without wait.

Depends on:
- https://github.com/kubevirt/project-infra/pull/2171

Signed-off-by: Enrique Llorente <ellorent@redhat.com>