### PR TITLE
centos8: update SELinux policy version

### DIFF
--- a/cluster-provision/k8s/1.24/provision.sh
+++ b/cluster-provision/k8s/1.24/provision.sh
@@ -140,9 +140,6 @@ repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 
-# Set the SELinux boolean that allows containers to use char devices like /dev/null
-semanage boolean --modify --on container_use_devices
-
 # Install Kubernetes packages.
 dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
     kubeadm-${version} \

--- a/cluster-provision/k8s/1.24/provision.sh
+++ b/cluster-provision/k8s/1.24/provision.sh
@@ -76,6 +76,10 @@ echo 'ACTION=="add|change", SUBSYSTEM=="block", KERNEL=="vd[a-z]", ATTR{queue/ro
 # To prevent preflight issue related to tc not found
 dnf install -y tc
 
+# The selinux-policy package shipped with the latest Centos stream "release" can be outdated.
+# Example: Centos 8 20220913.0 ships with selinux-policy-3.14.3-108, which misses crucial permissions
+dnf -y update selinux-policy
+
 # Install istioctl
 export PATH=$ISTIO_BIN_DIR:$PATH
 (

--- a/cluster-provision/k8s/1.25/provision.sh
+++ b/cluster-provision/k8s/1.25/provision.sh
@@ -80,6 +80,11 @@ echo 'ACTION=="add|change", SUBSYSTEM=="block", KERNEL=="vd[a-z]", ATTR{queue/ro
 
 # To prevent preflight issue related to tc not found
 dnf install -y iproute-tc
+
+# The selinux-policy package shipped with the latest Centos stream "release" can be outdated.
+# Example: Centos 8 20220913.0 ships with selinux-policy-3.14.3-108, which misses crucial permissions
+dnf -y update selinux-policy
+
 # Install istioctl
 export PATH=$ISTIO_BIN_DIR:$PATH
 (

--- a/cluster-provision/k8s/1.25/provision.sh
+++ b/cluster-provision/k8s/1.25/provision.sh
@@ -147,9 +147,6 @@ repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 
-# Set the SELinux boolean that allows containers to use char devices like /dev/null
-semanage boolean --modify --on container_use_devices
-
 # Install Kubernetes packages.
 dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
     kubeadm-${version} \

--- a/cluster-provision/k8s/1.26/provision.sh
+++ b/cluster-provision/k8s/1.26/provision.sh
@@ -175,9 +175,6 @@ gpgcheck=0
 repo_gpgcheck=0
 EOF
 
-# Set the SELinux boolean that allows containers to use char devices like /dev/null
-semanage boolean --modify --on container_use_devices
-
 # Install Kubernetes CNI.
 dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
     kubectl-${packages_version} \

--- a/cluster-provision/k8s/1.26/provision.sh
+++ b/cluster-provision/k8s/1.26/provision.sh
@@ -108,6 +108,11 @@ echo 'ACTION=="add|change", SUBSYSTEM=="block", KERNEL=="vd[a-z]", ATTR{queue/ro
 
 # To prevent preflight issue related to tc not found
 dnf install -y iproute-tc
+
+# The selinux-policy package shipped with the latest Centos stream "release" can be outdated.
+# Example: Centos 8 20220913.0 ships with selinux-policy-3.14.3-108, which misses crucial permissions
+dnf -y update selinux-policy
+
 # Install istioctl
 export PATH="$ISTIO_BIN_DIR:$PATH"
 (


### PR DESCRIPTION
The latest Centos 8 release ships with the `selinux-policy-3.14.3-108` package, which removes (mistakenly I assume) permissions that are critical to us.
The permissions are back in later versions of the Centos 8 `selinux-policy` package. However, there hasn't been a new "release" of Centos 8 Stream that includes the fixes.
2 of the permissions in question are:
```
allow container_t container_file_t:chr_file { ioctl };
allow iptables_t cgroup_t dir { ioctl };
```
Updating `selinux-policy` at provision time should bring both permissions back.

Updating to the new version also allows us to revert the commit that sets the `container_use_devices` SELinux boolean.