### PR TITLE
centos9: drop elevator kernel command-line

### DIFF
--- a/cluster-provision/centos9/scripts/kernel.args
+++ b/cluster-provision/centos9/scripts/kernel.args
@@ -1,1 +1,1 @@
-root=/dev/vda1 ro no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop spectre_v2=off nopti intel_iommu=on modprobe.blacklist=nouveau
+root=/dev/vda1 ro no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 spectre_v2=off nopti intel_iommu=on modprobe.blacklist=nouveau


### PR DESCRIPTION
Found this log while looking at dmesg:

    [    0.052248] Kernel command line: root=/dev/vda1 ro no_timer_check
                   console=tty0 console=ttyS0,115200n8 net.ifnames=0
                   biosdevname=0 elevator=noop spectre_v2=off nopti
                   intel_iommu=on modprobe.blacklist=nouveau
                   hugepagesz=2M hugepages=64
    [    0.052332] Kernel parameter elevator= does not have any effect anymore.
                   Please use sysfs to set IO scheduler for individual devices.

This option still works in centos8, so change it only for centos9, see:

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.4_release_notes/deprecated_functionality#deprecated-functionality_file-systems-and-storage