### PR TITLE
Add options to run multi-numa nodes

### DIFF
--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -22,6 +22,8 @@ while true; do
     -s | --block-device-size ) BLOCK_DEV_SIZE="$2"; shift 2 ;;
     -n | --nvme-device-size ) NVME_DISK_SIZES+="$2 "; shift 2 ;;
     -t | --scsi-device-size ) SCSI_DISK_SIZES+="$2 "; shift 2 ;;
+    --numa ) NUMA_NODES+="$2 "; shift 2 ;;
+    --object ) OBJECTS+="$2 "; shift 2 ;;
     -- ) shift; break ;;
     * ) break ;;
   esac
@@ -141,6 +143,16 @@ for size in ${SCSI_DISK_SIZES[@]}; do
   let "disk_num+=1"
 done
 
+NUMA_ARGS=""
+for node in ${NUMA_NODES[@]}; do
+  NUMA_ARGS="-numa $node $NUMA_ARGS"
+done
+
+OBJECTS_ARGS=""
+for object in ${OBJECTS[@]}; do
+  OBJECTS_ARGS="-object $object $OBJECTS_ARGS"
+done
+
 exec qemu-system-x86_64 -enable-kvm -drive format=qcow2,file=${next},if=virtio,cache=unsafe ${block_dev_arg} \
   -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n} \
   -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
@@ -148,7 +160,7 @@ exec qemu-system-x86_64 -enable-kvm -drive format=qcow2,file=${next},if=virtio,c
   -initrd /initrd.img \
   -kernel /vmlinuz \
   -append "$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}" \
-  -vnc :${n} -cpu host,migratable=no,+invtsc -m ${MEMORY} -smp ${CPU} \
+  -vnc :${n} -cpu host,migratable=no,+invtsc -m ${MEMORY} -smp ${CPU} ${NUMA_ARGS} ${OBJECTS_ARGS} \
   -serial pty -M q35,accel=kvm,kernel_irqchip=split \
   -device intel-iommu,intremap=on,caching-mode=on -device intel-hda -device hda-duplex -device AC97 \
   -uuid $(cat /proc/sys/kernel/random/uuid) \

--- a/cluster-provision/gocli/cmd/run_test.go
+++ b/cluster-provision/gocli/cmd/run_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGetCPUsRange(t *testing.T) {
+	testCases := []struct {
+		description    string
+		cpu            uint
+		numaCount      uint
+		expectedRanges []string
+	}{
+		{
+			description:    "two numa nodes, 6 cpus",
+			cpu:            6,
+			numaCount:      2,
+			expectedRanges: []string{"0-2", "3-5"},
+		},
+		{
+			description:    "three numa nodes, 6 cpus",
+			cpu:            6,
+			numaCount:      3,
+			expectedRanges: []string{"0-1", "2-3", "4-5"},
+		},
+		{
+			description:    "two numa nodes, 10 cpus",
+			cpu:            10,
+			numaCount:      2,
+			expectedRanges: []string{"0-4", "5-9"},
+		},
+		{
+			description:    "1 numa nodes, 10 cpus",
+			cpu:            10,
+			numaCount:      1,
+			expectedRanges: []string{"0-9"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(*testing.T) {
+			ranges := getCpusRanges(tc.cpu, tc.numaCount)
+			if !reflect.DeepEqual(tc.expectedRanges, ranges) {
+				t.Errorf("Expected ranges to equal: %v not: %v", tc.expectedRanges, ranges)
+			}
+		})
+	}
+}
+
+func TestGetMemorySizeAndUnit(t *testing.T) {
+	testCases := []struct {
+		description      string
+		memory           string
+		expectedSize     uint64
+		expectedUnit     string
+		expectedErrorMsg string
+	}{
+		{
+			description:      "simple case",
+			memory:           "8096M",
+			expectedSize:     8096,
+			expectedUnit:     "M",
+			expectedErrorMsg: "",
+		},
+		{
+			description:      "wrong unit format",
+			memory:           "8096Mi",
+			expectedSize:     0,
+			expectedUnit:     "",
+			expectedErrorMsg: "expected memory unit to be",
+		},
+		{
+			description:      "wrong unit",
+			memory:           "8096T",
+			expectedSize:     0,
+			expectedUnit:     "",
+			expectedErrorMsg: "expected memory unit to be",
+		},
+		{
+			description:      "cannot convert size",
+			memory:           "80a96T",
+			expectedSize:     0,
+			expectedUnit:     "",
+			expectedErrorMsg: "cannot convert memory size",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(*testing.T) {
+			size, unit, err := getMemorySizeAndUnit(tc.memory)
+			if size != tc.expectedSize {
+				t.Errorf("Expected size to equal: %d not: %d", tc.expectedSize, size)
+			}
+			if unit != tc.expectedUnit {
+				t.Errorf("Expected unit to equal: %s not: %s", tc.expectedUnit, unit)
+			}
+
+			if tc.expectedErrorMsg == "" && err != nil {
+				t.Errorf("Expected err to be nil not: %v", err)
+			}
+
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErrorMsg) {
+				t.Errorf("Expected err message: %s to contains %s", err.Error(), tc.expectedErrorMsg)
+			}
+		})
+	}
+}

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -5,6 +5,7 @@ set -e
 KUBEVIRT_WITH_ETC_IN_MEMORY=${KUBEVIRT_WITH_ETC_IN_MEMORY:-false}
 KUBEVIRT_WITH_ETC_CAPACITY=${KUBEVIRT_WITH_ETC_CAPACITY:-none}
 KUBEVIRT_DNS_HOST_PORT=${KUBEVIRT_DNS_HOST_PORT:-31111}
+KUBEVIRT_NUMA_NODES=${KUBEVIRT_NUMA_NODES:-1}
 
 export KUBEVIRTCI_PODMAN_SOCKET=${KUBEVIRTCI_PODMAN_SOCKET:-"/run/podman/podman.sock"}
 
@@ -90,6 +91,8 @@ function _add_common_params() {
     local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 6 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --random-ports --background --prefix $provider_prefix ${KUBEVIRT_PROVIDER} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
 
     params=" --dns-port $KUBEVIRT_DNS_HOST_PORT $params"
+    # add NUMA node param
+    params=" --numa-nodes $KUBEVIRT_NUMA_NODES $params"
 
     if [[ $TARGET =~ windows_sysprep.* ]] && [ -n "$WINDOWS_SYSPREP_NFS_DIR" ]; then
         params=" --nfs-data $WINDOWS_SYSPREP_NFS_DIR $params"


### PR DESCRIPTION
It would be beneficial to be able to run e2e tests on nodes with multiple NUMA nodes. 

I was wondering how to expose topology info of the nodes so it would be easy to retrieve in tests.
For now I have introduced new label `kubevirtci.io/numa_nodes` which will indicate how many numa_nodes is available on given hosts. We can use this label in e2e tests to retrieve the NUMA count like this:
```go
func GetNUMANodesCount(virtCli kubecli.KubevirtClient, nodeName string) int {
       node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
       Expect(err).ShouldNot(HaveOccurred())

       numaNodesLabel := "kubevirtci.io/numa_nodes"

       for label, val := range node.GetLabels() {
               if label == numaNodesLabel {
                       numaNodes, err := strconv.Atoi(val)
                       if err != nil { // if label value can't be converted to integer assume only 1 NUMA node
                               return 1
                       }

                       return numaNodes
               }
       }
       return 1
}
```