### PR TITLE
 Ksm support in kubevirtci

### DIFF
--- a/KUBEVIRTCI_LOCAL_TESTING.md
+++ b/KUBEVIRTCI_LOCAL_TESTING.md
@@ -67,6 +67,21 @@ To enable swap, please also export the following variables before running `make 
 export KUBEVIRT_SWAP_ON=true
 ```
 
+#### start cluster with ksm enabled
+To enable KSM (Kernel Samepage Merging), please also export the following variables before running `make cluster-up`:
+```bash
+# to tune ksm:
+# KUBEVIRT_KSM_SLEEP_BETWEEN_SCANS_MS - This parameter controls
+# how long KSM should sleep in millisecond between scans.
+# the Default value is 20
+# KUBEVIRT_KSM_PAGES_TO_SCAN - This parameter controls how many
+# pages KSM should scan in each pass.
+# The default value for pages_to_scan is 100, which means each 
+# scan run only inspects about half a megabyte of RAM.
+export KUBEVIRT_KSM_ON=true
+```
+For more details see pages_to_scan and sleep_millisecs in: https://www.kernel.org/doc/Documentation/vm/ksm.txt
+
 ## kubevirt: testing kubevirt locally with a freshly provisioned cluster
 
 After making changes to a kubevirtci provider, it's recommended to test it locally including kubevirt e2e tests before publishing it.

--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -30,6 +30,7 @@ KUBEVIRT_DEPLOY_GRAFANA=${KUBEVIRT_DEPLOY_GRAFANA:-false}
 KUBEVIRT_CGROUPV2=${KUBEVIRT_CGROUPV2:-false}
 KUBEVIRT_DEPLOY_CDI=${KUBEVIRT_DEPLOY_CDI:-false}
 KUBEVIRT_SWAP_ON=${KUBEVIRT_SWAP_ON:-false}
+KUBEVIRT_KSM_ON=${KUBEVIRT_KSM_ON:-false}
 KUBEVIRT_UNLIMITEDSWAP=${KUBEVIRT_UNLIMITEDSWAP:-false}
 
 # If on a developer setup, expose ocp on 8443, so that the openshift web console can be used (the port is important because of auth redirects)


### PR DESCRIPTION
Add option to deploy cluster with KSM so we could test and analyze memory over-commitment on the cluster's nodes.
KSM is a Linux kernel feature that allows the kernel to identify identical memory pages and replace them with a single copy.
This can be useful for reducing the memory usage of virtual machines or containers, as it allows them to share identical memory pages instead of each having their own copy.
