### PR TITLE
vm based providers: Pin NetworkManager version 

### DIFF
--- a/cluster-provision/k8s/1.22/k8s_provision.sh
+++ b/cluster-provision/k8s/1.22/k8s_provision.sh
@@ -47,7 +47,9 @@ systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet
 
-dnf install -y NetworkManager NetworkManager-ovs
+# Version 1.39.7-x cause the VM to hang on random places
+NETWORK_MANAGER_VERSION=1.39.5-1
+dnf install -y NetworkManager-${NETWORK_MANAGER_VERSION}.el8.x86_64 NetworkManager-ovs-${NETWORK_MANAGER_VERSION}.el8.x86_64
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -195,7 +197,7 @@ mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
-dnf install -y NetworkManager-config-server
+dnf install -y NetworkManager-config-server-${NETWORK_MANAGER_VERSION}.el8.noarch
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.23/k8s_provision.sh
+++ b/cluster-provision/k8s/1.23/k8s_provision.sh
@@ -42,7 +42,9 @@ systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet
 
-dnf install -y NetworkManager NetworkManager-ovs
+# Version 1.39.7-x cause the VM to hang on random places
+NETWORK_MANAGER_VERSION=1.39.5-1
+dnf install -y NetworkManager-${NETWORK_MANAGER_VERSION}.el8.x86_64 NetworkManager-ovs-${NETWORK_MANAGER_VERSION}.el8.x86_64
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -188,7 +190,7 @@ mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
-dnf install -y NetworkManager-config-server
+dnf install -y NetworkManager-config-server-${NETWORK_MANAGER_VERSION}.el8.noarch
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.24-ipv6/k8s_provision.sh
+++ b/cluster-provision/k8s/1.24-ipv6/k8s_provision.sh
@@ -46,7 +46,9 @@ rm -f /etc/cni/net.d/*
 systemctl daemon-reload
 systemctl enable crio kubelet --now
 
-dnf install -y NetworkManager NetworkManager-ovs
+# Version 1.39.7-x cause the VM to hang on random places
+NETWORK_MANAGER_VERSION=1.39.5-1
+dnf install -y NetworkManager-${NETWORK_MANAGER_VERSION}.el8.x86_64 NetworkManager-ovs-${NETWORK_MANAGER_VERSION}.el8.x86_64
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -195,7 +197,7 @@ mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
-dnf install -y NetworkManager-config-server
+dnf install -y NetworkManager-config-server-${NETWORK_MANAGER_VERSION}.el8.noarch
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.24/k8s_provision.sh
+++ b/cluster-provision/k8s/1.24/k8s_provision.sh
@@ -46,7 +46,9 @@ rm -f /etc/cni/net.d/*
 systemctl daemon-reload
 systemctl enable crio kubelet --now
 
-dnf install -y NetworkManager NetworkManager-ovs
+# Version 1.39.7-x cause the VM to hang on random places
+NETWORK_MANAGER_VERSION=1.39.5-1
+dnf install -y NetworkManager-${NETWORK_MANAGER_VERSION}.el8.x86_64 NetworkManager-ovs-${NETWORK_MANAGER_VERSION}.el8.x86_64
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -195,7 +197,7 @@ mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
-dnf install -y NetworkManager-config-server
+dnf install -y NetworkManager-config-server-${NETWORK_MANAGER_VERSION}.el8.noarch
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)


### PR DESCRIPTION
NetworkManager 1.39.7-x causes the node to get stuck on
various stages.
For example during CNI deploy or during kubeadm reset.
The provision / publish fails due to that without informative data.
For example
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/831/check-provision-k8s-1.24/1549349853673295872
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirtci/1549206667130834944

It happens even on idle VM after modifying the interface
and running the following command
"nmcli connection up" without creating a cluster.

In talk with NM team offline in order to find the root cause.
Meanwhile pinning the NM version 2 versions back, where it doesn't happen.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2109285