### PR TITLE
Add centos9 image build to publish.sh

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -15,6 +15,7 @@ docker tag ${TARGET_REPO}/gocli ${TARGET_REPO}/gocli:${KUBEVIRTCI_TAG}
 
 # Provision all base images
 (cd cluster-provision/centos8 && ./build.sh)
+(cd cluster-provision/centos9 && ./build.sh)
 
 # Provision all clusters
 CLUSTERS="$(find cluster-provision/k8s/* -maxdepth 0 -type d -printf '%f\n')"


### PR DESCRIPTION
The centos9 image is required to be built locally when publishing the 1.26 provider, which is the first to use it.

Error: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirtci/1595821136107540480#1:build-log.txt%3A26814

/cc @brianmcarey @xpivarc @Barakmor1 