### PR TITLE
kind: amend env variable CONFIG_WORKER_CPU_MANAGER

### DIFF
--- a/cluster-up/cluster/kind-1.23/provider.sh
+++ b/cluster-up/cluster/kind-1.23/provider.sh
@@ -35,7 +35,7 @@ function up() {
     cp $KIND_MANIFESTS_DIR/kind.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
     _add_kubeadm_cpu_manager_config_patch
     _add_extra_mounts
-    export CONFIG_CPU_MANAGER=true
+    export CONFIG_WORKER_CPU_MANAGER=true
     kind_up
 
     configure_registry_proxy


### PR DESCRIPTION
This variable is defined in cluster-up/cluster/kind/common.sh
which is CONFIG_WORKER_CPU_MANAGER rather than
CONFIG_CPU_MANAGER