### PR TITLE
kind-1.22-sriov, provider.sh: Remove unused SRIOV_TESTS_NS variable

### DIFF
--- a/cluster-up/cluster/kind-1.22-sriov/provider.sh
+++ b/cluster-up/cluster/kind-1.22-sriov/provider.sh
@@ -13,10 +13,6 @@ else
     export HOST_PORT=$ALTERNATE_HOST_PORT
 fi
 
-#'kubevirt-test-default1' is the default namespace of
-# Kubevirt SRIOV tests where the SRIOV VM's will be created.
-SRIOV_TESTS_NS="${SRIOV_TESTS_NS:-kubevirt-test-default1}"
-
 function set_kind_params() {
     export KIND_VERSION="${KIND_VERSION:-0.11.1}"
     export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-quay.io/kubevirtci/kindest_node:v1.22.2@sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f}"


### PR DESCRIPTION
There are no references in the code to the `SRIOV_TESTS_NS` variable or its default value.

Signed-off-by: Orel Misan <omisan@redhat.com>