### PR TITLE
Fix cloud init on alpine with test tooling

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
@@ -22,4 +22,6 @@ sed -Ei \
 step 'Enable services'
 rc-update add qemu-guest-agent default
 rc-update add cloud-init default
-rc-update add sshd
+rc-update add cloud-config default
+rc-update add cloud-final default
+rc-update add sshd default


### PR DESCRIPTION
The cloud init hangs in running and thus will never execute a user script:
```bash
alpine-test-tooling-cloudinit:~# cloud-init status
status: running
```
According to https://bugs.launchpad.net/cloud-init/+bug/1950915/comments/5 this should fix this.

Fixes #874 

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>