### PR TITLE
Revert "vm based providers: Pin NetworkManager version (#841)"

### DIFF
--- a/cluster-provision/k8s/1.22/k8s_provision.sh
+++ b/cluster-provision/k8s/1.22/k8s_provision.sh
@@ -47,9 +47,7 @@ systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet
 
-# Version 1.39.7-x cause the VM to hang on random places
-NETWORK_MANAGER_VERSION=1.39.5-1
-dnf install -y NetworkManager-${NETWORK_MANAGER_VERSION}.el8.x86_64 NetworkManager-ovs-${NETWORK_MANAGER_VERSION}.el8.x86_64
+dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -197,7 +195,7 @@ mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
-dnf install -y NetworkManager-config-server-${NETWORK_MANAGER_VERSION}.el8.noarch
+dnf install -y NetworkManager-config-server
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.23/k8s_provision.sh
+++ b/cluster-provision/k8s/1.23/k8s_provision.sh
@@ -42,9 +42,7 @@ systemctl daemon-reload
 systemctl enable crio && systemctl start crio
 systemctl enable kubelet && systemctl start kubelet
 
-# Version 1.39.7-x cause the VM to hang on random places
-NETWORK_MANAGER_VERSION=1.39.5-1
-dnf install -y NetworkManager-${NETWORK_MANAGER_VERSION}.el8.x86_64 NetworkManager-ovs-${NETWORK_MANAGER_VERSION}.el8.x86_64
+dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -190,7 +188,7 @@ mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
-dnf install -y NetworkManager-config-server-${NETWORK_MANAGER_VERSION}.el8.noarch
+dnf install -y NetworkManager-config-server
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.24-ipv6/k8s_provision.sh
+++ b/cluster-provision/k8s/1.24-ipv6/k8s_provision.sh
@@ -46,9 +46,7 @@ rm -f /etc/cni/net.d/*
 systemctl daemon-reload
 systemctl enable crio kubelet --now
 
-# Version 1.39.7-x cause the VM to hang on random places
-NETWORK_MANAGER_VERSION=1.39.5-1
-dnf install -y NetworkManager-${NETWORK_MANAGER_VERSION}.el8.x86_64 NetworkManager-ovs-${NETWORK_MANAGER_VERSION}.el8.x86_64
+dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -197,7 +195,7 @@ mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
-dnf install -y NetworkManager-config-server-${NETWORK_MANAGER_VERSION}.el8.noarch
+dnf install -y NetworkManager-config-server
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.24/k8s_provision.sh
+++ b/cluster-provision/k8s/1.24/k8s_provision.sh
@@ -46,9 +46,7 @@ rm -f /etc/cni/net.d/*
 systemctl daemon-reload
 systemctl enable crio kubelet --now
 
-# Version 1.39.7-x cause the VM to hang on random places
-NETWORK_MANAGER_VERSION=1.39.5-1
-dnf install -y NetworkManager-${NETWORK_MANAGER_VERSION}.el8.x86_64 NetworkManager-ovs-${NETWORK_MANAGER_VERSION}.el8.x86_64
+dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -197,7 +195,7 @@ mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
 
-dnf install -y NetworkManager-config-server-${NETWORK_MANAGER_VERSION}.el8.noarch
+dnf install -y NetworkManager-config-server
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)


### PR DESCRIPTION
This reverts commit ba7681ad70efa523c42abb8578ad4c65054687c3.
(https://github.com/kubevirt/kubevirtci/pull/841)

The BZ was fixed.
https://bugzilla.redhat.com/show_bug.cgi?id=2109285
