### PR TITLE
registry proxy: Fix crio support

### DIFF
--- a/K8S.md
+++ b/K8S.md
@@ -37,7 +37,7 @@ SSH into a node
 cluster-up/ssh.sh node01                                                   
 ```                                                                        
                                                                            
-Attach to node console with screen and pty
+## Attach to node console with screen and pty
 ```                                                  
 # Attach to node01 console                           
 docker exec -it ${KUBEVIRT_PROVIDER}-node01 screen /dev/pts/0
@@ -49,3 +49,9 @@ Make sure you don't leave open screens, else the next screen will be messed up.
 `screen -ls` shows the open screens.  
 `screen -XS <ID> quit` closes an open session.  
 Close all zombies and shutdown screen gracefully if you plan to open a new one instead.
+
+## Container image cache
+In order to have a local cache of container images:
+1. Run your proxy (see for example https://github.com/rpardini/docker-registry-proxy)
+2. Get the IP:PORT of the proxy and run `export KUBEVIRTCI_PROXY=http://<IP>:<PORT>`
+3. Run `cluster-up` flow as usual

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -34,17 +34,19 @@ import (
 
 const (
 	proxySettings = `
-mkdir -p /etc/systemd/system/docker.service.d/
+curl {{.Proxy}}/ca.crt > /etc/pki/ca-trust/source/anchors/docker_registry_proxy.crt
+update-ca-trust
 
-cat <<EOT  >/etc/systemd/system/docker.service.d/proxy.conf
+mkdir -p /etc/systemd/system/crio.service.d
+cat <<EOT >/etc/systemd/system/crio.service.d/override.conf
 [Service]
 Environment="HTTP_PROXY={{.Proxy}}"
 Environment="HTTPS_PROXY={{.Proxy}}"
-Environment="NO_PROXY=localhost,127.0.0.1"
+Environment="NO_PROXY=localhost,127.0.0.1,registry,10.96.0.0/12,10.244.0.0/16,192.168.0.0/16,fd00:10:96::/112,fd00:10:244::/112,fd00::/64"
 EOT
 
 systemctl daemon-reload
-systemctl restart docker
+systemctl restart crio.service
 EOF
 `
 	etcdDataDir         = "/var/lib/etcd"

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -140,6 +140,11 @@ function _add_common_params() {
     if [ -n "$KUBEVIRT_REALTIME_SCHEDULER" ]; then
         params=" --enable-realtime-scheduler $params"
     fi
+
+    if [ -n "$KUBEVIRTCI_PROXY" ]; then
+        params=" --docker-proxy=$KUBEVIRTCI_PROXY $params"
+    fi
+
     echo $params
 }
 


### PR DESCRIPTION
Fix registry proxy support for crio (the CRI that we use).
It is an opt-in optional feature.

It will allow to to overcome `docker.io` rate limits,
and to cache container images locally in order to save time.

Tested with the following commands (works also with podman):
```
docker volume create registry-ca
docker volume create registry-mirror-cache

docker run -d --restart=always --name docker_registry_proxy -it -p 0.0.0.0:3128:3128 -e ENABLE_MANIFEST_CACHE=true -e ALLOW_PUSH=true -e PROXY_CONNECT_TIMEOUT=600s -e PROXY_CONNECT_READ_TIMEOUT=600s -e PROXY_CONNECT_CONNECT_TIMEOUT=600s -e PROXY_CONNECT_SEND_TIMEOUT=600s -e SEND_TIMEOUT=600s -e CLIENT_BODY_TIMEOUT=600s -e CLIENT_HEADER_TIMEOUT=600s -e PROXY_READ_TIMEOUT=600s -e PROXY_CONNECT_TIMEOUT=600s -e PROXY_SEND_TIMEOUT=600s --mount type=volume,source=registry-mirror-cache,target=/docker_mirror_cache --mount type=volume,source=registry-ca,target=/ca quay.io/kubevirtci/rpardini-docker-registry-proxy:0.6.2
```

Get proxy ip by
`docker inspect docker_registry_proxy -f '{{.NetworkSettings.Networks.bridge.IPAddress}}'`

Tested sig-network tests, kubevirt conformance, and k8s conformance with both
single stack IPv6 and dual stack with the proxy locally.

Ref: https://github.com/kubevirt/kubevirtci/pull/70 (which did the same for the previous CRI)