### PR TITLE
SR-IOV providers: Bump SR-IOV CNI to v2.7.0

### DIFF
--- a/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/sriov-cni-daemonset.yaml
+++ b/cluster-up/cluster/kind-1.22-sriov/sriov-components/manifests/sriov-cni-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-sriov-cni
-        image: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.6.2
+        image: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.7.0
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/cluster-up/cluster/kind-1.23-sriov/sriov-components/manifests/sriov-cni-daemonset.yaml
+++ b/cluster-up/cluster/kind-1.23-sriov/sriov-components/manifests/sriov-cni-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-sriov-cni
-        image: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.6.2
+        image: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.7.0
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Following the flakes we have all over SR-IOV lanes due to [1] and [2], bump sriov-cni to v2.7.0 in order to consume the fix [3].

[1] https://github.com/kubevirt/kubevirt/issues/6776 
[2] https://github.com/k8snetworkplumbingwg/sriov-cni/issues/219 
[3] https://github.com/k8snetworkplumbingwg/sriov-cni/pull/220

Signed-off-by: Or Mergi <ormergi@redhat.com>