### PR TITLE
k8s-1.24-psa: Remove leftovers

### DIFF
--- a/cluster-up/cluster/k8s-1.24-psa/provider.sh
+++ b/cluster-up/cluster/k8s-1.24-psa/provider.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-if [ "${KUBEVIRT_CGROUPV2}" == "true" ]; then
-    export KUBEVIRT_PROVIDER_EXTRA_ARGS="${KUBEVIRT_PROVIDER_EXTRA_ARGS} --kernel-args='systemd.unified_cgroup_hierarchy=1'"
-fi
-
-# shellcheck disable=SC1090
-source "${KUBEVIRTCI_PATH}/cluster/k8s-provider-common.sh"


### PR DESCRIPTION
The dedicated provider `k8s-1.24-psa` was deleted (https://github.com/kubevirt/kubevirtci/pull/915)
however the cluster-up folder of it is a leftover.