### PR TITLE
vm based providers: Change default dns host port

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -4,6 +4,7 @@ set -e
 
 KUBEVIRT_WITH_ETC_IN_MEMORY=${KUBEVIRT_WITH_ETC_IN_MEMORY:-false}
 KUBEVIRT_WITH_ETC_CAPACITY=${KUBEVIRT_WITH_ETC_CAPACITY:-none}
+KUBEVIRT_DNS_HOST_PORT=${KUBEVIRT_DNS_HOST_PORT:-31111}
 
 export KUBEVIRTCI_PODMAN_SOCKET=${KUBEVIRTCI_PODMAN_SOCKET:-"/run/podman/podman.sock"}
 
@@ -88,8 +89,7 @@ function _add_common_params() {
     # shellcheck disable=SC2155
     local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 6 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --random-ports --background --prefix $provider_prefix ${KUBEVIRT_PROVIDER} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
 
-    dns_host_port=53
-    params=" --dns-port $dns_host_port $params"
+    params=" --dns-port $KUBEVIRT_DNS_HOST_PORT $params"
 
     if [[ $TARGET =~ windows_sysprep.* ]] && [ -n "$WINDOWS_SYSPREP_NFS_DIR" ]; then
         params=" --nfs-data $WINDOWS_SYSPREP_NFS_DIR $params"


### PR DESCRIPTION
Since some OS (i.e RHEL), already listens to
127.0.0.1 on port 53, change the default dns host port to the dedicated
gocli dns port (31111).
It can be overridden by setting `KUBEVIRT_DNS_HOST_PORT`.

Fixes: https://github.com/kubevirt/kubevirtci/issues/900