### PR TITLE
Upgrade cri-o to version 1.24 for 1.24 providers

### DIFF
--- a/cluster-provision/k8s/1.24-ipv6/provision.sh
+++ b/cluster-provision/k8s/1.24-ipv6/provision.sh
@@ -85,7 +85,7 @@ export PATH=$ISTIO_BIN_DIR:$PATH
   chmod +x $ISTIO_BIN_DIR/istioctl
 )
 
-export CRIO_VERSION=1.22
+export CRIO_VERSION=1.24
 cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo
 [devel_kubic_libcontainers_stable]
 name=Stable Releases of Upstream github.com/containers packages (CentOS_8_Stream)

--- a/cluster-provision/k8s/1.24/provision.sh
+++ b/cluster-provision/k8s/1.24/provision.sh
@@ -85,7 +85,7 @@ export PATH=$ISTIO_BIN_DIR:$PATH
   chmod +x $ISTIO_BIN_DIR/istioctl
 )
 
-export CRIO_VERSION=1.22
+export CRIO_VERSION=1.24
 cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo
 [devel_kubic_libcontainers_stable]
 name=Stable Releases of Upstream github.com/containers packages (CentOS_8_Stream)


### PR DESCRIPTION
The cri-o version for the 1.24 provider was downgraded to 1.22[1] due to
an intermittent issue[2]. This issue has been resolved in the latest
release of cri-o so upgrading to 1.24.

[1] https://github.com/kubevirt/kubevirtci/pull/809
[2] https://github.com/cri-o/cri-o/issues/5889

/cc @xpivarc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>