### PR TITLE
Remove pin of kernel version in CentOS Stream 8 providers

### DIFF
--- a/cluster-provision/k8s/1.24/provision.sh
+++ b/cluster-provision/k8s/1.24/provision.sh
@@ -47,26 +47,8 @@ function pull_container_retry() {
     fi
 }
 
-# FIXME: remove after version >= kernel-4.18.0-492.el8
-current_kernel_version=$(uname -r)
-echo "current kernel version is ${current_kernel_version}"
-echo "WARNING: installing previous kernel to mitigate bug"
-
-# download kernel rpm and install it
-kernel_version="4.18.0-448.el8.x86_64"
-(
-    cd /tmp
-    curl --output kernel-${kernel_version}.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-${kernel_version}.rpm
-    dnf localinstall -y kernel-${kernel_version}.rpm
-)
-
-grubby --info=ALL | grep ^kernel
-grubby --set-default "/boot/vmlinuz-${kernel_version}"
-echo "downgraded kernel version is ${kernel_version}"
-
 # Install modules of the initrd kernel
-dnf install -y "kernel-modules-${kernel_version}"
-dnf install -y "kernel-modules-${current_kernel_version}"
+dnf install -y "kernel-modules-$(uname -r)"
 
 # Resize root partition
 dnf install -y cloud-utils-growpart

--- a/cluster-provision/k8s/1.25/provision.sh
+++ b/cluster-provision/k8s/1.25/provision.sh
@@ -48,26 +48,8 @@ function pull_container_retry() {
     fi
 }
 
-# FIXME: remove after version >= kernel-4.18.0-492.el8
-current_kernel_version=$(uname -r)
-echo "current kernel version is ${current_kernel_version}"
-echo "WARNING: installing previous kernel to mitigate bug"
-
-# download kernel rpm and install it
-kernel_version="4.18.0-448.el8.x86_64"
-(
-    cd /tmp
-    curl --output kernel-${kernel_version}.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-${kernel_version}.rpm
-    dnf localinstall -y kernel-${kernel_version}.rpm
-)
-
-grubby --info=ALL | grep ^kernel
-grubby --set-default "/boot/vmlinuz-${kernel_version}"
-echo "downgraded kernel version is ${kernel_version}"
-
 # Install modules of the initrd kernel
-dnf install -y "kernel-modules-${kernel_version}"
-dnf install -y "kernel-modules-${current_kernel_version}"
+dnf install -y "kernel-modules-$(uname -r)"
 
 # Resize root partition
 dnf install -y cloud-utils-growpart


### PR DESCRIPTION
This reverts temporary changes that were made to workaround an kernel
issue[1] in CentOS Stream 8 - this kernel issue is now fixed so it is no
longer necessary to pin the kernel version.

[1] https://github.com/kubevirt/kubevirtci/issues/1005

Closes #1005 