### PR TITLE
podman: Support non root user via root socket

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -23,19 +23,19 @@ detect_podman_socket() {
 }
 
 if [ "${KUBEVIRTCI_RUNTIME}" = "podman" ]; then
-    _docker_socket=$(detect_podman_socket)
-    _cri_bin="podman --remote --url=unix://$_docker_socket"
+    _cri_socket=$(detect_podman_socket)
+    _cri_bin="podman --remote --url=unix://$_cri_socket"
 elif [ "${KUBEVIRTCI_RUNTIME}" = "docker" ]; then
     _cri_bin=docker
-    _docker_socket="/var/run/docker.sock"
+    _cri_socket="/var/run/docker.sock"
 else
-    _docker_socket=$(detect_podman_socket)
-    if [ -n "$_docker_socket" ]; then
-        _cri_bin="podman --remote --url=unix://$_docker_socket"
+    _cri_socket=$(detect_podman_socket)
+    if [ -n "$_cri_socket" ]; then
+        _cri_bin="podman --remote --url=unix://$_cri_socket"
         >&2 echo "selecting podman as container runtime"
     elif docker ps >/dev/null 2>&1; then
         _cri_bin=docker
-        _docker_socket="/var/run/docker.sock"
+        _cri_socket="/var/run/docker.sock"
         >&2 echo "selecting docker as container runtime"
     else
         >&2 echo "no working container runtime found. Neither docker nor podman seems to work."
@@ -44,7 +44,7 @@ else
 fi
 
 _cli_container="${KUBEVIRTCI_GOCLI_CONTAINER:-quay.io/kubevirtci/gocli:${KUBEVIRTCI_TAG}}"
-_cli="${_cri_bin} run --privileged --net=host --rm ${USE_TTY} -v ${_docker_socket}:/var/run/docker.sock"
+_cli="${_cri_bin} run --privileged --net=host --rm ${USE_TTY} -v ${_cri_socket}:/var/run/docker.sock"
 # gocli will try to mount /lib/modules to make it accessible to dnsmasq in
 # in case it exists
 if [ -d /lib/modules ]; then

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -121,22 +121,22 @@ function up() {
     fi
     eval ${_cli:?} run $params
 
-    # Copy k8s config and kubectl
-    # Workaround https://github.com/containers/conmon/issues/315 by not dumping the file to stdout for the time being
-    if [[ ${_cri_bin} = podman* ]]; then
-        ${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl /kubevirtci_config/.kubectl
-        ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf /kubevirtci_config/.kubeconfig
-    else
-        ${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
-        ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
-    fi
-
-    chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
     # Set server and disable tls check
     export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
-    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --server="https://$(_main_ip):$(_port k8s)"
-    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
+    kubectl config set-cluster kubernetes --server="https://$(_main_ip):$(_port k8s)"
+    kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
+
+    # Workaround https://github.com/containers/conmon/issues/315 by not dumping the file to stdout for the time being
+    if [[ ${_cri_bin} = podman* ]]; then
+        k8s_version=$(kubectl get node node01 --no-headers -o=custom-columns=VERSION:.status.nodeInfo.kubeletVersion)
+        curl -Ls "https://dl.k8s.io/release/${k8s_version}/bin/linux/amd64/kubectl" -o ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    else
+        ${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    fi
+
+    chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
 
     # Make sure that local config is correct
     prepare_config


### PR DESCRIPTION
In order to use roootful podman by a non root user,
podman supports a socket (like docker does).

Adapt code to support it.
Changes:
1. Support the default root socket path `/run/podman/podman.socket`
2. Download the kubectl according the cluster version instead
copying it from the node.
We used to copy it from the node as a workaround of podman issue (affect only 1.8M+ files),
but it is copied with root only permissions, and then the non root
user can't access it.
Downloading it instead allows non root user to access it.
Note that kubectl needs to be presented.
It will be used for checking the cluster version and then the kubectl with the same
version as the cluster will be downloaded and used (as before).
(potential improvement - we can download only if not present already, in order to save few seconds).

Kind podman support will be on a follow PR.

Note: even as root we would need to start `podman.socket`
because kubevirtci and kubevirt are trying to use socket for podman at all cases.

Signed-off-by: Or Shoval <oshoval@redhat.com>