### PR TITLE
podman: Present socket env var

### DIFF
--- a/PODMAN.md
+++ b/PODMAN.md
@@ -52,4 +52,8 @@ export CONTAINER_HOST=unix:///run/podman/podman.sock
 Validate it by running `podman run hello-world` as the non root user
 and see that as root `podman ps -a` shows the same exited container (or vice versa).
 
+In case you wish to use a custom socket path, change the values of `CONTAINER_HOST`
+and `KUBEVIRTCI_PODMAN_SOCKET` accordingly,
+i.e `export KUBEVIRTCI_PODMAN_SOCKET="${XDG_RUNTIME_DIR}/podman/podman.sock"`
+
 Tested on fedora 35.

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -5,6 +5,8 @@ set -e
 KUBEVIRT_WITH_ETC_IN_MEMORY=${KUBEVIRT_WITH_ETC_IN_MEMORY:-false}
 KUBEVIRT_WITH_ETC_CAPACITY=${KUBEVIRT_WITH_ETC_CAPACITY:-none}
 
+export KUBEVIRTCI_PODMAN_SOCKET=${KUBEVIRTCI_PODMAN_SOCKET:-"/run/podman/podman.sock"}
+
 if [ -z "${KUBEVIRTCI_TAG}" ] && [ -z "${KUBEVIRTCI_GOCLI_CONTAINER}" ]; then
     >&2 echo "FATAL: either KUBEVIRTCI_TAG or KUBEVIRTCI_GOCLI_CONTAINER must be set"
     exit 1
@@ -15,10 +17,8 @@ if [ -n "${KUBEVIRTCI_TAG}" ] && [ -n "${KUBEVIRTCI_GOCLI_CONTAINER}" ]; then
 fi
 
 detect_podman_socket() {
-    if curl --unix-socket "/run/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
-        echo "/run/podman/podman.sock"
-    elif curl --unix-socket "${XDG_RUNTIME_DIR}/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
-        echo "${XDG_RUNTIME_DIR}/podman/podman.sock"
+    if curl --unix-socket "${KUBEVIRTCI_PODMAN_SOCKET}" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
+        echo "${KUBEVIRTCI_PODMAN_SOCKET}"
     fi
 }
 


### PR DESCRIPTION
In order to make the code easier to maintain
and agnostic of custom socket path,
preset an env var `KUBEVIRTCI_PODMAN_SOCKET`.
The default value will be `/run/podman/podman.sock`
which is podman.socket root user default value.

The user can override this value in case he uses
a custom path such as one depends on `XDG_RUNTIME_DIR`.