### PR TITLE
Bump SR-IOV proivider components

### DIFF
--- a/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/kustomization.yaml
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/kustomization.yaml
@@ -6,10 +6,6 @@ resources:
 - sriov-cni-daemonset.yaml
 - sriovdp-daemonset.yaml
 - sriovdp-config.yaml
-images:
-  - name: nfvpe/sriov-cni
-    newName: quay.io/kubevirtci/sriov-cni
-    newTag: v2.6
 patchesJson6902:
 - target:
     group: apps

--- a/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/kustomization.yaml
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/kustomization.yaml
@@ -7,9 +7,6 @@ resources:
 - sriovdp-daemonset.yaml
 - sriovdp-config.yaml
 images:
-  - name: nfvpe/sriov-device-plugin
-    newName: quay.io/kubevirtci/sriov-device-plugin
-    newTag: v3.3
   - name: nfvpe/sriov-cni
     newName: quay.io/kubevirtci/sriov-cni
     newTag: v2.6

--- a/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/multus/kustomization.yaml
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/multus/kustomization.yaml
@@ -3,12 +3,12 @@ kind: Kustomization
 resources:
 - multus.yaml
 images:
-- name: nfvpe/multus
-  newName: quay.io/kubevirtci/multus
+- name: ghcr.io/k8snetworkplumbingwg/multus-cni
+  newTag: v3.8
 patchesJson6902:
 - path: patch-args.yaml
   target:
     group: apps
     version: v1
     kind: DaemonSet
-    name: kube-multus-ds-amd64
+    name: kube-multus-ds

--- a/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/multus/multus.yaml
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/multus/multus.yaml
@@ -18,12 +18,30 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
+            Working Group to express the intent for attaching pods to one or more logical or physical
+            networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
           type: object
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this represen
+                tation of an object. Servers should convert recognized schemas to the
+                latest internal value, and may reject unrecognized values. More info:
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             spec:
+              description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
               type: object
               properties:
                 config:
+                  description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
                   type: string
 ---
 kind: ClusterRole
@@ -43,6 +61,15 @@ rules:
       - pods/status
     verbs:
       - get
+      - update
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
       - update
 ---
 kind: ClusterRoleBinding
@@ -64,68 +91,59 @@ metadata:
   name: multus
   namespace: kube-system
 ---
-apiVersion: apps/v1
-kind: DaemonSet
+kind: ConfigMap
+apiVersion: v1
 metadata:
-  name: kube-multus-ds-amd64
+  name: multus-cni-config
   namespace: kube-system
   labels:
     tier: node
     app: multus
-    name: multus
-spec:
-  selector:
-    matchLabels:
-      name: multus
-  updateStrategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        tier: node
-        app: multus
-        name: multus
-    spec:
-      hostNetwork: true
-      nodeSelector:
-        kubernetes.io/arch: amd64
-      tolerations:
-      - operator: Exists
-        effect: NoSchedule
-      serviceAccountName: multus
-      containers:
-      - name: kube-multus
-        image: nfvpe/multus:v3.4
-        command: ["/entrypoint.sh"]
-        args:
-        - "--multus-conf-file=auto"
-        - "--cni-version=0.3.1"
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
-          limits:
-            cpu: "100m"
-            memory: "50Mi"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: cni
-          mountPath: /host/etc/cni/net.d
-        - name: cnibin
-          mountPath: /host/opt/cni/bin
-      volumes:
-        - name: cni
-          hostPath:
-            path: /etc/cni/net.d
-        - name: cnibin
-          hostPath:
-            path: /opt/cni/bin
+data:
+  # NOTE: If you'd prefer to manually apply a configuration file, you may create one here.
+  # In the case you'd like to customize the Multus installation, you should change the arguments to the Multus pod
+  # change the "args" line below from
+  # - "--multus-conf-file=auto"
+  # to:
+  # "--multus-conf-file=/tmp/multus-conf/70-multus.conf"
+  # Additionally -- you should ensure that the name "70-multus.conf" is the alphabetically first name in the
+  # /etc/cni/net.d/ directory on each node, otherwise, it will not be used by the Kubelet.
+  cni-conf.json: |
+    {
+      "name": "multus-cni-network",
+      "type": "multus",
+      "capabilities": {
+        "portMappings": true
+      },
+      "delegates": [
+        {
+          "cniVersion": "0.3.1",
+          "name": "default-cni-network",
+          "plugins": [
+            {
+              "type": "flannel",
+              "name": "flannel.1",
+                "delegate": {
+                  "isDefaultGateway": true,
+                  "hairpinMode": true
+                }
+              },
+              {
+                "type": "portmap",
+                "capabilities": {
+                  "portMappings": true
+                }
+              }
+          ]
+        }
+      ],
+      "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
+    }
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kube-multus-ds-ppc64le
+  name: kube-multus-ds
   namespace: kube-system
   labels:
     tier: node
@@ -145,16 +163,13 @@ spec:
         name: multus
     spec:
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/arch: ppc64le
       tolerations:
       - operator: Exists
         effect: NoSchedule
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        # ppc64le support requires multus:latest for now. support 3.3 or later.
-        image: nfvpe/multus:latest-ppc64le
+        image: ghcr.io/k8snetworkplumbingwg/multus-cni:stable
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=auto"
@@ -162,10 +177,10 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "90Mi"
+            memory: "50Mi"
           limits:
             cpu: "100m"
-            memory: "90Mi"
+            memory: "50Mi"
         securityContext:
           privileged: true
         volumeMounts:
@@ -173,6 +188,9 @@ spec:
           mountPath: /host/etc/cni/net.d
         - name: cnibin
           mountPath: /host/opt/cni/bin
+        - name: multus-cfg
+          mountPath: /tmp/multus-conf
+      terminationGracePeriodSeconds: 10
       volumes:
         - name: cni
           hostPath:
@@ -180,3 +198,9 @@ spec:
         - name: cnibin
           hostPath:
             path: /opt/cni/bin
+        - name: multus-cfg
+          configMap:
+            name: multus-cni-config
+            items:
+            - key: cni-conf.json
+              path: 70-multus.conf

--- a/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/sriov-cni-daemonset.yaml
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/sriov-cni-daemonset.yaml
@@ -18,19 +18,23 @@ spec:
         tier: node
         app: sriov-cni
     spec:
-      hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       tolerations:
       - key: node-role.kubernetes.io/control-plane
         operator: Exists
         effect: NoSchedule
       containers:
       - name: kube-sriov-cni
-        image: nfvpe/sriov-cni
+        image: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.6.2
         imagePullPolicy: IfNotPresent
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         resources:
           requests:
             cpu: "100m"

--- a/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/sriovdp-daemonset.yaml
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/sriovdp-daemonset.yaml
@@ -35,13 +35,20 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: nfvpe/sriov-device-plugin:v3.3
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.4.0
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp
         - --log-level=10
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "40Mi"
+          limits:
+            cpu: 1
+            memory: "200Mi"
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/
@@ -100,13 +107,20 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: nfvpe/sriov-device-plugin:ppc64le
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest-ppc64le
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp
         - --log-level=10
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "40Mi"
+          limits:
+            cpu: 1
+            memory: "200Mi"
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/
@@ -164,15 +178,20 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-# this is a temporary image repository for arm64 architecture, util CI/CD of the
-# sriov-device-plugin will not allow to recreate multiple images
-        image: alexeyperevalov/arm64-sriov-device-plugin
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest-arm64
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp
         - --log-level=10
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "40Mi"
+          limits:
+            cpu: 1
+            memory: "200Mi"
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/


### PR DESCRIPTION
Bump the following SR-IOV provider components:
- [SR-IOV device plugin](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/releases/tag/v3.4.0)  v3.3 ->  v3.4
- [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni/releases/tag/v2.6.2) v2.6 ->  v2.6.2
- [Multus](https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v3.8) v3.4 -> v3.8


Note to reviewer:
- Each component manifest was taken as-is from each component release, it is patched on cluster-up using Kustomize.
- I picked one version before the latest which seems to be stable.
- This PR is ready to merge once each component image is mirrored to KubevirtCI registry.