### PR TITLE
Set k8s-1.2[4,5,6] provider to deploy CNAO v0.80.0 

### DIFF
--- a/cluster-provision/k8s/1.24/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.24/manifests/cnao/network-addons-config-example.cr.yaml
@@ -9,5 +9,4 @@ spec:
   linuxBridge: {}
   macvtap: {}
   multus: {}
-  multusDynamicNetworks: {}
   ovs: {}

--- a/cluster-provision/k8s/1.24/manifests/cnao/network-addons-config.crd.yaml
+++ b/cluster-provision/k8s/1.24/manifests/cnao/network-addons-config.crd.yaml
@@ -60,10 +60,6 @@ spec:
                 description: Multus plugin enables attaching multiple network interfaces
                   to Pods in Kubernetes
                 type: object
-              multusDynamicNetworks:
-                description: A multus extension enabling hot-plug and hot-unplug of
-                  Pod interfaces
-                type: object
               ovs:
                 description: Ovs plugin allows users to define Kubernetes networks
                   on top of Open vSwitch bridges available on nodes
@@ -1689,10 +1685,6 @@ spec:
               multus:
                 description: Multus plugin enables attaching multiple network interfaces
                   to Pods in Kubernetes
-                type: object
-              multusDynamicNetworks:
-                description: A multus extension enabling hot-plug and hot-unplug of
-                  Pod interfaces
                 type: object
               ovs:
                 description: Ovs plugin allows users to define Kubernetes networks

--- a/cluster-provision/k8s/1.24/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.24/manifests/cnao/operator.yaml
@@ -23,7 +23,6 @@ rules:
   - get
   - list
   - watch
-  - use
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -116,7 +115,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.82.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.80.0
   labels:
     prometheus.cnao.io: "true"
   name: cluster-network-addons-operator
@@ -140,27 +139,25 @@ spec:
       containers:
       - env:
         - name: MULTUS_IMAGE
-          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e
-        - name: MULTUS_DYNAMIC_NETWORKS_CONTROLLER_IMAGE
-          value: ghcr.io/maiqueb/multus-dynamic-networks-controller@sha256:bd1b07503fd505c66a6ba8b55445a9de94eb322c95d5c22a475df03a8ec67e50
+          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins@sha256:c0d14ab010f44bf733aff02b77eb4b5a0ce38fd0c4918a7ecf6941a7bebd72df
+          value: quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2
         - name: OVS_CNI_IMAGE
           value: quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214
+          value: quay.io/kubevirt/kubemacpool@sha256:fb07b1be9e0990e3846ef628e993694bf0765602af5907abf98f7e218db0cb4a
         - name: MACVTAP_CNI_IMAGE
-          value: quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02
+          value: quay.io/kubevirt/macvtap-cni@sha256:d46f3adb242eec63b494533ab1a3b5dcd44a3a51e857e13c04dd67c862528712
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.80.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.82.0
+          value: 0.80.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -178,7 +175,7 @@ spec:
           value: openshift-monitoring
         - name: MONITORING_SERVICE_ACCOUNT
           value: prometheus-k8s
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.80.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources:

--- a/cluster-provision/k8s/1.25/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.25/manifests/cnao/network-addons-config-example.cr.yaml
@@ -9,5 +9,4 @@ spec:
   linuxBridge: {}
   macvtap: {}
   multus: {}
-  multusDynamicNetworks: {}
   ovs: {}

--- a/cluster-provision/k8s/1.25/manifests/cnao/network-addons-config.crd.yaml
+++ b/cluster-provision/k8s/1.25/manifests/cnao/network-addons-config.crd.yaml
@@ -60,10 +60,6 @@ spec:
                 description: Multus plugin enables attaching multiple network interfaces
                   to Pods in Kubernetes
                 type: object
-              multusDynamicNetworks:
-                description: A multus extension enabling hot-plug and hot-unplug of
-                  Pod interfaces
-                type: object
               ovs:
                 description: Ovs plugin allows users to define Kubernetes networks
                   on top of Open vSwitch bridges available on nodes
@@ -1689,10 +1685,6 @@ spec:
               multus:
                 description: Multus plugin enables attaching multiple network interfaces
                   to Pods in Kubernetes
-                type: object
-              multusDynamicNetworks:
-                description: A multus extension enabling hot-plug and hot-unplug of
-                  Pod interfaces
                 type: object
               ovs:
                 description: Ovs plugin allows users to define Kubernetes networks

--- a/cluster-provision/k8s/1.25/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.25/manifests/cnao/operator.yaml
@@ -23,7 +23,6 @@ rules:
   - get
   - list
   - watch
-  - use
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -116,7 +115,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.82.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.80.0
   labels:
     prometheus.cnao.io: "true"
   name: cluster-network-addons-operator
@@ -140,27 +139,25 @@ spec:
       containers:
       - env:
         - name: MULTUS_IMAGE
-          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e
-        - name: MULTUS_DYNAMIC_NETWORKS_CONTROLLER_IMAGE
-          value: ghcr.io/maiqueb/multus-dynamic-networks-controller@sha256:bd1b07503fd505c66a6ba8b55445a9de94eb322c95d5c22a475df03a8ec67e50
+          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins@sha256:c0d14ab010f44bf733aff02b77eb4b5a0ce38fd0c4918a7ecf6941a7bebd72df
+          value: quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2
         - name: OVS_CNI_IMAGE
           value: quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214
+          value: quay.io/kubevirt/kubemacpool@sha256:fb07b1be9e0990e3846ef628e993694bf0765602af5907abf98f7e218db0cb4a
         - name: MACVTAP_CNI_IMAGE
-          value: quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02
+          value: quay.io/kubevirt/macvtap-cni@sha256:d46f3adb242eec63b494533ab1a3b5dcd44a3a51e857e13c04dd67c862528712
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.80.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.82.0
+          value: 0.80.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -178,7 +175,7 @@ spec:
           value: openshift-monitoring
         - name: MONITORING_SERVICE_ACCOUNT
           value: prometheus-k8s
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.80.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources:

--- a/cluster-provision/k8s/1.26-centos9/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.26-centos9/manifests/cnao/network-addons-config-example.cr.yaml
@@ -9,5 +9,4 @@ spec:
   linuxBridge: {}
   macvtap: {}
   multus: {}
-  multusDynamicNetworks: {}
   ovs: {}

--- a/cluster-provision/k8s/1.26-centos9/manifests/cnao/network-addons-config.crd.yaml
+++ b/cluster-provision/k8s/1.26-centos9/manifests/cnao/network-addons-config.crd.yaml
@@ -60,10 +60,6 @@ spec:
                 description: Multus plugin enables attaching multiple network interfaces
                   to Pods in Kubernetes
                 type: object
-              multusDynamicNetworks:
-                description: A multus extension enabling hot-plug and hot-unplug of
-                  Pod interfaces
-                type: object
               ovs:
                 description: Ovs plugin allows users to define Kubernetes networks
                   on top of Open vSwitch bridges available on nodes
@@ -1689,10 +1685,6 @@ spec:
               multus:
                 description: Multus plugin enables attaching multiple network interfaces
                   to Pods in Kubernetes
-                type: object
-              multusDynamicNetworks:
-                description: A multus extension enabling hot-plug and hot-unplug of
-                  Pod interfaces
                 type: object
               ovs:
                 description: Ovs plugin allows users to define Kubernetes networks

--- a/cluster-provision/k8s/1.26-centos9/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.26-centos9/manifests/cnao/operator.yaml
@@ -23,7 +23,6 @@ rules:
   - get
   - list
   - watch
-  - use
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -116,7 +115,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.82.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.80.0
   labels:
     prometheus.cnao.io: "true"
   name: cluster-network-addons-operator
@@ -140,27 +139,25 @@ spec:
       containers:
       - env:
         - name: MULTUS_IMAGE
-          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e
-        - name: MULTUS_DYNAMIC_NETWORKS_CONTROLLER_IMAGE
-          value: ghcr.io/maiqueb/multus-dynamic-networks-controller@sha256:bd1b07503fd505c66a6ba8b55445a9de94eb322c95d5c22a475df03a8ec67e50
+          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins@sha256:c0d14ab010f44bf733aff02b77eb4b5a0ce38fd0c4918a7ecf6941a7bebd72df
+          value: quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2
         - name: OVS_CNI_IMAGE
           value: quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214
+          value: quay.io/kubevirt/kubemacpool@sha256:fb07b1be9e0990e3846ef628e993694bf0765602af5907abf98f7e218db0cb4a
         - name: MACVTAP_CNI_IMAGE
-          value: quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02
+          value: quay.io/kubevirt/macvtap-cni@sha256:d46f3adb242eec63b494533ab1a3b5dcd44a3a51e857e13c04dd67c862528712
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.80.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.82.0
+          value: 0.80.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -178,7 +175,7 @@ spec:
           value: openshift-monitoring
         - name: MONITORING_SERVICE_ACCOUNT
           value: prometheus-k8s
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.80.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources:

--- a/cluster-provision/k8s/1.26/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.26/manifests/cnao/network-addons-config-example.cr.yaml
@@ -9,5 +9,4 @@ spec:
   linuxBridge: {}
   macvtap: {}
   multus: {}
-  multusDynamicNetworks: {}
   ovs: {}

--- a/cluster-provision/k8s/1.26/manifests/cnao/network-addons-config.crd.yaml
+++ b/cluster-provision/k8s/1.26/manifests/cnao/network-addons-config.crd.yaml
@@ -60,10 +60,6 @@ spec:
                 description: Multus plugin enables attaching multiple network interfaces
                   to Pods in Kubernetes
                 type: object
-              multusDynamicNetworks:
-                description: A multus extension enabling hot-plug and hot-unplug of
-                  Pod interfaces
-                type: object
               ovs:
                 description: Ovs plugin allows users to define Kubernetes networks
                   on top of Open vSwitch bridges available on nodes
@@ -1689,10 +1685,6 @@ spec:
               multus:
                 description: Multus plugin enables attaching multiple network interfaces
                   to Pods in Kubernetes
-                type: object
-              multusDynamicNetworks:
-                description: A multus extension enabling hot-plug and hot-unplug of
-                  Pod interfaces
                 type: object
               ovs:
                 description: Ovs plugin allows users to define Kubernetes networks

--- a/cluster-provision/k8s/1.26/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.26/manifests/cnao/operator.yaml
@@ -23,7 +23,6 @@ rules:
   - get
   - list
   - watch
-  - use
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -116,7 +115,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.82.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.81.0
   labels:
     prometheus.cnao.io: "true"
   name: cluster-network-addons-operator
@@ -150,17 +149,17 @@ spec:
         - name: OVS_CNI_IMAGE
           value: quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214
+          value: quay.io/kubevirt/kubemacpool@sha256:fb07b1be9e0990e3846ef628e993694bf0765602af5907abf98f7e218db0cb4a
         - name: MACVTAP_CNI_IMAGE
           value: quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.81.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.82.0
+          value: 0.81.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -178,7 +177,7 @@ spec:
           value: openshift-monitoring
         - name: MONITORING_SERVICE_ACCOUNT
           value: prometheus-k8s
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.81.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources:

--- a/cluster-provision/k8s/1.26/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.26/manifests/cnao/operator.yaml
@@ -115,7 +115,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.81.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.80.0
   labels:
     prometheus.cnao.io: "true"
   name: cluster-network-addons-operator
@@ -139,11 +139,9 @@ spec:
       containers:
       - env:
         - name: MULTUS_IMAGE
-          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e
-        - name: MULTUS_DYNAMIC_NETWORKS_CONTROLLER_IMAGE
-          value: ghcr.io/maiqueb/multus-dynamic-networks-controller@sha256:bd1b07503fd505c66a6ba8b55445a9de94eb322c95d5c22a475df03a8ec67e50
+          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:829c27e9392d013eee5086ca7670d7326d723ebaec526237215e86086b5a3234
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins@sha256:c0d14ab010f44bf733aff02b77eb4b5a0ce38fd0c4918a7ecf6941a7bebd72df
+          value: quay.io/kubevirt/cni-default-plugins@sha256:5d9442c26f8750d44f97175f36dbd74bef503f782b9adefcfd08215d065c437a
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2
         - name: OVS_CNI_IMAGE
@@ -151,15 +149,15 @@ spec:
         - name: KUBEMACPOOL_IMAGE
           value: quay.io/kubevirt/kubemacpool@sha256:fb07b1be9e0990e3846ef628e993694bf0765602af5907abf98f7e218db0cb4a
         - name: MACVTAP_CNI_IMAGE
-          value: quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02
+          value: quay.io/kubevirt/macvtap-cni@sha256:d46f3adb242eec63b494533ab1a3b5dcd44a3a51e857e13c04dd67c862528712
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.81.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.80.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.81.0
+          value: 0.80.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -177,7 +175,7 @@ spec:
           value: openshift-monitoring
         - name: MONITORING_SERVICE_ACCOUNT
           value: prometheus-k8s
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.81.0
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.80.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources:


### PR DESCRIPTION
CNAO v0.82.0 deploys Multus V4-alpha which is not GA'ed yet, v0.80.0 deploys Multus V3 (GA version).

We need GA'ed Multus version on our sig-network gating lanes in order to continue with the development
of the hotplug NICs.

This PR reverts the providers k8s-1.24,k8s-1.25 and k8s-1.26 to deploy CNAO to v0.80.0.

**Once this PR lands at kubevirt/kubevirt, sig-network lanes will run with Multus v3.9.1**