### PR TITLE
vm based: Add validation that single stack is indeed as expected

### DIFF
--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -41,7 +41,7 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
     timeout 210s bash -c "until ${ksh} wait --for=condition=Ready pod --timeout=30s --all -l app!=whereabouts; do sleep 1; done"
     timeout 210s bash -c "until ${ksh} wait --for=condition=Ready pod --timeout=30s -n kube-system --all -l app!=whereabouts; do sleep 1; done"
     ${ksh} get nodes
-    ${ksh} get pods -A
+    ${ksh} get pods -A -owide
 
     # Run some checks for KUBEVIRT_NUM_NODES
     # and KUBEVIRT_NUM_SECONDARY_NICS


### PR DESCRIPTION
Update `check-cluster-up` script to validate single stack cluster is indeed
IPv6 single stack by validating it has only one IP, and this IP is IPv6.

Additional change:
Print the pods with `-owide` to see the IPs for each pod.
It would help to see if the cluster IPs are as expected.
Both in case of failure and generally.
