### PR TITLE
Use full name for check-image-pull-policies image

### DIFF
--- a/cluster-provision/k8s/validate-manifest-pull-policies.sh
+++ b/cluster-provision/k8s/validate-manifest-pull-policies.sh
@@ -25,7 +25,7 @@ function main {
     manifest_dir="$DIR/$1/manifests"
     echo "Checking $manifest_dir"
     docker run --rm -v "$manifest_dir:/manifests:Z" \
-        kubevirtci/check-image-pull-policies@sha256:118c4828afa52e58fc07663f400a357764cc1e7432ab56c439bb5c0b4b11b4dc \
+	 docker.io/kubevirtci/check-image-pull-policies@sha256:118c4828afa52e58fc07663f400a357764cc1e7432ab56c439bb5c0b4b11b4dc \
             --manifest-source=/manifests \
             --dry-run=false \
             --verbose=false

--- a/cluster-provision/k8s/validate-manifest-pull-policies.sh
+++ b/cluster-provision/k8s/validate-manifest-pull-policies.sh
@@ -25,7 +25,7 @@ function main {
     manifest_dir="$DIR/$1/manifests"
     echo "Checking $manifest_dir"
     docker run --rm -v "$manifest_dir:/manifests:Z" \
-	 docker.io/kubevirtci/check-image-pull-policies@sha256:118c4828afa52e58fc07663f400a357764cc1e7432ab56c439bb5c0b4b11b4dc \
+	 quay.io/kubevirtci/check-image-pull-policies@sha256:c942d3a4a17f1576f81eba0a5844c904d496890677c6943380b543bbf2d9d1be \
             --manifest-source=/manifests \
             --dry-run=false \
             --verbose=false

--- a/cluster-provision/k8s/validate-pod-pull-policies.sh
+++ b/cluster-provision/k8s/validate-pod-pull-policies.sh
@@ -35,7 +35,7 @@ function main() {
     echo "Checking $manifest_dir"
     # TODO: for now we disable (via --dry-run) the non zero exit code in case of failure here to give the teams some time to fix the policies
     docker run --rm -v "$manifest_dir:/manifests:Z" \
-      docker.io/kubevirtci/check-image-pull-policies@sha256:118c4828afa52e58fc07663f400a357764cc1e7432ab56c439bb5c0b4b11b4dc \
+      quay.io/kubevirtci/check-image-pull-policies@sha256:c942d3a4a17f1576f81eba0a5844c904d496890677c6943380b543bbf2d9d1be \
         --manifest-source=/manifests \
         --dry-run=true \
         --verbose=false

--- a/cluster-provision/k8s/validate-pod-pull-policies.sh
+++ b/cluster-provision/k8s/validate-pod-pull-policies.sh
@@ -35,7 +35,7 @@ function main() {
     echo "Checking $manifest_dir"
     # TODO: for now we disable (via --dry-run) the non zero exit code in case of failure here to give the teams some time to fix the policies
     docker run --rm -v "$manifest_dir:/manifests:Z" \
-        kubevirtci/check-image-pull-policies@sha256:118c4828afa52e58fc07663f400a357764cc1e7432ab56c439bb5c0b4b11b4dc \
+      docker.io/kubevirtci/check-image-pull-policies@sha256:118c4828afa52e58fc07663f400a357764cc1e7432ab56c439bb5c0b4b11b4dc \
         --manifest-source=/manifests \
         --dry-run=true \
         --verbose=false


### PR DESCRIPTION
Podman fails to find this image in automated prow jobs due to the short
image name. [1]

[1]
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2191/rehearsal-check-provision-k8s-1.23/1544958773141966848#1:build-log.txt%3A15297

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>