### PR TITLE
Fix duplicate mount error during provisioning

### DIFF
--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -185,7 +185,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 			fmt.Sprintf("NODE_NUM=%s", nodeNum),
 		},
 		Volumes: map[string]struct{}{
-			"/var/run/disk/":    {},
+			"/var/run/disk":     {},
 			"/var/lib/registry": {},
 		},
 		Cmd: []string{"/bin/bash", "-c", fmt.Sprintf("/vm.sh --memory %s --cpu %s %s", memory, strconv.Itoa(int(cpu)), qemuArgs)},


### PR DESCRIPTION
Podman recently changed the handling of volumes at the container create
stage[1] to fix a bug[2] so when the bootstrap image was updated this
started failing in the check-provision lanes[3].

[1] https://github.com/containers/podman/pull/18458
[2] https://github.com/containers/podman/issues/18454
[3] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/1024/check-provision-k8s-1.26-centos9/1670717915193675776#1:build-log.txt%3A2275