### PR TITLE
sriov provider, multus: Raise log verbosity level

### DIFF
--- a/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/multus/patch-args.yaml
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/multus/patch-args.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: "--multus-log-level=verbose"
+  value: "--multus-log-level=debug"
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value: "--multus-log-file=/var/log/multus.log"


### PR DESCRIPTION
Raise Multus log verbosity to debug on SR-IOV clusters.

Signed-off-by: Or Mergi <ormergi@redhat.com>