### PR TITLE
vm based providers: Allow using custom images URL

### DIFF
--- a/KUBEVIRTCI_LOCAL_TESTING.md
+++ b/KUBEVIRTCI_LOCAL_TESTING.md
@@ -35,6 +35,10 @@ please use `export BYPASS_PMAN_CHANGE_CHECK=true` to bypass provision-manager ch
 export KUBEVIRTCI_PROVISION_CHECK=1
 ```
 
+If `KUBEVIRTCI_PROVISION_CHECK` is not used,
+you can set `KUBEVIRTCI_CONTAINER_REGISTRY` (default: `quay.io`), `KUBEVIRTCI_CONTAINER_ORG` (default: `kubevirtci`) and `KUBEVIRTCI_CONTAINER_SUFFIX` (default: according gocli tag),
+in order to use a custom image.
+
 Note:
 In case you updated gocli and need to test it locally as well, export additionally:
 ```bash

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -101,8 +101,22 @@ function _add_common_params() {
 
     if [ -n "${KUBEVIRTCI_PROVISION_CHECK}" ]; then
         params=" --container-registry=quay.io --container-suffix=:latest $params"
-    elif [[ ${KUBEVIRT_SLIM} == "true" ]]; then
-        params=" --slim $params"
+    else
+        if [ -n $KUBEVIRTCI_CONTAINER_REGISTRY ]; then
+            params=" --container-registry=$KUBEVIRTCI_CONTAINER_REGISTRY $params"
+        fi
+
+        if [ -n $KUBEVIRTCI_CONTAINER_ORG ]; then
+            params=" --container-org=$KUBEVIRTCI_CONTAINER_ORG $params"
+        fi
+
+        if [ -n $KUBEVIRTCI_CONTAINER_SUFFIX ]; then
+            params=" --container-suffix=:$KUBEVIRTCI_CONTAINER_SUFFIX $params"
+        fi
+
+        if [[ ${KUBEVIRT_SLIM} == "true" ]]; then
+            params=" --slim $params"
+        fi
     fi
 
     if [ $KUBEVIRT_WITH_ETC_IN_MEMORY == "true" ]; then


### PR DESCRIPTION
If `KUBEVIRTCI_PROVISION_CHECK` is not used,
you can set the following:
`KUBEVIRTCI_CONTAINER_REGISTRY` (default: `quay.io`)
`KUBEVIRTCI_CONTAINER_ORG` (default: `kubevirtci`)
`KUBEVIRTCI_CONTAINER_SUFFIX` (default: according gocli tag)
in order to use a custom image.

Usage example (will fetch quay.io/username/k8s-1.25:latest, in case KUBEVIRT_PROVIDER=k8s-1.25)
```
export KUBEVIRTCI_CONTAINER_REGISTRY=quay.io
export KUBEVIRTCI_CONTAINER_ORG=username
export KUBEVIRTCI_CONTAINER_SUFFIX=latest
```
