### PR TITLE
SELinux: add missing permission to centos8-based providers

### DIFF
--- a/cluster-provision/k8s/1.23/provision.sh
+++ b/cluster-provision/k8s/1.23/provision.sh
@@ -118,6 +118,10 @@ registries = ['registry:5000']
 registries = []
 EOF
 
+# Add an SELinux rule missing from pre-v2.193.0 container-selinux, see kubevirt/kubevirt docs
+echo '(allow container_t tmpfs_t (filesystem (mount)))' >/tmp/passt.cil
+semodule -i /tmp/passt.cil
+
 #TODO: el8 repo
 # Add Kubernetes repository.
 cat <<EOF >/etc/yum.repos.d/kubernetes.repo

--- a/cluster-provision/k8s/1.24/provision.sh
+++ b/cluster-provision/k8s/1.24/provision.sh
@@ -128,6 +128,10 @@ registries = ['registry:5000']
 registries = []
 EOF
 
+# Add an SELinux rule missing from pre-v2.193.0 container-selinux, see kubevirt/kubevirt docs
+echo '(allow container_t tmpfs_t (filesystem (mount)))' >/tmp/passt.cil
+semodule -i /tmp/passt.cil
+
 #TODO: el8 repo
 # Add Kubernetes repository.
 cat <<EOF >/etc/yum.repos.d/kubernetes.repo

--- a/cluster-provision/k8s/1.25-ipv6/provision.sh
+++ b/cluster-provision/k8s/1.25-ipv6/provision.sh
@@ -143,6 +143,10 @@ registries = ['registry:5000']
 registries = []
 EOF
 
+# Add an SELinux rule missing from pre-v2.193.0 container-selinux, see kubevirt/kubevirt docs
+echo '(allow container_t tmpfs_t (filesystem (mount)))' >/tmp/passt.cil
+semodule -i /tmp/passt.cil
+
 #TODO: el8 repo
 # Add Kubernetes repository.
 cat <<EOF >/etc/yum.repos.d/kubernetes.repo

--- a/cluster-provision/k8s/1.25/provision.sh
+++ b/cluster-provision/k8s/1.25/provision.sh
@@ -143,6 +143,10 @@ registries = ['registry:5000']
 registries = []
 EOF
 
+# Add an SELinux rule missing from pre-v2.193.0 container-selinux, see kubevirt/kubevirt docs
+echo '(allow container_t tmpfs_t (filesystem (mount)))' >/tmp/passt.cil
+semodule -i /tmp/passt.cil
+
 #TODO: el8 repo
 # Add Kubernetes repository.
 cat <<EOF >/etc/yum.repos.d/kubernetes.repo

--- a/cluster-provision/k8s/1.26/provision.sh
+++ b/cluster-provision/k8s/1.26/provision.sh
@@ -173,6 +173,10 @@ EOF
 
 packages_version=$(getKubernetesClosestStableVersion)
 
+# Add an SELinux rule missing from pre-v2.193.0 container-selinux, see kubevirt/kubevirt docs
+echo '(allow container_t tmpfs_t (filesystem (mount)))' >/tmp/passt.cil
+semodule -i /tmp/passt.cil
+
 # Add Kubernetes release repository.
 # use repodata from GCS bucket, since the release repo might not have it right after the release
 # we deduce the https path from the gcs path gs://kubernetes-release/release/${version}/rpm/x86_64/


### PR DESCRIPTION
Since Centos 8 does not provide a recent-enough version of container-selinux, use the alternative solution from the docs in kubevirt/kubevirt.

See the kubevirt/kubevirt docs as updated by https://github.com/kubevirt/kubevirt/pull/9021:
```
SELinux-enabled nodes need to have [Container-selinux](https://github.com/containers/container-selinux) version 2.193.0 or newer installed.

For nodes running an operating system that does not offer container-selinux v2.193.0 or newer, it is possible to use v2.170.0 or newer and either:
- Not use passt-based networking
- Manually add the missing SELinux rule for passt by running the following commands on each node:
echo '(allow container_t tmpfs_t (filesystem (mount)))' >/tmp/passt.cil
semodule -i /tmp/passt.cil
```