### PR TITLE
Retry removing containers that may have failed to delete due to dependent containers

### DIFF
--- a/cluster-provision/gocli/docker/docker.go
+++ b/cluster-provision/gocli/docker/docker.go
@@ -207,6 +207,8 @@ func NewCleanupHandler(cli *client.Client, cleanupChan chan error, errWriter io.
 	go func() {
 		createdContainers := []string{}
 		createdVolumes := []string{}
+		containersFailedToRemove := []string{}
+
 		defer close(done)
 
 		for {
@@ -229,6 +231,13 @@ func NewCleanupHandler(cli *client.Client, cleanupChan chan error, errWriter io.
 								io.Copy(os.Stderr, reader)
 							}
 						}
+						err := cli.ContainerRemove(ctx, c, types.ContainerRemoveOptions{Force: true})
+						if err != nil {
+							fmt.Fprintf(errWriter, "%v\n", err)
+							containersFailedToRemove = append(containersFailedToRemove, c)
+						}
+					}
+					for _, c := range containersFailedToRemove {
 						err := cli.ContainerRemove(ctx, c, types.ContainerRemoveOptions{Force: true})
 						if err != nil {
 							fmt.Fprintf(errWriter, "%v\n", err)


### PR DESCRIPTION
During kubevirtci provisioning, the provision-dnsmasq container fails to
delete when run with podman as there are dependent containers still
running[1].

Adding a retry here successfully removes the provision-dnsmasq container
as there are no longer any dependent containers.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirtci/1565349289993965568#1:build-log.txt%3A4745

/cc @oshoval @dhiller @enp0s3 

Signed-off-by: Brian Carey <bcarey@redhat.com>