### PR TITLE
k8s-1.26: Update cni ipv6 diff file

### DIFF
--- a/cluster-provision/k8s/1.26/manifests/cni_ipv6.diff
+++ b/cluster-provision/k8s/1.26/manifests/cni_ipv6.diff
@@ -108,3 +108,12 @@
            env:
              # Choose which controllers to run.
              - name: ENABLED_CONTROLLERS
+@@ -3847,7 +3863,7 @@
+ 
+ # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
+ 
+-apiVersion: policy/v1beta1
++apiVersion: policy/v1
+ kind: PodDisruptionBudget
+ metadata:
+   name: calico-kube-controllers


### PR DESCRIPTION
Add missing section to the cni of ipv6.
This way we can create a single stack provider when needed.

Signed-off-by: Or Shoval <oshoval@redhat.com>