### PR TITLE
Remove check for localhost node name in up.sh

### DIFF
--- a/cluster-up/up.sh
+++ b/cluster-up/up.sh
@@ -11,9 +11,3 @@ fi
 source ${KUBEVIRTCI_PATH}hack/common.sh
 source ${KUBEVIRTCI_CLUSTER_PATH}/$KUBEVIRT_PROVIDER/provider.sh
 up
-
-# check if the environment has a corrupted host
-if [[ $(${KUBEVIRTCI_PATH}kubectl.sh get nodes | grep localhost) != "" ]]; then
-    echo "The environment has a corrupted host"
-    exit 1
-fi


### PR DESCRIPTION
There is a case where external kubernetes cluster may have been installed without a hostname defined which leads to a node name like `localhost.localdomain` - this is the case with the AMD SEV cluster.

I have not hit this case using any of the other kubevirtci providers so I think this check is no longer needed. 

/cc @dhiller @xpivarc @enp0s3 

Signed-off-by: Brian Carey <bcarey@redhat.com>