### PR TITLE
local storage: Fix deploy flow

### DIFF
--- a/cluster-provision/k8s/1.22/manifests/local-volume.yaml
+++ b/cluster-provision/k8s/1.22/manifests/local-volume.yaml
@@ -2,8 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
  name: local
- annotations:
-  storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete

--- a/cluster-provision/k8s/1.22/rook-ceph.sh
+++ b/cluster-provision/k8s/1.22/rook-ceph.sh
@@ -33,5 +33,4 @@ kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/ceph/storageclass
 kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/ceph/snapshotclass.yaml
 
 # set default storageclass
-kubectl --kubeconfig /etc/kubernetes/admin.conf patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 kubectl --kubeconfig /etc/kubernetes/admin.conf patch storageclass rook-ceph-block -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'

--- a/cluster-provision/k8s/1.23/manifests/local-volume.yaml
+++ b/cluster-provision/k8s/1.23/manifests/local-volume.yaml
@@ -2,8 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
  name: local
- annotations:
-  storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete

--- a/cluster-provision/k8s/1.23/rook-ceph.sh
+++ b/cluster-provision/k8s/1.23/rook-ceph.sh
@@ -33,5 +33,4 @@ kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/ceph/storageclass
 kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/ceph/snapshotclass.yaml
 
 # set default storageclass
-kubectl --kubeconfig /etc/kubernetes/admin.conf patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 kubectl --kubeconfig /etc/kubernetes/admin.conf patch storageclass rook-ceph-block -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'

--- a/cluster-provision/k8s/1.24-ipv6/manifests/local-volume.yaml
+++ b/cluster-provision/k8s/1.24-ipv6/manifests/local-volume.yaml
@@ -2,8 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
  name: local
- annotations:
-  storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete

--- a/cluster-provision/k8s/1.24-ipv6/rook-ceph.sh
+++ b/cluster-provision/k8s/1.24-ipv6/rook-ceph.sh
@@ -33,5 +33,4 @@ kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/ceph/storageclass
 kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/ceph/snapshotclass.yaml
 
 # set default storageclass
-kubectl --kubeconfig /etc/kubernetes/admin.conf patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 kubectl --kubeconfig /etc/kubernetes/admin.conf patch storageclass rook-ceph-block -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'

--- a/cluster-provision/k8s/1.24/manifests/local-volume.yaml
+++ b/cluster-provision/k8s/1.24/manifests/local-volume.yaml
@@ -2,8 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
  name: local
- annotations:
-  storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete

--- a/cluster-provision/k8s/1.24/rook-ceph.sh
+++ b/cluster-provision/k8s/1.24/rook-ceph.sh
@@ -33,5 +33,4 @@ kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/ceph/storageclass
 kubectl --kubeconfig /etc/kubernetes/admin.conf create -f /tmp/ceph/snapshotclass.yaml
 
 # set default storageclass
-kubectl --kubeconfig /etc/kubernetes/admin.conf patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 kubectl --kubeconfig /etc/kubernetes/admin.conf patch storageclass rook-ceph-block -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -98,6 +98,11 @@ function deploy_cdi() {
 function deploy_local_storage() {
     if [ "$KUBEVIRT_DEPLOY_LOCAL_STORAGE" == "true" ]; then
         $kubectl create -f /provision/local-volume.yaml
+
+        default_storage_class=$($kubectl get storageclass -o jsonpath='{\.items[?\(@\.metadata\.annotations\.storageclass\\.kubernetes\\.io/is-default-class==\"true\"\)].metadata.name}')
+        if [ -z $default_storage_class ]; then
+            $kubectl patch storageclass/local -p \'{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"}}}\'
+        fi
     fi
 }
 


### PR DESCRIPTION
Since local storage is deployed now after ceph,
ceph can't update local storage labels.

Remove the labels from the local storage manifests,
and add them only if no other default storage was detected.
This way ceph won't need to update them at all.
