### PR TITLE
Update the qemu sound devices to use the -device flag

### DIFF
--- a/cluster-provision/centos8/scripts/vm.sh
+++ b/cluster-provision/centos8/scripts/vm.sh
@@ -150,6 +150,6 @@ exec qemu-system-x86_64 -enable-kvm -drive format=qcow2,file=${next},if=virtio,c
   -append "$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}" \
   -vnc :${n} -cpu host,migratable=no,+invtsc -m ${MEMORY} -smp ${CPU} \
   -serial pty -M q35,accel=kvm,kernel_irqchip=split \
-  -device intel-iommu,intremap=on,caching-mode=on -soundhw hda -soundhw ac97 \
+  -device intel-iommu,intremap=on,caching-mode=on -device intel-hda -device hda-duplex -device AC97 \
   -uuid $(cat /proc/sys/kernel/random/uuid) \
   ${QEMU_ARGS}


### PR DESCRIPTION
The ``-soundhw`` flag has been deprecated in favour of ``-device`` flag - this is
causing warning messages when creating the VM instance.

```
qemu-system-x86_64: warning: '-soundhw ac97' is deprecated, please use '-device AC97' instead
qemu-system-x86_64: warning: '-soundhw hda' is deprecated, please use '-device intel-hda -device hda-duplex' instead
```

/cc @dhiller @oshoval 



Signed-off-by: Brian Carey <bcarey@redhat.com>