### PR TITLE
publish: Fix script to support single stack providers

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -19,7 +19,11 @@ docker tag ${TARGET_REPO}/gocli ${TARGET_REPO}/gocli:${KUBEVIRTCI_TAG}
 # Provision all clusters
 CLUSTERS="$(find cluster-provision/k8s/* -maxdepth 0 -type d -printf '%f\n')"
 for i in ${CLUSTERS}; do
-    cluster-provision/gocli/build/cli provision cluster-provision/k8s/$i
+    NETWORK_STACK="dualstack"
+    if [[ $i =~ ipv6 ]]; then
+        NETWORK_STACK="ipv6"
+    fi
+    cluster-provision/gocli/build/cli provision cluster-provision/k8s/$i --network-stack ${NETWORK_STACK}
     docker tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}
 done
 


### PR DESCRIPTION
The publish was missing single stack flag in case
the provider is an IPv6 one,
so all the providers were created dual stack.
Support specifying single stack for the single stack ones.

Note: future AI - add validation that the cluster is as expected.

Signed-off-by: Or Shoval <oshoval@redhat.com>