### PR TITLE
k3d: refactor _create_cluster and add k3d-1.25 provider

### DIFF
--- a/cluster-up/cluster/k3d-1.25/OWNERS
+++ b/cluster-up/cluster/k3d-1.25/OWNERS
@@ -1,0 +1,10 @@
+filters:
+  ".*":
+    reviewers:
+      - qinqon
+      - oshoval
+      - phoracek
+      - ormergi
+    approvers:
+      - qinqon
+      - phoracek

--- a/cluster-up/cluster/k3d-1.25/README.md
+++ b/cluster-up/cluster/k3d-1.25/README.md
@@ -1,0 +1,74 @@
+# K8s 1.25.x in a K3d cluster
+
+Provides a pre-deployed containerized k8s cluster with version 1.25.x that runs
+using [K3d](https://github.com/k3d-io/k3d)
+The cluster is completely ephemeral and is recreated on every cluster restart. The KubeVirt containers are built on the
+local machine and are then pushed to a registry which is exposed at
+`127.0.0.1:5000`.
+
+## Bringing the cluster up
+
+```bash
+export KUBEVIRT_PROVIDER=k3d-1.25
+export KUBECONFIG=$(realpath _ci-configs/k3d-1.25/.kubeconfig)
+make cluster-up
+```
+```
+$ kubectl get nodes
+NAME                 STATUS   ROLES                  AGE   VERSION
+k3d-k3d-server-0   Ready    control-plane,master   67m   v1.25.6+k3s1
+k3d-k3d-agent-0    Ready    worker                 67m   v1.25.6+k3s1
+k3d-k3d-agent-1    Ready    worker                 67m   v1.25.6+k3s1
+```
+
+### Conneting to a node
+```bash
+export KUBEVIRT_PROVIDER=k3d-1.25
+./cluster-up/ssh.sh <node_name> /bin/sh
+```
+
+## Bringing the cluster down
+
+```bash
+export KUBEVIRT_PROVIDER=k3d-1.25
+make cluster-down
+```
+
+This destroys the whole cluster.
+
+Note: killing the containers / cluster without gracefully moving the nics to the root ns before it,
+might result in unreachable nics for few minutes.
+
+## Using podman
+Podman v4 is required.
+
+Run:
+```bash
+systemctl enable --now podman.socket
+ln -s /run/podman/podman.sock /var/run/docker.sock
+```
+The rest is as usual.
+For more info see https://k3d.io/v5.4.1/usage/advanced/podman.
+
+## Updating the provider
+
+### Bumping K3D
+Update `K3D_TAG` (see `cluster-up/cluster/k3d/common.sh` for more info)
+
+### Bumping CNI
+Update `CNI_VERSION` (see `cluster-up/cluster/k3d/common.sh` for more info)
+
+### Bumping Multus
+Download the newer manifest `https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/deployments/multus-daemonset-crio.yml`
+replace this file `cluster-up/cluster/$KUBEVIRT_PROVIDER/sriov-components/manifests/multus/multus.yaml`
+and update the kustomization file `cluster-up/cluster/$KUBEVIRT_PROVIDER/sriov-components/manifests/multus/kustomization.yaml`
+according needs.
+
+### Bumping calico
+1. Fetch new calico yaml (https://docs.tigera.io/calico/3.25/getting-started/kubernetes/k3s/quickstart)
+   Enable `allow_ip_forwarding` (See https://k3d.io/v5.4.7/usage/advanced/calico)
+   Or use the one that is suggested here https://k3d.io/v5.4.7/usage/advanced/calico whenever it is updated.
+2. Prefix the images in the yaml with `quay.io/` unless they have it already.
+3. Update `cluster-up/cluster/k3d/manifests/calico.yaml` (see `CALICO` at `cluster-up/cluster/k3d/common.sh` for more info)
+
+Note: Make sure to follow the latest verions on the links above.

--- a/cluster-up/cluster/k3d-1.25/TROUBLESHOOTING.md
+++ b/cluster-up/cluster/k3d-1.25/TROUBLESHOOTING.md
@@ -1,0 +1,58 @@
+# How to troubleshoot a failing k3d job
+
+If logging and output artifacts are not enough, there is a way to connect to a running CI pod and troubleshoot directly from there.
+
+## Pre-requisites
+
+- A working (enabled) account on the [CI cluster](shift.ovirt.org), specifically enabled to the `kubevirt-prow-jobs` project.
+- The [mkpj tool](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/mkpj) installed
+
+## Launching a custom job
+
+Through the `mkpj` tool, it's possible to craft a custom Prow Job that can be executed on the CI cluster.
+
+Just `go get` it by running `go get k8s.io/test-infra/prow/cmd/mkpj`
+
+Then run the following command from a checkout of the [project-infra repo](https://github.com/kubevirt/project-infra):
+
+```bash
+mkpj --pull-number $KUBEVIRT_PR_NUMBER -job pull-kubevirt-e2e-k3d-1.25 -job-config-path github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml --config-path github/ci/prow/files/config.yaml > debugkind.yaml
+```
+
+You will end up having a ProwJob manifest in the `debugkind.yaml` file.
+
+It's strongly recommended to replace the job's name, as it will be easier to find and debug the relative pod, by replacing `metadata.name` with something more recognizeable.
+
+The `$KUBEVIRT_PR_NUMBER` can be an actual PR on the [kubevirt repo](https://github.com/kubevirt/kubevirt).
+
+In case we just want to debug the cluster provided by the CI, it's recommended to override the entry point, either in the test PR we are instrumenting (a good sample can be found [here](https://github.com/kubevirt/kubevirt/pull/3022)), or by overriding the entry point directly in the prow job's manifest.
+
+Remember that we want the cluster long living, so a long sleep must be provided as part of the entry point.
+
+Make sure you switch to the `kubevirt-prow-jobs` project, and apply the manifest:
+
+```bash
+kubectl apply -f debugkind.yaml
+```
+
+You will end up with a ProwJob object, and a pod with the same name you gave to the ProwJob.
+
+Once the pod is up & running, connect to it via bash:
+
+```bash
+kubectl exec -it debugprowjobpod bash
+```
+
+### Logistics
+
+Once you are in the pod, you'll be able to troubleshoot what's happening in the environment CI is running its tests.
+
+Run the follow to bring up a [k3d](https://github.com/k3d-io/k3d) cluster with SR-IOV installed.
+
+```bash
+KUBEVIRT_PROVIDER=k3d-1.25 make cluster-up
+```
+
+Use `k3d kubeconfig print k3d` to extract the kubeconfig file.
+The `kubectl` binary is already on board and in `$PATH`.
+See `README.md` for more info.

--- a/cluster-up/cluster/k3d-1.25/provider.sh
+++ b/cluster-up/cluster/k3d-1.25/provider.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+export CLUSTER_NAME="k3d"
+export HOST_PORT=5000
+
+function up() {
+    k3d_up
+
+    version=$(_kubectl get node k3d-$CLUSTER_NAME-server-0 -o=custom-columns=VERSION:.status.nodeInfo.kubeletVersion --no-headers)
+    echo "$KUBEVIRT_PROVIDER cluster '$CLUSTER_NAME' is ready ($version)"
+}
+
+source ${KUBEVIRTCI_PATH}/cluster/k3d/common.sh


### PR DESCRIPTION
To enable the k3d provider to adapt for SR-IOV e2e testing and Arm64 e2e testing, a flexible configuration for creating a k3d cluster is necessary. The following changes have been made:
    1. "_cluster_nodes_args" allows the number of servers and agents to be set.
    2. "_cni_args" sets the CNI for the k3d cluster.
    3. "_device_args" sets the mounted device from the host.
    4. When "DISABLE_DEFAULT_SERVICES" is set to true, all k3d default services (Traefik, ServiceLB, Metrics-Server) will be disabled.

Add k3d-1.25 provider which is based on k3d-1.25-sriov, but with the removal of SR-IOV related settings to simplify it as much as possible.

The discussion is in https://github.com/kubevirt/kubevirtci/issues/984