### PR TITLE
istio: Use quay.io as the hub

### DIFF
--- a/cluster-provision/k8s/1.22/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.22/extra-pre-pull-images
@@ -1,8 +1,8 @@
 docker.io/grafana/grafana:7.5.4
-docker.io/istio/install-cni:1.10.0
-docker.io/istio/operator:1.10.0
-docker.io/istio/pilot:1.10.0
-docker.io/istio/proxyv2:1.10.0
+quay.io/kubevirtci/install-cni:1.10.0
+quay.io/kubevirtci/operator:1.10.0
+quay.io/kubevirtci/pilot:1.10.0
+quay.io/kubevirtci/proxyv2:1.10.0
 quay.io/prometheus-operator/prometheus-config-reloader:v0.47.0
 quay.io/calico/cni:v3.18.0
 quay.io/calico/kube-controllers:v3.18.0

--- a/cluster-provision/k8s/1.22/istio.sh
+++ b/cluster-provision/k8s/1.22/istio.sh
@@ -6,7 +6,7 @@ source /var/lib/kubevirtci/shared_vars.sh
 export PATH=$ISTIO_BIN_DIR:$PATH
 
 kubectl --kubeconfig /etc/kubernetes/admin.conf create ns istio-system
-istioctl --kubeconfig /etc/kubernetes/admin.conf operator init
+istioctl --kubeconfig /etc/kubernetes/admin.conf --hub quay.io/kubevirtci operator init
 
 istio_manifests_dir=/opt/istio
 mkdir -p /opt/istio
@@ -18,6 +18,7 @@ metadata:
   name: istio-operator
 spec:
   profile: demo
+  hub: quay.io/kubevirtci
   components:
     cni:
       enabled: true

--- a/cluster-provision/k8s/1.22/provision.sh
+++ b/cluster-provision/k8s/1.22/provision.sh
@@ -85,8 +85,6 @@ export PATH=$ISTIO_BIN_DIR:$PATH
   curl https://storage.googleapis.com/kubevirtci-istioctl-mirror/istio-$ISTIO_VERSION/bin/istioctl -o $ISTIO_BIN_DIR/istioctl
   chmod +x $ISTIO_BIN_DIR/istioctl
 )
-# generate Istio manifests for pre-pulling images
-istioctl manifest generate --set profile=demo --set components.cni.enabled=true | tee /tmp/istio-deployment.yaml
 
 export CRIO_VERSION=1.22
 cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo

--- a/cluster-provision/k8s/1.23/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.23/extra-pre-pull-images
@@ -1,8 +1,8 @@
 docker.io/grafana/grafana:7.5.4
-docker.io/istio/install-cni:1.10.0
-docker.io/istio/operator:1.10.0
-docker.io/istio/pilot:1.10.0
-docker.io/istio/proxyv2:1.10.0
+quay.io/kubevirtci/install-cni:1.10.0
+quay.io/kubevirtci/operator:1.10.0
+quay.io/kubevirtci/pilot:1.10.0
+quay.io/kubevirtci/proxyv2:1.10.0
 quay.io/prometheus-operator/prometheus-config-reloader:v0.47.0
 quay.io/calico/cni:v3.18.0
 quay.io/calico/kube-controllers:v3.18.0

--- a/cluster-provision/k8s/1.23/istio.sh
+++ b/cluster-provision/k8s/1.23/istio.sh
@@ -6,7 +6,7 @@ source /var/lib/kubevirtci/shared_vars.sh
 export PATH=$ISTIO_BIN_DIR:$PATH
 
 kubectl --kubeconfig /etc/kubernetes/admin.conf create ns istio-system
-istioctl --kubeconfig /etc/kubernetes/admin.conf operator init
+istioctl --kubeconfig /etc/kubernetes/admin.conf --hub quay.io/kubevirtci operator init
 
 istio_manifests_dir=/opt/istio
 mkdir -p /opt/istio
@@ -18,6 +18,7 @@ metadata:
   name: istio-operator
 spec:
   profile: demo
+  hub: quay.io/kubevirtci
   components:
     cni:
       enabled: true

--- a/cluster-provision/k8s/1.23/provision.sh
+++ b/cluster-provision/k8s/1.23/provision.sh
@@ -77,8 +77,6 @@ export PATH=$ISTIO_BIN_DIR:$PATH
   curl https://storage.googleapis.com/kubevirtci-istioctl-mirror/istio-$ISTIO_VERSION/bin/istioctl -o $ISTIO_BIN_DIR/istioctl
   chmod +x $ISTIO_BIN_DIR/istioctl
 )
-# generate Istio manifests for pre-pulling images
-istioctl manifest generate --set profile=demo --set components.cni.enabled=true | tee /tmp/istio-deployment.yaml
 
 export CRIO_VERSION=1.22
 cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo

--- a/cluster-provision/k8s/1.24-ipv6/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.24-ipv6/extra-pre-pull-images
@@ -1,8 +1,8 @@
 docker.io/grafana/grafana:7.5.4
-docker.io/istio/install-cni:1.10.0
-docker.io/istio/operator:1.10.0
-docker.io/istio/pilot:1.10.0
-docker.io/istio/proxyv2:1.10.0
+quay.io/kubevirtci/install-cni:1.10.0
+quay.io/kubevirtci/operator:1.10.0
+quay.io/kubevirtci/pilot:1.10.0
+quay.io/kubevirtci/proxyv2:1.10.0
 quay.io/prometheus-operator/prometheus-config-reloader:v0.47.0
 quay.io/calico/cni:v3.18.0
 quay.io/calico/kube-controllers:v3.18.0

--- a/cluster-provision/k8s/1.24-ipv6/istio.sh
+++ b/cluster-provision/k8s/1.24-ipv6/istio.sh
@@ -6,7 +6,7 @@ source /var/lib/kubevirtci/shared_vars.sh
 export PATH=$ISTIO_BIN_DIR:$PATH
 
 kubectl --kubeconfig /etc/kubernetes/admin.conf create ns istio-system
-istioctl --kubeconfig /etc/kubernetes/admin.conf operator init
+istioctl --kubeconfig /etc/kubernetes/admin.conf --hub quay.io/kubevirtci operator init
 
 istio_manifests_dir=/opt/istio
 mkdir -p /opt/istio
@@ -18,6 +18,7 @@ metadata:
   name: istio-operator
 spec:
   profile: demo
+  hub: quay.io/kubevirtci
   components:
     cni:
       enabled: true

--- a/cluster-provision/k8s/1.24-ipv6/provision.sh
+++ b/cluster-provision/k8s/1.24-ipv6/provision.sh
@@ -84,8 +84,6 @@ export PATH=$ISTIO_BIN_DIR:$PATH
   curl https://storage.googleapis.com/kubevirtci-istioctl-mirror/istio-$ISTIO_VERSION/bin/istioctl -o $ISTIO_BIN_DIR/istioctl
   chmod +x $ISTIO_BIN_DIR/istioctl
 )
-# generate Istio manifests for pre-pulling images
-istioctl manifest generate --set profile=demo --set components.cni.enabled=true | tee /tmp/istio-deployment.yaml
 
 export CRIO_VERSION=1.22
 cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo

--- a/cluster-provision/k8s/1.24/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.24/extra-pre-pull-images
@@ -1,8 +1,8 @@
 docker.io/grafana/grafana:7.5.4
-docker.io/istio/install-cni:1.10.0
-docker.io/istio/operator:1.10.0
-docker.io/istio/pilot:1.10.0
-docker.io/istio/proxyv2:1.10.0
+quay.io/kubevirtci/install-cni:1.10.0
+quay.io/kubevirtci/operator:1.10.0
+quay.io/kubevirtci/pilot:1.10.0
+quay.io/kubevirtci/proxyv2:1.10.0
 quay.io/prometheus-operator/prometheus-config-reloader:v0.47.0
 quay.io/calico/cni:v3.18.0
 quay.io/calico/kube-controllers:v3.18.0

--- a/cluster-provision/k8s/1.24/istio.sh
+++ b/cluster-provision/k8s/1.24/istio.sh
@@ -6,7 +6,7 @@ source /var/lib/kubevirtci/shared_vars.sh
 export PATH=$ISTIO_BIN_DIR:$PATH
 
 kubectl --kubeconfig /etc/kubernetes/admin.conf create ns istio-system
-istioctl --kubeconfig /etc/kubernetes/admin.conf operator init
+istioctl --kubeconfig /etc/kubernetes/admin.conf --hub quay.io/kubevirtci operator init
 
 istio_manifests_dir=/opt/istio
 mkdir -p /opt/istio
@@ -18,6 +18,7 @@ metadata:
   name: istio-operator
 spec:
   profile: demo
+  hub: quay.io/kubevirtci
   components:
     cni:
       enabled: true

--- a/cluster-provision/k8s/1.24/provision.sh
+++ b/cluster-provision/k8s/1.24/provision.sh
@@ -84,8 +84,6 @@ export PATH=$ISTIO_BIN_DIR:$PATH
   curl https://storage.googleapis.com/kubevirtci-istioctl-mirror/istio-$ISTIO_VERSION/bin/istioctl -o $ISTIO_BIN_DIR/istioctl
   chmod +x $ISTIO_BIN_DIR/istioctl
 )
-# generate Istio manifests for pre-pulling images
-istioctl manifest generate --set profile=demo --set components.cni.enabled=true | tee /tmp/istio-deployment.yaml
 
 export CRIO_VERSION=1.22
 cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo


### PR DESCRIPTION
In order to use quay.io over docker.io (that has rate limits),
update Istio opreator hub to point to `quay.io/kubevirtci`.
The images caching is done via `extra-pre-pull-images` so no need to
also generate manifests for the pre pulling.

In order to bump Istio:
Mirror the images to quay (project-infra `hack/images_to_mirror.csv`)
and update them on `extra-pre-pull-images`

Depends on https://github.com/kubevirt/project-infra/pull/2236 (merged)
