### PR TITLE
grafana: Use quay mirror

### DIFF
--- a/cluster-provision/k8s/1.22/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.22/extra-pre-pull-images
@@ -1,4 +1,4 @@
-docker.io/grafana/grafana:7.5.4
+quay.io/kubevirtci/grafana-grafana:7.5.4
 quay.io/kubevirtci/install-cni:1.10.0
 quay.io/kubevirtci/operator:1.10.0
 quay.io/kubevirtci/pilot:1.10.0

--- a/cluster-provision/k8s/1.22/manifests/prometheus/grafana/kustomization.yaml
+++ b/cluster-provision/k8s/1.22/manifests/prometheus/grafana/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- grafana-deployment.yaml
+images:
+  - name: grafana/grafana
+    newName: quay.io/kubevirtci/grafana-grafana

--- a/cluster-provision/k8s/1.22/provision.sh
+++ b/cluster-provision/k8s/1.22/provision.sh
@@ -153,6 +153,9 @@ cni_manifest="/provision/cni.yaml"
 mv /tmp/cni.do-not-change.yaml $cni_manifest
 patch $cni_manifest $cni_diff
 
+kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
+mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
+
 if [[ ${slim} == false ]]; then
     # Pre pull all images from the manifests
     for image in $(/tmp/fetch-images.sh /tmp); do

--- a/cluster-provision/k8s/1.23/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.23/extra-pre-pull-images
@@ -1,4 +1,4 @@
-docker.io/grafana/grafana:7.5.4
+quay.io/kubevirtci/grafana-grafana:7.5.4
 quay.io/kubevirtci/install-cni:1.10.0
 quay.io/kubevirtci/operator:1.10.0
 quay.io/kubevirtci/pilot:1.10.0

--- a/cluster-provision/k8s/1.23/manifests/prometheus/grafana/kustomization.yaml
+++ b/cluster-provision/k8s/1.23/manifests/prometheus/grafana/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- grafana-deployment.yaml
+images:
+  - name: grafana/grafana
+    newName: quay.io/kubevirtci/grafana-grafana

--- a/cluster-provision/k8s/1.23/provision.sh
+++ b/cluster-provision/k8s/1.23/provision.sh
@@ -145,6 +145,9 @@ cni_manifest="/provision/cni.yaml"
 mv /tmp/cni.do-not-change.yaml $cni_manifest
 patch $cni_manifest /tmp/cni.diff
 
+kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
+mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
+
 if [[ ${slim} == false ]]; then
     # Pre pull all images from the manifests
     for image in $(/tmp/fetch-images.sh /tmp); do

--- a/cluster-provision/k8s/1.24-ipv6/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.24-ipv6/extra-pre-pull-images
@@ -1,4 +1,4 @@
-docker.io/grafana/grafana:7.5.4
+quay.io/kubevirtci/grafana-grafana:7.5.4
 quay.io/kubevirtci/install-cni:1.10.0
 quay.io/kubevirtci/operator:1.10.0
 quay.io/kubevirtci/pilot:1.10.0

--- a/cluster-provision/k8s/1.24-ipv6/manifests/prometheus/grafana/kustomization.yaml
+++ b/cluster-provision/k8s/1.24-ipv6/manifests/prometheus/grafana/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- grafana-deployment.yaml
+images:
+  - name: grafana/grafana
+    newName: quay.io/kubevirtci/grafana-grafana

--- a/cluster-provision/k8s/1.24-ipv6/provision.sh
+++ b/cluster-provision/k8s/1.24-ipv6/provision.sh
@@ -154,6 +154,9 @@ cni_manifest="/provision/cni.yaml"
 mv /tmp/cni.do-not-change.yaml $cni_manifest
 patch $cni_manifest $cni_diff
 
+kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
+mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
+
 if [[ ${slim} == false ]]; then
     # Pre pull all images from the manifests
     for image in $(/tmp/fetch-images.sh /tmp); do

--- a/cluster-provision/k8s/1.24/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.24/extra-pre-pull-images
@@ -1,4 +1,4 @@
-docker.io/grafana/grafana:7.5.4
+quay.io/kubevirtci/grafana-grafana:7.5.4
 quay.io/kubevirtci/install-cni:1.10.0
 quay.io/kubevirtci/operator:1.10.0
 quay.io/kubevirtci/pilot:1.10.0

--- a/cluster-provision/k8s/1.24/manifests/prometheus/grafana/kustomization.yaml
+++ b/cluster-provision/k8s/1.24/manifests/prometheus/grafana/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- grafana-deployment.yaml
+images:
+  - name: grafana/grafana
+    newName: quay.io/kubevirtci/grafana-grafana

--- a/cluster-provision/k8s/1.24/provision.sh
+++ b/cluster-provision/k8s/1.24/provision.sh
@@ -154,6 +154,9 @@ cni_manifest="/provision/cni.yaml"
 mv /tmp/cni.do-not-change.yaml $cni_manifest
 patch $cni_manifest $cni_diff
 
+kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
+mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
+
 if [[ ${slim} == false ]]; then
     # Pre pull all images from the manifests
     for image in $(/tmp/fetch-images.sh /tmp); do


### PR DESCRIPTION
Kustomize `grafana` to use quay image.

Had to do the following fix for that:    
Currently manifests are copied both on `linux`
and `k8s` phases.
In case using phased mode, the changes
that are done on the `linux` phase would be overridden.
Some changes should be done on `linux` phase
because the images are pre pulled on this phase,
so it should be done before pre pulling.
Therefore copy the manifests only on the `linux` phase.

Additional cosmetic change:
Verify that the script exists just before running it.
