### PR TITLE
Bump ceph patch version

### DIFF
--- a/cluster-provision/k8s/1.22/manifests/ceph/cluster-test.yaml
+++ b/cluster-provision/k8s/1.22/manifests/ceph/cluster-test.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: quay.io/ceph/ceph:v16.2.7
+    image: quay.io/ceph/ceph:v16.2.10
     allowUnsupported: true
   mon:
     count: 1

--- a/cluster-provision/k8s/1.23/manifests/ceph/cluster-test.yaml
+++ b/cluster-provision/k8s/1.23/manifests/ceph/cluster-test.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: quay.io/ceph/ceph:v16.2.7
+    image: quay.io/ceph/ceph:v16.2.10
     allowUnsupported: true
   mon:
     count: 1

--- a/cluster-provision/k8s/1.24-ipv6/manifests/ceph/cluster-test.yaml
+++ b/cluster-provision/k8s/1.24-ipv6/manifests/ceph/cluster-test.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: quay.io/ceph/ceph:v16.2.7
+    image: quay.io/ceph/ceph:v16.2.10
     allowUnsupported: true
   mon:
     count: 1

--- a/cluster-provision/k8s/1.24/manifests/ceph/cluster-test.yaml
+++ b/cluster-provision/k8s/1.24/manifests/ceph/cluster-test.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: quay.io/ceph/ceph:v16.2.7
+    image: quay.io/ceph/ceph:v16.2.10
     allowUnsupported: true
   mon:
     count: 1


### PR DESCRIPTION
Update ceph to latest "patch version" to get stability and security fixes.

Bump from v16.2.7 to v16.2.10:
https://ceph.com/en/news/blog/2022/v16-2-10-pacific-released/
https://ceph.com/en/news/blog/2022/v16-2-9-pacific-released/
https://ceph.com/en/news/blog/2022/v16-2-8-pacific-released/

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>