### PR TITLE
robust stack: Fix presubmit sanity check

### DIFF
--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -18,8 +18,6 @@ function cleanup() {
     make cluster-down
 }
 
-SINGLE_STACK_PROVIDER=${SINGLE_STACK_PROVIDER:-$(find ../../cluster-provision/k8s/* -maxdepth 0 -type d -printf '%f\n' | grep -v "-" | tail -1)}
-
 export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
 # check cluster-up
 (
@@ -88,7 +86,8 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
         hack/conformance.sh $conformance_config
     fi
 
-    if [ $SINGLE_STACK_PROVIDER == $KUBEVIRT_PROVIDER ]; then
+    # KUBEVIRT_SINGLE_STACK is supported by k8s-1.25+
+    if [ $KUBEVIRT_PROVIDER != "k8s-1.24" ]; then
         echo "Sanity check cluster-up of single stack cluster"
         make cluster-down
         export KUBEVIRT_SINGLE_STACK=true


### PR DESCRIPTION
The previous logic selected only the latest provider, 
excluding the variants that include dash (i.e -centos9).

Atm we run 1.26-centos9 instead 1.26, so the sanity check won't run.
Fix it by running it for all supported providers (1.25+).
This is a fast sanity check (only cluster-up and check IPs) and safer this way.

Also fix a bug that the condition compared `KUBEVIRT_PROVIDER` which 
is in the form `k8s-x.yz` with plain version i.e `x.yz`.

Note:
Maybe in the future we can consider running it even before the dual stack, so if it fails
it gives quick report, as it doesn't include conformance, while dual stack does.
