### PR TITLE
Stopgap fix: prefer docker over podman for kind

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -3,7 +3,7 @@
 set -e
 
 function detect_cri() {
-    if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi
+    if docker ps >/dev/null 2>&1; then echo docker; elif podman ps >/dev/null 2>&1; then echo podman; fi
 }
 
 export CRI_BIN=${CRI_BIN:-$(detect_cri)}


### PR DESCRIPTION
We require additional changes to run some CI lanes and jumped too
far ahead by preferring podman if it ever exists.

See https://github.com/kubevirt/project-infra/pull/2212 for example failures.

This makes it possible to have podman as a package on the CI images
without the additional changes being done yet.