### PR TITLE
Update provisioning container image to Fedora 37

### DIFF
--- a/cluster-provision/centos8/Dockerfile
+++ b/cluster-provision/centos8/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM quay.io/kubevirtci/fedora@sha256:486fd5578f93fbc57a519e34ad4b7cac927c3f8a95409baedf0c19e9f287c207
+FROM quay.io/kubevirtci/fedora@sha256:9b8e2b468d0d0523529bde44e8a0f17aad93dcedcf876c111183ffd4ea40d724
 
 ARG centos_version
 

--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM quay.io/kubevirtci/fedora@sha256:486fd5578f93fbc57a519e34ad4b7cac927c3f8a95409baedf0c19e9f287c207
+FROM quay.io/kubevirtci/fedora@sha256:9b8e2b468d0d0523529bde44e8a0f17aad93dcedcf876c111183ffd4ea40d724
 
 ARG centos_version
 


### PR DESCRIPTION
The latest fedora 37 image was mirrored from registry.fedoraproject.org to the kubevirtci quay repo. This change updates to use the mirrored f37 image as it has been released for some time now.

Signed-off-by: Brian Carey <bcarey@redhat.com>