### PR TITLE
cnao, vm based: Bump CNAO to v0.86.0

### DIFF
--- a/cluster-provision/k8s/1.25/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.25/manifests/cnao/network-addons-config-example.cr.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   imagePullPolicy: IfNotPresent
   kubeMacPool: {}
+  kubeSecondaryDNS: {}
   linuxBridge: {}
   macvtap: {}
   multus: {}

--- a/cluster-provision/k8s/1.25/manifests/cnao/network-addons-config.crd.yaml
+++ b/cluster-provision/k8s/1.25/manifests/cnao/network-addons-config.crd.yaml
@@ -48,6 +48,17 @@ spec:
                     description: RangeStart defines the first mac in range
                     type: string
                 type: object
+              kubeSecondaryDNS:
+                description: KubeSecondaryDNS plugin allows to support FQDN for VMI's
+                  secondary networks
+                properties:
+                  domain:
+                    description: Domain defines the FQDN domain
+                    type: string
+                  nameServerIP:
+                    description: NameServerIp defines the name server IP
+                    type: string
+                type: object
               linuxBridge:
                 description: LinuxBridge plugin allows users to create a bridge and
                   add the host and the container to it
@@ -55,6 +66,12 @@ spec:
               macvtap:
                 description: MacvtapCni plugin allows users to define Kubernetes networks
                   on top of existing host interfaces
+                properties:
+                  devicePluginConfig:
+                    description: DevicePluginConfig allows the user to override the
+                      name of the `ConfigMap` where the device plugin configuration
+                      is held
+                    type: string
                 type: object
               multus:
                 description: Multus plugin enables attaching multiple network interfaces
@@ -1678,6 +1695,17 @@ spec:
                     description: RangeStart defines the first mac in range
                     type: string
                 type: object
+              kubeSecondaryDNS:
+                description: KubeSecondaryDNS plugin allows to support FQDN for VMI's
+                  secondary networks
+                properties:
+                  domain:
+                    description: Domain defines the FQDN domain
+                    type: string
+                  nameServerIP:
+                    description: NameServerIp defines the name server IP
+                    type: string
+                type: object
               linuxBridge:
                 description: LinuxBridge plugin allows users to create a bridge and
                   add the host and the container to it
@@ -1685,6 +1713,12 @@ spec:
               macvtap:
                 description: MacvtapCni plugin allows users to define Kubernetes networks
                   on top of existing host interfaces
+                properties:
+                  devicePluginConfig:
+                    description: DevicePluginConfig allows the user to override the
+                      name of the `ConfigMap` where the device plugin configuration
+                      is held
+                    type: string
                 type: object
               multus:
                 description: Multus plugin enables attaching multiple network interfaces

--- a/cluster-provision/k8s/1.25/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.25/manifests/cnao/operator.yaml
@@ -14,38 +14,230 @@ metadata:
   name: cluster-network-addons-operator
 rules:
 - apiGroups:
+  - operator.openshift.io
+  resources:
+  - networks
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - security.openshift.io
-  resourceNames:
-  - privileged
   resources:
   - securitycontextconstraints
   verbs:
   - get
   - list
-  - watch
-  - use
+  - create
+  - update
 - apiGroups:
-  - operator.openshift.io
+  - apiextensions.k8s.io
   resources:
-  - networks
+  - customresourcedefinitions
   verbs:
   - get
-  - list
-  - watch
+  - create
+  - update
 - apiGroups:
   - networkaddonsoperator.network.kubevirt.io
   resources:
   - networkaddonsconfigs
   verbs:
-  - get
   - list
   - watch
 - apiGroups:
-  - '*'
+  - networkaddonsoperator.network.kubevirt.io
+  resources:
+  - networkaddonsconfigs/status
+  verbs:
+  - patch
+- apiGroups:
+  - networkaddonsoperator.network.kubevirt.io
+  resources:
+  - networkaddonsconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - get
+  - create
+  - update
+  - bind
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/status
+  verbs:
+  - get
+  - update
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - k8s.cni.cncf.io
   resources:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -71,30 +263,71 @@ metadata:
   namespace: cluster-network-addons
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
   - ""
   resources:
-  - pods
   - configmaps
   verbs:
   - get
-  - list
-  - watch
   - create
-  - patch
   - update
-  - delete
 - apiGroups:
   - apps
   resources:
   - deployments
-  - replicasets
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - update
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
   verbs:
   - get
-  - list
-  - watch
   - create
-  - patch
   - update
+  - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
   - delete
 
 ---
@@ -116,7 +349,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.82.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.86.0
   labels:
     prometheus.cnao.io: "true"
   name: cluster-network-addons-operator
@@ -140,27 +373,31 @@ spec:
       containers:
       - env:
         - name: MULTUS_IMAGE
-          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e
+          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:3fbcc32bd4e4d15bd93c96def784a229cd84cca27942bf4858b581f31c97ee02
         - name: MULTUS_DYNAMIC_NETWORKS_CONTROLLER_IMAGE
-          value: ghcr.io/maiqueb/multus-dynamic-networks-controller@sha256:bd1b07503fd505c66a6ba8b55445a9de94eb322c95d5c22a475df03a8ec67e50
+          value: ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:dee1979d92f0a31598a6e3569ac7004be7d29e7ca9e31db23753ef263110dc04
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins@sha256:c0d14ab010f44bf733aff02b77eb4b5a0ce38fd0c4918a7ecf6941a7bebd72df
+          value: quay.io/kubevirt/cni-default-plugins@sha256:406b43253fb5d45f50d1543879353822e3f746e2794b65ab30754e800386b76d
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2
         - name: OVS_CNI_IMAGE
-          value: quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3
+          value: quay.io/kubevirt/ovs-cni-plugin@sha256:5f7290e2294255ab2547c3b4bf48cc2d75531ec5a43e600366e9b2719bef983f
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214
+          value: quay.io/kubevirt/kubemacpool@sha256:afba7d0c4a95d2d4924f6ee6ef16bbe59117877383819057f01809150829cb0c
         - name: MACVTAP_CNI_IMAGE
-          value: quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02
+          value: quay.io/kubevirt/macvtap-cni@sha256:434420511e09b2b5ede785a2c9062b6658ffbc26fbdd4629ce06110f9039c600
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901
+        - name: KUBE_SECONDARY_DNS_IMAGE
+          value: ghcr.io/kubevirt/kubesecondarydns@sha256:77132adb5f840ceb0aadd408731a5c8b01a4b427a78084ab5e4e9b961195cb02
+        - name: CORE_DNS_IMAGE
+          value: registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.86.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.82.0
+          value: 0.86.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -178,7 +415,9 @@ spec:
           value: openshift-monitoring
         - name: MONITORING_SERVICE_ACCOUNT
           value: prometheus-k8s
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+        - name: RUNBOOK_URL_TEMPLATE
+          value: https://kubevirt.io/monitoring/runbooks/
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.86.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources:

--- a/cluster-provision/k8s/1.26-centos9/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.26-centos9/manifests/cnao/network-addons-config-example.cr.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   imagePullPolicy: IfNotPresent
   kubeMacPool: {}
+  kubeSecondaryDNS: {}
   linuxBridge: {}
   macvtap: {}
   multus: {}

--- a/cluster-provision/k8s/1.26-centos9/manifests/cnao/network-addons-config.crd.yaml
+++ b/cluster-provision/k8s/1.26-centos9/manifests/cnao/network-addons-config.crd.yaml
@@ -48,6 +48,17 @@ spec:
                     description: RangeStart defines the first mac in range
                     type: string
                 type: object
+              kubeSecondaryDNS:
+                description: KubeSecondaryDNS plugin allows to support FQDN for VMI's
+                  secondary networks
+                properties:
+                  domain:
+                    description: Domain defines the FQDN domain
+                    type: string
+                  nameServerIP:
+                    description: NameServerIp defines the name server IP
+                    type: string
+                type: object
               linuxBridge:
                 description: LinuxBridge plugin allows users to create a bridge and
                   add the host and the container to it
@@ -55,6 +66,12 @@ spec:
               macvtap:
                 description: MacvtapCni plugin allows users to define Kubernetes networks
                   on top of existing host interfaces
+                properties:
+                  devicePluginConfig:
+                    description: DevicePluginConfig allows the user to override the
+                      name of the `ConfigMap` where the device plugin configuration
+                      is held
+                    type: string
                 type: object
               multus:
                 description: Multus plugin enables attaching multiple network interfaces
@@ -1678,6 +1695,17 @@ spec:
                     description: RangeStart defines the first mac in range
                     type: string
                 type: object
+              kubeSecondaryDNS:
+                description: KubeSecondaryDNS plugin allows to support FQDN for VMI's
+                  secondary networks
+                properties:
+                  domain:
+                    description: Domain defines the FQDN domain
+                    type: string
+                  nameServerIP:
+                    description: NameServerIp defines the name server IP
+                    type: string
+                type: object
               linuxBridge:
                 description: LinuxBridge plugin allows users to create a bridge and
                   add the host and the container to it
@@ -1685,6 +1713,12 @@ spec:
               macvtap:
                 description: MacvtapCni plugin allows users to define Kubernetes networks
                   on top of existing host interfaces
+                properties:
+                  devicePluginConfig:
+                    description: DevicePluginConfig allows the user to override the
+                      name of the `ConfigMap` where the device plugin configuration
+                      is held
+                    type: string
                 type: object
               multus:
                 description: Multus plugin enables attaching multiple network interfaces

--- a/cluster-provision/k8s/1.26-centos9/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.26-centos9/manifests/cnao/operator.yaml
@@ -14,38 +14,230 @@ metadata:
   name: cluster-network-addons-operator
 rules:
 - apiGroups:
+  - operator.openshift.io
+  resources:
+  - networks
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - security.openshift.io
-  resourceNames:
-  - privileged
   resources:
   - securitycontextconstraints
   verbs:
   - get
   - list
-  - watch
-  - use
+  - create
+  - update
 - apiGroups:
-  - operator.openshift.io
+  - apiextensions.k8s.io
   resources:
-  - networks
+  - customresourcedefinitions
   verbs:
   - get
-  - list
-  - watch
+  - create
+  - update
 - apiGroups:
   - networkaddonsoperator.network.kubevirt.io
   resources:
   - networkaddonsconfigs
   verbs:
-  - get
   - list
   - watch
 - apiGroups:
-  - '*'
+  - networkaddonsoperator.network.kubevirt.io
+  resources:
+  - networkaddonsconfigs/status
+  verbs:
+  - patch
+- apiGroups:
+  - networkaddonsoperator.network.kubevirt.io
+  resources:
+  - networkaddonsconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - get
+  - create
+  - update
+  - bind
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/status
+  verbs:
+  - get
+  - update
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - k8s.cni.cncf.io
   resources:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -71,30 +263,71 @@ metadata:
   namespace: cluster-network-addons
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
   - ""
   resources:
-  - pods
   - configmaps
   verbs:
   - get
-  - list
-  - watch
   - create
-  - patch
   - update
-  - delete
 - apiGroups:
   - apps
   resources:
   - deployments
-  - replicasets
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - update
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
   verbs:
   - get
-  - list
-  - watch
   - create
-  - patch
   - update
+  - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
   - delete
 
 ---
@@ -116,7 +349,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.82.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.86.0
   labels:
     prometheus.cnao.io: "true"
   name: cluster-network-addons-operator
@@ -140,27 +373,31 @@ spec:
       containers:
       - env:
         - name: MULTUS_IMAGE
-          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e
+          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:3fbcc32bd4e4d15bd93c96def784a229cd84cca27942bf4858b581f31c97ee02
         - name: MULTUS_DYNAMIC_NETWORKS_CONTROLLER_IMAGE
-          value: ghcr.io/maiqueb/multus-dynamic-networks-controller@sha256:bd1b07503fd505c66a6ba8b55445a9de94eb322c95d5c22a475df03a8ec67e50
+          value: ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:dee1979d92f0a31598a6e3569ac7004be7d29e7ca9e31db23753ef263110dc04
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins@sha256:c0d14ab010f44bf733aff02b77eb4b5a0ce38fd0c4918a7ecf6941a7bebd72df
+          value: quay.io/kubevirt/cni-default-plugins@sha256:406b43253fb5d45f50d1543879353822e3f746e2794b65ab30754e800386b76d
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2
         - name: OVS_CNI_IMAGE
-          value: quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3
+          value: quay.io/kubevirt/ovs-cni-plugin@sha256:5f7290e2294255ab2547c3b4bf48cc2d75531ec5a43e600366e9b2719bef983f
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214
+          value: quay.io/kubevirt/kubemacpool@sha256:afba7d0c4a95d2d4924f6ee6ef16bbe59117877383819057f01809150829cb0c
         - name: MACVTAP_CNI_IMAGE
-          value: quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02
+          value: quay.io/kubevirt/macvtap-cni@sha256:434420511e09b2b5ede785a2c9062b6658ffbc26fbdd4629ce06110f9039c600
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901
+        - name: KUBE_SECONDARY_DNS_IMAGE
+          value: ghcr.io/kubevirt/kubesecondarydns@sha256:77132adb5f840ceb0aadd408731a5c8b01a4b427a78084ab5e4e9b961195cb02
+        - name: CORE_DNS_IMAGE
+          value: registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.86.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.82.0
+          value: 0.86.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -178,7 +415,9 @@ spec:
           value: openshift-monitoring
         - name: MONITORING_SERVICE_ACCOUNT
           value: prometheus-k8s
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+        - name: RUNBOOK_URL_TEMPLATE
+          value: https://kubevirt.io/monitoring/runbooks/
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.86.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources:

--- a/cluster-provision/k8s/1.27/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.27/manifests/cnao/network-addons-config-example.cr.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   imagePullPolicy: IfNotPresent
   kubeMacPool: {}
+  kubeSecondaryDNS: {}
   linuxBridge: {}
   macvtap: {}
   multus: {}

--- a/cluster-provision/k8s/1.27/manifests/cnao/network-addons-config.crd.yaml
+++ b/cluster-provision/k8s/1.27/manifests/cnao/network-addons-config.crd.yaml
@@ -48,6 +48,17 @@ spec:
                     description: RangeStart defines the first mac in range
                     type: string
                 type: object
+              kubeSecondaryDNS:
+                description: KubeSecondaryDNS plugin allows to support FQDN for VMI's
+                  secondary networks
+                properties:
+                  domain:
+                    description: Domain defines the FQDN domain
+                    type: string
+                  nameServerIP:
+                    description: NameServerIp defines the name server IP
+                    type: string
+                type: object
               linuxBridge:
                 description: LinuxBridge plugin allows users to create a bridge and
                   add the host and the container to it
@@ -55,6 +66,12 @@ spec:
               macvtap:
                 description: MacvtapCni plugin allows users to define Kubernetes networks
                   on top of existing host interfaces
+                properties:
+                  devicePluginConfig:
+                    description: DevicePluginConfig allows the user to override the
+                      name of the `ConfigMap` where the device plugin configuration
+                      is held
+                    type: string
                 type: object
               multus:
                 description: Multus plugin enables attaching multiple network interfaces
@@ -1678,6 +1695,17 @@ spec:
                     description: RangeStart defines the first mac in range
                     type: string
                 type: object
+              kubeSecondaryDNS:
+                description: KubeSecondaryDNS plugin allows to support FQDN for VMI's
+                  secondary networks
+                properties:
+                  domain:
+                    description: Domain defines the FQDN domain
+                    type: string
+                  nameServerIP:
+                    description: NameServerIp defines the name server IP
+                    type: string
+                type: object
               linuxBridge:
                 description: LinuxBridge plugin allows users to create a bridge and
                   add the host and the container to it
@@ -1685,6 +1713,12 @@ spec:
               macvtap:
                 description: MacvtapCni plugin allows users to define Kubernetes networks
                   on top of existing host interfaces
+                properties:
+                  devicePluginConfig:
+                    description: DevicePluginConfig allows the user to override the
+                      name of the `ConfigMap` where the device plugin configuration
+                      is held
+                    type: string
                 type: object
               multus:
                 description: Multus plugin enables attaching multiple network interfaces

--- a/cluster-provision/k8s/1.27/manifests/cnao/operator.yaml
+++ b/cluster-provision/k8s/1.27/manifests/cnao/operator.yaml
@@ -14,38 +14,230 @@ metadata:
   name: cluster-network-addons-operator
 rules:
 - apiGroups:
+  - operator.openshift.io
+  resources:
+  - networks
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - security.openshift.io
-  resourceNames:
-  - privileged
   resources:
   - securitycontextconstraints
   verbs:
   - get
   - list
-  - watch
-  - use
+  - create
+  - update
 - apiGroups:
-  - operator.openshift.io
+  - apiextensions.k8s.io
   resources:
-  - networks
+  - customresourcedefinitions
   verbs:
   - get
-  - list
-  - watch
+  - create
+  - update
 - apiGroups:
   - networkaddonsoperator.network.kubevirt.io
   resources:
   - networkaddonsconfigs
   verbs:
-  - get
   - list
   - watch
 - apiGroups:
-  - '*'
+  - networkaddonsoperator.network.kubevirt.io
+  resources:
+  - networkaddonsconfigs/status
+  verbs:
+  - patch
+- apiGroups:
+  - networkaddonsoperator.network.kubevirt.io
+  resources:
+  - networkaddonsconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - get
+  - create
+  - update
+  - bind
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/status
+  verbs:
+  - get
+  - update
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - k8s.cni.cncf.io
   resources:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -71,30 +263,71 @@ metadata:
   namespace: cluster-network-addons
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
   - ""
   resources:
-  - pods
   - configmaps
   verbs:
   - get
-  - list
-  - watch
   - create
-  - patch
   - update
-  - delete
 - apiGroups:
   - apps
   resources:
   - deployments
-  - replicasets
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - update
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
   verbs:
   - get
-  - list
-  - watch
   - create
-  - patch
   - update
+  - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
   - delete
 
 ---
@@ -116,7 +349,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    networkaddonsoperator.network.kubevirt.io/version: 0.82.0
+    networkaddonsoperator.network.kubevirt.io/version: 0.86.0
   labels:
     prometheus.cnao.io: "true"
   name: cluster-network-addons-operator
@@ -140,27 +373,31 @@ spec:
       containers:
       - env:
         - name: MULTUS_IMAGE
-          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:4e336bd177b5c60e753be48484abb48edb002c7207de9f265fff2e00e8f5106e
+          value: ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:3fbcc32bd4e4d15bd93c96def784a229cd84cca27942bf4858b581f31c97ee02
         - name: MULTUS_DYNAMIC_NETWORKS_CONTROLLER_IMAGE
-          value: ghcr.io/maiqueb/multus-dynamic-networks-controller@sha256:bd1b07503fd505c66a6ba8b55445a9de94eb322c95d5c22a475df03a8ec67e50
+          value: ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:dee1979d92f0a31598a6e3569ac7004be7d29e7ca9e31db23753ef263110dc04
         - name: LINUX_BRIDGE_IMAGE
-          value: quay.io/kubevirt/cni-default-plugins@sha256:c0d14ab010f44bf733aff02b77eb4b5a0ce38fd0c4918a7ecf6941a7bebd72df
+          value: quay.io/kubevirt/cni-default-plugins@sha256:406b43253fb5d45f50d1543879353822e3f746e2794b65ab30754e800386b76d
         - name: LINUX_BRIDGE_MARKER_IMAGE
           value: quay.io/kubevirt/bridge-marker@sha256:5d24c6d1ecb0556896b7b81c7e5260b54173858425777b7a84df8a706c07e6d2
         - name: OVS_CNI_IMAGE
-          value: quay.io/kubevirt/ovs-cni-plugin@sha256:3654b80dd5e459c3e73dd027d732620ed8b488b8a15dfe7922457d16c7e834c3
+          value: quay.io/kubevirt/ovs-cni-plugin@sha256:5f7290e2294255ab2547c3b4bf48cc2d75531ec5a43e600366e9b2719bef983f
         - name: KUBEMACPOOL_IMAGE
-          value: quay.io/kubevirt/kubemacpool@sha256:0cc5ad824fc163d6dea5e9bd872467c691eaa9a88944008b5d746495b2a72214
+          value: quay.io/kubevirt/kubemacpool@sha256:afba7d0c4a95d2d4924f6ee6ef16bbe59117877383819057f01809150829cb0c
         - name: MACVTAP_CNI_IMAGE
-          value: quay.io/kubevirt/macvtap-cni@sha256:5a288f1f9956c2ea8127fa736b598326852d2aa58a8469fa663a1150c2313b02
+          value: quay.io/kubevirt/macvtap-cni@sha256:434420511e09b2b5ede785a2c9062b6658ffbc26fbdd4629ce06110f9039c600
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/openshift/origin-kube-rbac-proxy@sha256:baedb268ac66456018fb30af395bb3d69af5fff3252ff5d549f0231b1ebb6901
+        - name: KUBE_SECONDARY_DNS_IMAGE
+          value: ghcr.io/kubevirt/kubesecondarydns@sha256:77132adb5f840ceb0aadd408731a5c8b01a4b427a78084ab5e4e9b961195cb02
+        - name: CORE_DNS_IMAGE
+          value: registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e
         - name: OPERATOR_IMAGE
-          value: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+          value: quay.io/kubevirt/cluster-network-addons-operator:v0.86.0
         - name: OPERATOR_NAME
           value: cluster-network-addons-operator
         - name: OPERATOR_VERSION
-          value: 0.82.0
+          value: 0.86.0
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -178,7 +415,9 @@ spec:
           value: openshift-monitoring
         - name: MONITORING_SERVICE_ACCOUNT
           value: prometheus-k8s
-        image: quay.io/kubevirt/cluster-network-addons-operator:v0.82.0
+        - name: RUNBOOK_URL_TEMPLATE
+          value: https://kubevirt.io/monitoring/runbooks/
+        image: quay.io/kubevirt/cluster-network-addons-operator:v0.86.0
         imagePullPolicy: Always
         name: cluster-network-addons-operator
         resources:


### PR DESCRIPTION
This will allow KSD to be prepulled.
Note that CNAO and KMP Rbacs were changed (reduced to be more precise).
