### PR TITLE
whereabouts: bump to v0.6.1 hoping to finally end duplicate IP assigments

### DIFF
--- a/cluster-provision/k8s/1.25/manifests/whereabouts/whereabouts-v0.6.1.yaml
+++ b/cluster-provision/k8s/1.25/manifests/whereabouts/whereabouts-v0.6.1.yaml
@@ -193,48 +193,6 @@ subjects:
   name: whereabouts
   namespace: kube-system
 ---
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  labels:
-    app: whereabouts
-    tier: node
-  name: ip-reconciler
-  namespace: kube-system
-spec:
-  concurrencyPolicy: Forbid
-  jobTemplate:
-    spec:
-      backoffLimit: 0
-      template:
-        metadata:
-          labels:
-            app: whereabouts
-        spec:
-          containers:
-          - command:
-            - /ip-reconciler
-            - -log-level=verbose
-            image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5.4-amd64
-            name: whereabouts
-            resources:
-              requests:
-                cpu: 100m
-                memory: 50Mi
-            volumeMounts:
-            - mountPath: /host/etc/cni/net.d
-              name: cni-net-dir
-          priorityClassName: system-node-critical
-          restartPolicy: OnFailure
-          serviceAccountName: whereabouts
-          volumes:
-          - hostPath:
-              path: /etc/cni/net.d
-            name: cni-net-dir
-      ttlSecondsAfterFinished: 300
-  schedule: '*/5 * * * *'
-  successfulJobsHistoryLimit: 0
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -266,15 +224,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5.4-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.6.1-amd64
         name: whereabouts
         resources:
           limits:
             cpu: 100m
-            memory: 50Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         securityContext:
           privileged: true
         volumeMounts:
@@ -284,7 +242,7 @@ spec:
           name: cni-net-dir
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       serviceAccountName: whereabouts
       tolerations:
       - effect: NoSchedule

--- a/cluster-provision/k8s/1.26-centos9/manifests/whereabouts/whereabouts-v0.6.1.yaml
+++ b/cluster-provision/k8s/1.26-centos9/manifests/whereabouts/whereabouts-v0.6.1.yaml
@@ -193,48 +193,6 @@ subjects:
   name: whereabouts
   namespace: kube-system
 ---
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  labels:
-    app: whereabouts
-    tier: node
-  name: ip-reconciler
-  namespace: kube-system
-spec:
-  concurrencyPolicy: Forbid
-  jobTemplate:
-    spec:
-      backoffLimit: 0
-      template:
-        metadata:
-          labels:
-            app: whereabouts
-        spec:
-          containers:
-          - command:
-            - /ip-reconciler
-            - -log-level=verbose
-            image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5.4-amd64
-            name: whereabouts
-            resources:
-              requests:
-                cpu: 100m
-                memory: 50Mi
-            volumeMounts:
-            - mountPath: /host/etc/cni/net.d
-              name: cni-net-dir
-          priorityClassName: system-node-critical
-          restartPolicy: OnFailure
-          serviceAccountName: whereabouts
-          volumes:
-          - hostPath:
-              path: /etc/cni/net.d
-            name: cni-net-dir
-      ttlSecondsAfterFinished: 300
-  schedule: '*/5 * * * *'
-  successfulJobsHistoryLimit: 0
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -266,15 +224,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5.4-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.6.1-amd64
         name: whereabouts
         resources:
           limits:
             cpu: 100m
-            memory: 50Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         securityContext:
           privileged: true
         volumeMounts:
@@ -284,7 +242,7 @@ spec:
           name: cni-net-dir
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       serviceAccountName: whereabouts
       tolerations:
       - effect: NoSchedule

--- a/cluster-provision/k8s/1.27/manifests/whereabouts/whereabouts-v0.6.1.yaml
+++ b/cluster-provision/k8s/1.27/manifests/whereabouts/whereabouts-v0.6.1.yaml
@@ -193,48 +193,6 @@ subjects:
   name: whereabouts
   namespace: kube-system
 ---
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  labels:
-    app: whereabouts
-    tier: node
-  name: ip-reconciler
-  namespace: kube-system
-spec:
-  concurrencyPolicy: Forbid
-  jobTemplate:
-    spec:
-      backoffLimit: 0
-      template:
-        metadata:
-          labels:
-            app: whereabouts
-        spec:
-          containers:
-          - command:
-            - /ip-reconciler
-            - -log-level=verbose
-            image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5.4-amd64
-            name: whereabouts
-            resources:
-              requests:
-                cpu: 100m
-                memory: 50Mi
-            volumeMounts:
-            - mountPath: /host/etc/cni/net.d
-              name: cni-net-dir
-          priorityClassName: system-node-critical
-          restartPolicy: OnFailure
-          serviceAccountName: whereabouts
-          volumes:
-          - hostPath:
-              path: /etc/cni/net.d
-            name: cni-net-dir
-      ttlSecondsAfterFinished: 300
-  schedule: '*/5 * * * *'
-  successfulJobsHistoryLimit: 0
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -266,15 +224,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5.4-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.6.1-amd64
         name: whereabouts
         resources:
           limits:
             cpu: 100m
-            memory: 50Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         securityContext:
           privileged: true
         volumeMounts:
@@ -284,7 +242,7 @@ spec:
           name: cni-net-dir
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       serviceAccountName: whereabouts
       tolerations:
       - effect: NoSchedule

--- a/hack/kustomization/whereabouts/kustomization.yaml
+++ b/hack/kustomization/whereabouts/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ./ip-reconciler-job.yaml
 - ./daemonset-install.yaml
 - ./whereabouts.cni.cncf.io_ippools.yaml
 - ./whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml


### PR DESCRIPTION
With whereabouts 0.5.4 on k8s 1.25+, we're seeing multiple pods receiving the same IP. This makes our whereabouts-based functional test extremely flaky.
Example:
https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.25-sig-compute-migrations/1619352259101986816
Looking at the artifacts, you can see that the 3 virt-handlers received whereabout IPs 172.21.42.1, 172.21.42.2, 172.21.42.1 (should be 3):
https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.25-sig-compute-migrations/1619352259101986816/artifacts/k8s-reporter/1_pods.log

The issue has been raised directly to a whereabouts maintainer, but we'll open an issue on the whereabouts github if v0.6 doesn't fix it.