### PR TITLE
k8s-1.26: Use centos8 base image

### DIFF
--- a/cluster-provision/k8s/1.26/base
+++ b/cluster-provision/k8s/1.26/base
@@ -1,1 +1,1 @@
-centos9
+centos8


### PR DESCRIPTION
Currently, Istio doesnt work with centos9 [1] [2].

Use centos8 as base image for k8s-1.26 provider to unblock using it on development environment.

[1] https://github.com/istio/istio/issues/42485
[2] https://issues.redhat.com/browse/OSSM-2382

Signed-off-by: Or Mergi <ormergi@redhat.com>