### PR TITLE
Pin containers-common to a specific version

### DIFF
--- a/cluster-provision/k8s/1.22/provision.sh
+++ b/cluster-provision/k8s/1.22/provision.sh
@@ -103,7 +103,9 @@ baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcon
 gpgcheck=0
 enabled=1
 EOF
-dnf install -y cri-o
+# TODO: Remove the package pinning once cri-o support the new 'keyPaths' key
+dnf install -y cri-o containers-common-1-23.module_el8.7.0+1106+45480ee0.x86_64
+echo "" >> /etc/containers/policy.json
 
 # install podman for functionality missing in crictl (tag, etc)
 dnf install -y podman

--- a/cluster-provision/k8s/1.23/provision.sh
+++ b/cluster-provision/k8s/1.23/provision.sh
@@ -95,7 +95,9 @@ baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcon
 gpgcheck=0
 enabled=1
 EOF
-dnf install -y cri-o
+# TODO: Remove the package pinning once cri-o support the new 'keyPaths' key
+dnf install -y cri-o containers-common-1-23.module_el8.7.0+1106+45480ee0.x86_64
+echo "" >> /etc/containers/policy.json
 
 # install podman for functionality missing in crictl (tag, etc)
 dnf install -y podman

--- a/cluster-provision/k8s/1.24-ipv6/provision.sh
+++ b/cluster-provision/k8s/1.24-ipv6/provision.sh
@@ -102,7 +102,9 @@ baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcon
 gpgcheck=0
 enabled=1
 EOF
-dnf install -y cri-o
+# TODO: Remove the package pinning once cri-o support the new 'keyPaths' key
+dnf install -y cri-o containers-common-1-23.module_el8.7.0+1106+45480ee0.x86_64
+echo "" >> /etc/containers/policy.json
 
 systemctl enable --now crio
 

--- a/cluster-provision/k8s/1.24/provision.sh
+++ b/cluster-provision/k8s/1.24/provision.sh
@@ -102,7 +102,10 @@ baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcon
 gpgcheck=0
 enabled=1
 EOF
-dnf install -y cri-o
+# TODO: Remove the package pinning once cri-o support the new 'keyPaths' key
+#       and we modifying the policy.json file to prevent from the upgrade from replacing it
+dnf install -y cri-o containers-common-1-23.module_el8.7.0+1106+45480ee0.x86_64
+echo "" >> /etc/containers/policy.json
 
 systemctl enable --now crio
 


### PR DESCRIPTION
As 'cri-o' dons't support the new 'keyPaths' keyword in /etc/containers/policy.json

Signed-off-by: Rabin Yasharzadehe <rabin@redhat.com>