### PR TITLE
Update whereabouts image tag to match the manifest version

### DIFF
--- a/cluster-provision/k8s/1.22-ipv6/manifests/whereabouts/whereabouts-v0.5.yaml
+++ b/cluster-provision/k8s/1.22-ipv6/manifests/whereabouts/whereabouts-v0.5.yaml
@@ -195,7 +195,7 @@ spec:
           - command:
             - /ip-reconciler
             - -log-level=verbose
-            image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+            image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5-amd64
             name: whereabouts
             resources:
               requests:
@@ -238,7 +238,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5-amd64
         name: whereabouts
         resources:
           limits:

--- a/cluster-provision/k8s/1.22/manifests/whereabouts/whereabouts-v0.5.yaml
+++ b/cluster-provision/k8s/1.22/manifests/whereabouts/whereabouts-v0.5.yaml
@@ -195,7 +195,7 @@ spec:
           - command:
             - /ip-reconciler
             - -log-level=verbose
-            image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+            image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5-amd64
             name: whereabouts
             resources:
               requests:
@@ -238,7 +238,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5-amd64
         name: whereabouts
         resources:
           limits:

--- a/cluster-provision/k8s/1.23/manifests/whereabouts/whereabouts-v0.5.yaml
+++ b/cluster-provision/k8s/1.23/manifests/whereabouts/whereabouts-v0.5.yaml
@@ -195,7 +195,7 @@ spec:
           - command:
             - /ip-reconciler
             - -log-level=verbose
-            image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+            image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5-amd64
             name: whereabouts
             resources:
               requests:
@@ -238,7 +238,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5-amd64
         name: whereabouts
         resources:
           limits:

--- a/cluster-provision/k8s/1.24-ipv6/manifests/whereabouts/whereabouts-v0.5.yaml
+++ b/cluster-provision/k8s/1.24-ipv6/manifests/whereabouts/whereabouts-v0.5.yaml
@@ -195,7 +195,7 @@ spec:
           - command:
             - /ip-reconciler
             - -log-level=verbose
-            image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+            image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5-amd64
             name: whereabouts
             resources:
               requests:
@@ -238,7 +238,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5-amd64
         name: whereabouts
         resources:
           limits:

--- a/cluster-provision/k8s/1.24/manifests/whereabouts/whereabouts-v0.5.yaml
+++ b/cluster-provision/k8s/1.24/manifests/whereabouts/whereabouts-v0.5.yaml
@@ -195,7 +195,7 @@ spec:
           - command:
             - /ip-reconciler
             - -log-level=verbose
-            image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+            image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5-amd64
             name: whereabouts
             resources:
               requests:
@@ -238,7 +238,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5-amd64
         name: whereabouts
         resources:
           limits:


### PR DESCRIPTION
An issue has occurred when using the latest whereabouts image as the
ip-reconciler has been moved[1]. Updating the image tag to match the
manifest version v0.5

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/835/check-provision-k8s-1.23/1548876282610061312

/cc @oshoval @enp0s3 

[1] https://github.com/k8snetworkplumbingwg/whereabouts/commit/545f05525c710a1f7f5b34c47ee6396d223581bc

Signed-off-by: Brian Carey <bcarey@redhat.com>