### PR TITLE
Revert "Control-plane nodes which are marked as schedulable are also given worker role. (#985)"

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -163,15 +163,13 @@ function _get_pods() {
 function _fix_node_labels() {
     # Due to inconsistent labels and taints state in multi-nodes clusters,
     # it is nessecery to remove taint NoSchedule and set role labels manualy:
-    #   Control-plane nodes might lack 'schedulable=true' label and have NoScheduable taint.
-    #	Control-plane nodes which have 'schedulable=true' should have worker role label
+    #   Control-plane nodes might lack 'scheduable=true' label and have NoScheduable taint.
     #   Worker nodes might lack worker role label.
     master_nodes=$(_get_nodes | grep -i $MASTER_NODES_PATTERN | awk '{print $1}')
     for node in ${master_nodes[@]}; do
         # removing NoSchedule taint if is there
         if _kubectl taint nodes $node node-role.kubernetes.io/master:NoSchedule-; then
             _kubectl label node $node kubevirt.io/schedulable=true
-            _kubectl label node $node node-role.kubernetes.io/worker=""
         fi
     done
 


### PR DESCRIPTION
This reverts commit 2e998c2fa81de4615aa1ca0b2c47fe6387be023e.

kind provider main priority is SR-IOV `kind-1.23-sriov`
This commit breaks it, the presubmit is optional atm, but we should not break this lane.

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9505/pull-kubevirt-e2e-kind-1.23-sriov/1641018041468719104

```
10:10:51: error: 'kubevirt.io/schedulable' already has a value (true), and --overwrite is false
make: *** [Makefile:144: cluster-up] Error 1
```

Moreover, on this lane there are two workers, and 1 control-plane before the change,
each worker gets a PF, having all the 3 nodes be workers means we need 3 PF but the CI job has only 2 PF.
The periodic will fail due to this reason IIUC even if the previous error is fixed.

See more info please following this discussion
https://github.com/kubevirt/kubevirt/pull/9505#issuecomment-1488299304
and https://github.com/kubevirt/kubevirtci/pull/985
those suggest possible action items.

Please run `check-up-kind-1.23-sriov` when changing kind provider.
