### PR TITLE
WIP publish job: Optimize provision job time

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+readonly ARTIFACTS=${ARTIFACTS:-${PWD}}
+readonly CONCURRENT_PROVISION_JOBS_COUNT="${CONCURRENT_PROVISION_JOBS_COUNT:-2}"
+
 KUBEVIRTCI_TAG=$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)
 export KUBEVIRTCI_TAG
 
@@ -9,28 +12,88 @@ TARGET_REPO="quay.io/kubevirtci"
 TARGET_KUBEVIRT_REPO="quay.io/kubevirt"
 TARGET_GIT_REMOTE="https://kubevirt-bot@github.com/kubevirt/kubevirtci.git"
 
+# provision_on_background takes a function name and arguments list,
+# executes the given command with each arg in the background and wait for it to finish.
+# Usage:
+# provision_on_background "foo" "a b c"
+#   foo a &
+#   foo b &
+#   foo c &
+# Each job stdout is exported to file at $ARTIFACTS, for example:
+# foo-a.log
+# foo-b.log
+# foo-c.log
+# The amount of background jobs is controlled by CONCURRENT_PROVISION_JOBS_COUNT env var.
+exec_on_background() {
+  local -r command=$1
+  local -r args=($2)
+
+  local -r jobs_count="${#args[@]}"
+  local offset=0
+  while [ "${jobs_count}" -gt "${offset}" ]; do
+      jobs_batch_pids=()
+      jobs_batch=("${args[@]:${offset}:${CONCURRENT_PROVISION_JOBS_COUNT}}")
+      for job in ${jobs_batch[@]}; do
+          job_name="${command}-${job}"
+          eval "${command} ${job}" &> "${ARTIFACTS}/${job_name}.log" &
+          jobs_batch_pids+=($!)
+          echo "[$(date --utc)] ${job_name}, PID: $!.."
+      done
+      offset=$((offset+CONCURRENT_PROVISION_JOBS_COUNT))
+
+      # wait for providers to finish
+      set +e
+      for job_pid in "${jobs_batch_pids[@]}"; do
+          echo "[$(date --utc)] waiting for job, PID: ${job_pid}.."
+          wait ${job_pid}
+          result=$?
+          echo "[$(date --utc)] job PID ${job_pid} finished with return code ${result}"
+          if [ "${result}" -ne 0 ]; then
+              echo "FATAL: base job failed, PID: ${job_pid}"
+              exit 1
+          fi
+      done
+      set -e
+  done
+}
+
 # Build gocli
 (cd cluster-provision/gocli && make container)
 docker tag ${TARGET_REPO}/gocli ${TARGET_REPO}/gocli:${KUBEVIRTCI_TAG}
 
 # Provision all base images
-(cd cluster-provision/centos8 && ./build.sh)
-(cd cluster-provision/centos9 && ./build.sh)
+provision_cluster_node_base_image() {
+    local -r os_name=$1
+    echo "provisioning base: cd cluster-provision/${os_name} && ./build.sh"
+    (cd cluster-provision/${os_name} && ./build.sh) &
+}
+readonly BASE_IMAGES=("centos8" "centos9")
+exec_on_background "provision_cluster_node_base_image" "${BASE_IMAGES[*]}"
 
-# Provision all clusters
-CLUSTERS="$(find cluster-provision/k8s/* -maxdepth 0 -type d -printf '%f\n')"
-for i in ${CLUSTERS}; do
-    NETWORK_STACK="dualstack"
-    if [[ $i =~ ipv6 ]]; then
-        NETWORK_STACK="ipv6"
+# provision all cluster image
+provision_cluster_node_k8s_image() {
+    local -r provider_name=$1
+
+    local gocli_provision_flags=""
+    if [[ $provider_name =~ ipv6 ]]; then
+        gocli_provision_flags="--network-stack ipv6"
+    else
+        gocli_provision_flags="--network-stack dualstack"
     fi
 
-    cluster-provision/gocli/build/cli provision cluster-provision/k8s/$i --network-stack ${NETWORK_STACK}
-    docker tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}
-
-    cluster-provision/gocli/build/cli provision cluster-provision/k8s/$i --network-stack ${NETWORK_STACK} --slim
-    docker tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim
+    if [[ $provider_name =~ slim ]]; then
+        gocli_provision_flags="${gocli_provision_flags} --slim"
+    fi
+    cluster-provision/gocli/build/cli provision cluster-provision/k8s/${provider_name} "${gocli_provision_flags}"
+    docker tag ${TARGET_REPO}/k8s-${provider_name} ${TARGET_REPO}/k8s-${provider_name}:${KUBEVIRTCI_TAG}
+}
+readonly CLUSTERS=($(find cluster-provision/k8s/* -maxdepth 0 -type d -printf '%f\n'))
+k8s_images=()
+for c in "${CLUSTERS[@]}"; do
+  k8s_images+=("${c}")
+  k8s_images+=("${c}-slim")
 done
+exec_on_background "provision_cluster_node_k8s_image" "${k8s_images[*]}"
 
 # Provision alpine container disk and tag it
 (cd cluster-provision/images/vm-image-builder && ./create-containerdisk.sh alpine-cloud-init)


### PR DESCRIPTION
Currently, there are 5 providers and 2 base images, where for each provider we build two flavors of images, regular (with pre-pulled images) and slim (no pre-puled images). 
That is a total of 12 images per each publish job that executes for each merged PR.

This PR parallelizes the provision jobs that are executed by the publish job. 

Run provision jobs in parallel in order to reduce CI time and have quicker feedback.
The amount of jobs that will run concurrently is controlled by CONCURRENT_PROVISION_JOBS_COUNT env var, default 2.

Signed-off-by: Or Mergi <ormergi@redhat.com>