### PR TITLE
Adds note about CLI dependencies

### DIFF
--- a/KUBEVIRTCI_LOCAL_TESTING.md
+++ b/KUBEVIRTCI_LOCAL_TESTING.md
@@ -9,6 +9,11 @@ Steps:
 
 ### kubevirtci: provision cluster locally
 
+Install the following CLI tools before running the script:
+* `docker` or `podman`
+* `go`
+* `kubectl`
+
 ```bash
 # switch to kubevirtci directory
 cd $KUBEVIRTCI_DIR


### PR DESCRIPTION
Signed-off-by: Dharmit Shah <shahdharmit@gmail.com>

When I tried running the `../provision.sh` script as mentioned in `KUBEVIRTCI_LOCAL_TESTING.md`, I faced failures due to the unavailability of the CLIs mentioned in this PR. I was running it from a system that was freshly installed with Fedora 37.

