### PR TITLE
1.26 based on CentOS9

### DIFF
--- a/cluster-provision/k8s/1.26/base
+++ b/cluster-provision/k8s/1.26/base
@@ -1,1 +1,1 @@
-centos8
+centos9


### PR DESCRIPTION
Because the 0.59 release is just a few days we should do this bump ... now.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>