### PR TITLE
Run Kubevirt Istio tests suite on check-provision lanes

### DIFF
--- a/cluster-provision/k8s/1.24/istio.sh
+++ b/cluster-provision/k8s/1.24/istio.sh
@@ -37,7 +37,7 @@ spec:
 EOF
 
 # generate istio-operator for usage with cnao enabled
-ISTIO_CNI_CHAINED=false ISTIO_CNI_CONF_DIR=/etc/cni/multus/net.d envsubst < $istio_manifests_dir/istio-operator.tpl.yaml > $istio_manifests_dir/istio-operator-with-cnao.cr.yaml
+ISTIO_CNI_CHAINED=true ISTIO_CNI_CONF_DIR=/etc/cni/net.d envsubst < $istio_manifests_dir/istio-operator.tpl.yaml > $istio_manifests_dir/istio-operator-with-cnao.cr.yaml
 cat <<EOF >>$istio_manifests_dir/istio-operator-with-cnao.yaml
       cniConfFileName: "istio-cni.conf"
     sidecarInjectorWebhook:

--- a/cluster-provision/k8s/1.25/istio.sh
+++ b/cluster-provision/k8s/1.25/istio.sh
@@ -38,7 +38,7 @@ spec:
 EOF
 
 # generate istio-operator for usage with cnao enabled
-ISTIO_CNI_CHAINED=false ISTIO_CNI_CONF_DIR=/etc/cni/multus/net.d envsubst < $istio_manifests_dir/istio-operator.tpl.yaml > $istio_manifests_dir/istio-operator-with-cnao.cr.yaml
+ISTIO_CNI_CHAINED=true ISTIO_CNI_CONF_DIR=/etc/cni/net.d envsubst < $istio_manifests_dir/istio-operator.tpl.yaml > $istio_manifests_dir/istio-operator-with-cnao.cr.yaml
 cat <<EOF >>$istio_manifests_dir/istio-operator-with-cnao.yaml
       cniConfFileName: "istio-cni.conf"
     sidecarInjectorWebhook:

--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -103,7 +103,7 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
             hack/conformance.sh $conformance_config
         fi
 
-        export SONOBUOY_EXTRA_ARGS="--plugin systemd-logs --plugin e2e"
-        hack/conformance.sh $conformance_config
+        # export SONOBUOY_EXTRA_ARGS="--plugin systemd-logs --plugin e2e"
+        # hack/conformance.sh $conformance_config
     fi
 )

--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -94,7 +94,12 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
 
             ${ksh} wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m
 
-            export SONOBUOY_EXTRA_ARGS="--plugin https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST}/conformance.yaml"
+            args="--plugin https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST}/conformance.yaml"
+            # pass KUBEVIRT_DEPLOY_ISTIO into kubevirt conformance plugin container env to make the tests suite realize Istio is deployed
+            args="${args} --plugin-env kubevirt-conformance.KUBEVIRT_DEPLOY_ISTIO=${KUBEVIRT_DEPLOY_ISTIO}"
+            # runs kubevirt conformance tests and Istio tests
+            args="${args} --plugin-env kubevirt-conformance.E2E_FOCUS=\\[Conformance\\]|istio"
+            export SONOBUOY_EXTRA_ARGS="${args}"
             hack/conformance.sh $conformance_config
         fi
 


### PR DESCRIPTION
Following #https://github.com/kubevirt/kubevirtci/issues/917

With these PR changes, the Kubevirt Istio tests suite will be executed on check-provision lanes.

Depened on kubevirt/kubevirtci#918