### PR TITLE
provision-manager: Switch to fedora

### DIFF
--- a/cluster-provision/gocli/build/Dockerfile
+++ b/cluster-provision/gocli/build/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.18.0
+FROM fedora:35
 
-RUN apk add git
+RUN dnf install -y git
 WORKDIR /workdir
 RUN git config --global --add safe.directory /workdir
 


### PR DESCRIPTION
It is possible that gocli Alpine is the cause for the hangs during provision we see lately.
It started with the pman PR, and also running pman itself hanged once.
Lets move to fedora, to see if it is related.
We can also consider using go-git and then we can remove the OS totally.