### PR TITLE
kind providers: Support Podman auto detection

### DIFF
--- a/cluster-up/cluster/kind-1.22-sriov/provider.sh
+++ b/cluster-up/cluster/kind-1.22-sriov/provider.sh
@@ -29,9 +29,9 @@ function print_sriov_data() {
         if [[ ! "$node" =~ .*"control-plane".* ]]; then
             echo "Node: $node"
             echo "VFs:"
-            docker exec $node bash -c "ls -l /sys/class/net/*/device/virtfn*"
+            ${CRI_BIN} exec $node bash -c "ls -l /sys/class/net/*/device/virtfn*"
             echo "PFs PCI Addresses:"
-            docker exec $node bash -c "grep PCI_SLOT_NAME /sys/class/net/*/device/uevent"
+            ${CRI_BIN} exec $node bash -c "grep PCI_SLOT_NAME /sys/class/net/*/device/uevent"
         fi
     done
 }
@@ -51,7 +51,7 @@ function configure_registry_proxy() {
 function up() {
     # print hardware info for easier debugging based on logs
     echo 'Available NICs'
-    docker run --rm --cap-add=SYS_RAWIO quay.io/phoracek/lspci@sha256:0f3cacf7098202ef284308c64e3fc0ba441871a846022bb87d65ff130c79adb1 sh -c "lspci | egrep -i 'network|ethernet'"
+    ${CRI_BIN} run --rm --cap-add=SYS_RAWIO quay.io/phoracek/lspci@sha256:0f3cacf7098202ef284308c64e3fc0ba441871a846022bb87d65ff130c79adb1 sh -c "lspci | egrep -i 'network|ethernet'"
     echo ""
 
     cp $KIND_MANIFESTS_DIR/kind.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml

--- a/cluster-up/cluster/kind-1.22-sriov/sriov-node/node.sh
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-node/node.sh
@@ -56,7 +56,7 @@ function node::configure_sriov_pfs() {
     pfs_in_use+=( $pf_name )
 
     # KIND mounts sysfs as read-only by default, remount as R/W"
-    node_exec="docker exec $node"
+    node_exec="${CRI_BIN} exec $node"
     $node_exec mount -o remount,rw /sys
 
     ls_node_dev_vfio="${node_exec} ls -la -Z /dev/vfio"
@@ -81,15 +81,15 @@ function node::configure_sriov_vfs() {
     local -r config_vf_script=$(basename "$CONFIGURE_VFS_SCRIPT_PATH")
 
     for node in "${nodes_array[@]}"; do
-      docker cp "$CONFIGURE_VFS_SCRIPT_PATH" "$node:/"
-      docker exec "$node" bash -c "DRIVER=$driver DRIVER_KMODULE=$driver_kmodule VFS_COUNT=$vfs_count ./$config_vf_script"
-      docker exec "$node" ls -la -Z /dev/vfio
+      ${CRI_BIN} cp "$CONFIGURE_VFS_SCRIPT_PATH" "$node:/"
+      ${CRI_BIN} exec "$node" bash -c "DRIVER=$driver DRIVER_KMODULE=$driver_kmodule VFS_COUNT=$vfs_count ./$config_vf_script"
+      ${CRI_BIN} exec "$node" ls -la -Z /dev/vfio
     done
 }
 
 function prepare_node_netns() {
   local -r node_name=$1
-  local -r node_pid=$(docker inspect -f '{{.State.Pid}}' "$node_name")
+  local -r node_pid=$($CRI_BIN inspect -f '{{.State.Pid}}' "$node_name")
 
   # Docker does not create the required symlink for a container netns
   # it perverts iplink from learning that container netns.
@@ -112,7 +112,7 @@ function move_pf_to_node_netns() {
 
 function node::total_vfs_count() {
   local -r node_name=$1
-  local -r node_pid=$(docker inspect -f '{{.State.Pid}}' "$node_name")
+  local -r node_pid=$($CRI_BIN inspect -f '{{.State.Pid}}' "$node_name")
   local -r pfs_sriov_numvfs=( $(cat /proc/$node_pid/root/sys/class/net/*/device/sriov_numvfs) )
   local total_vfs_on_node=0
 

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -179,10 +179,6 @@ function _fix_node_labels() {
     done
 }
 
-function _get_cri_bridge_mtu() {
-  docker network inspect -f '{{index .Options "com.docker.network.driver.mtu"}}' bridge
-}
-
 function setup_kind() {
     $KIND --loglevel debug create cluster --retain --name=${CLUSTER_NAME} --config=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml --image=$KIND_NODE_IMAGE
     $KIND get kubeconfig --name=${CLUSTER_NAME} > ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+function detect_cri() {
+    if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi
+}
+
+export CRI_BIN=${CRI_BIN:-$(detect_cri)}
+
 # check CPU arch
 PLATFORM=$(uname -m)
 case ${PLATFORM} in
@@ -20,9 +26,9 @@ aarch64* | arm64*)
     ;;
 esac
 
-NODE_CMD="docker exec -it -d "
+NODE_CMD="${CRI_BIN} exec -it -d "
 export KIND_MANIFESTS_DIR="${KUBEVIRTCI_PATH}/cluster/kind/manifests"
-export KIND_NODE_CLI="docker exec -it "
+export KIND_NODE_CLI="${CRI_BIN} exec -it "
 export KUBEVIRTCI_PATH
 export KUBEVIRTCI_CONFIG_PATH
 KIND_DEFAULT_NETWORK="kind"
@@ -44,7 +50,7 @@ function _wait_kind_up {
     else
         selector="control-plane"
     fi
-    while [ -z "$(docker exec --privileged ${CLUSTER_NAME}-control-plane kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes --selector=node-role.kubernetes.io/${selector} -o=jsonpath='{.items..status.conditions[-1:].status}' | grep True)" ]; do
+    while [ -z "$(${CRI_BIN} exec --privileged ${CLUSTER_NAME}-control-plane kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes --selector=node-role.kubernetes.io/${selector} -o=jsonpath='{.items..status.conditions[-1:].status}' | grep True)" ]; do
         echo "Waiting for kind to be ready ..."
         sleep 10
     done
@@ -83,18 +89,18 @@ function _insecure-registry-config-cmd() {
 
 # this works since the nodes use the same names as containers
 function _ssh_into_node() {
-    docker exec -it "$1" bash
+    ${CRI_BIN} exec -it "$1" bash
 }
 
 function _run_registry() {
     local -r network=${1}
 
-    until [ -z "$(docker ps -a | grep $REGISTRY_NAME)" ]; do
-        docker stop $REGISTRY_NAME || true
-        docker rm $REGISTRY_NAME || true
+    until [ -z "$($CRI_BIN ps -a | grep $REGISTRY_NAME)" ]; do
+        ${CRI_BIN} stop $REGISTRY_NAME || true
+        ${CRI_BIN} rm $REGISTRY_NAME || true
         sleep 5
     done
-    docker run -d --network=${network} -p $HOST_PORT:5000  --restart=always --name $REGISTRY_NAME quay.io/kubevirtci/library-registry:2.7.1
+    ${CRI_BIN} run -d --network=${network} -p $HOST_PORT:5000  --restart=always --name $REGISTRY_NAME quay.io/kubevirtci/library-registry:2.7.1
 
 }
 
@@ -103,7 +109,7 @@ function _configure_registry_on_node() {
     local -r network=${2}
 
     _configure-insecure-registry-and-reload "${NODE_CMD} ${node} bash -c"
-    ${NODE_CMD} ${node} sh -c "echo $(docker inspect --format "{{.NetworkSettings.Networks.${network}.IPAddress }}" $REGISTRY_NAME)'\t'registry >> /etc/hosts"
+    ${NODE_CMD} ${node} sh -c "echo $(${CRI_BIN} inspect --format "{{.NetworkSettings.Networks.${network}.IPAddress }}" $REGISTRY_NAME)'\t'registry >> /etc/hosts"
 }
 
 function _install_cnis {
@@ -120,8 +126,8 @@ function _install_cni_plugins {
     fi
 
     for node in $(_get_nodes | awk '{print $1}'); do
-        docker cp "${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/$CNI_ARCHIVE" $node:/
-        docker exec $node /bin/sh -c "tar xf $CNI_ARCHIVE -C /opt/cni/bin"
+        ${CRI_BIN} cp "${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/$CNI_ARCHIVE" $node:/
+        ${CRI_BIN} exec $node /bin/sh -c "tar xf $CNI_ARCHIVE -C /opt/cni/bin"
     done
 }
 
@@ -181,16 +187,16 @@ function setup_kind() {
     $KIND --loglevel debug create cluster --retain --name=${CLUSTER_NAME} --config=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml --image=$KIND_NODE_IMAGE
     $KIND get kubeconfig --name=${CLUSTER_NAME} > ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
-    docker cp ${CLUSTER_NAME}-control-plane:$KUBECTL_PATH ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    ${CRI_BIN} cp ${CLUSTER_NAME}-control-plane:$KUBECTL_PATH ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
     chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
 
     if [ $KUBEVIRT_WITH_KIND_ETCD_IN_MEMORY == "true" ]; then
         for node in $(_get_nodes | awk '{print $1}' | grep control-plane); do
             echo "[$node] Checking KIND cluster etcd data is mounted to RAM: $ETCD_IN_MEMORY_DATA_DIR"
-            docker exec $node df -h $(dirname $ETCD_IN_MEMORY_DATA_DIR) | grep -P '(tmpfs|ramfs)'
+            ${CRI_BIN} exec $node df -h $(dirname $ETCD_IN_MEMORY_DATA_DIR) | grep -P '(tmpfs|ramfs)'
             [ $(echo $?) != 0 ] && echo "[$node] etcd data directory is not mounted to RAM" && return 1
 
-            docker exec $node du -h $ETCD_IN_MEMORY_DATA_DIR
+            ${CRI_BIN} exec $node du -h $ETCD_IN_MEMORY_DATA_DIR
             [ $(echo $?) != 0 ] && echo "[$node] Failed to check etcd data directory" && return 1
         done
     fi
@@ -306,6 +312,6 @@ function down() {
     fi
     # On CI, avoid failing an entire test run just because of a deletion error
     $KIND delete cluster --name=${CLUSTER_NAME} || [ "$CI" = "true" ]
-    docker rm -f $REGISTRY_NAME >> /dev/null
+    ${CRI_BIN} rm -f $REGISTRY_NAME >> /dev/null
     rm -f ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
 }

--- a/cluster-up/cluster/kind/configure-registry-proxy.sh
+++ b/cluster-up/cluster/kind/configure-registry-proxy.sh
@@ -20,7 +20,7 @@
 
 set -ex
 
-CRI=${CRI:-docker}
+CRI_BIN=${CRI_BIN:-docker}
 
 KIND_BIN="${KIND_BIN:-./kind}"
 PROXY_HOSTNAME="${PROXY_HOSTNAME:-docker-registry-proxy}"
@@ -29,7 +29,7 @@ CLUSTER_NAME="${CLUSTER_NAME:-sriov}"
 SETUP_URL="http://${PROXY_HOSTNAME}:3128/setup/systemd"
 pids=""
 for node in $($KIND_BIN get nodes --name "$CLUSTER_NAME"); do
-   $CRI exec "$node" sh -c "\
+   $CRI_BIN exec "$node" sh -c "\
       curl $SETUP_URL | \
       sed s/docker\.service/containerd\.service/g | \
       sed '/Environment/ s/$/ \"NO_PROXY=127.0.0.0\/8,10.0.0.0\/8,172.16.0.0\/12,192.168.0.0\/16\"/' | \


### PR DESCRIPTION
Use naive auto detection of the CRI.
Parametrize CRI usages.

Note: 
We support currently only rootful podman using the root user.
Rootful socket via non root user is not supported for kind SR-IOV providers.
Hence the naive auto detection is good enough and the simplest.

Signed-off-by: Or Shoval <oshoval@redhat.com>