### PR TITLE
vm based providers: Fix cluster-up script

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -102,15 +102,15 @@ function _add_common_params() {
     if [ -n "${KUBEVIRTCI_PROVISION_CHECK}" ]; then
         params=" --container-registry=quay.io --container-suffix=:latest $params"
     else
-        if [ -n $KUBEVIRTCI_CONTAINER_REGISTRY ]; then
+        if [[ -n ${KUBEVIRTCI_CONTAINER_REGISTRY} ]]; then
             params=" --container-registry=$KUBEVIRTCI_CONTAINER_REGISTRY $params"
         fi
 
-        if [ -n $KUBEVIRTCI_CONTAINER_ORG ]; then
+        if [[ -n ${KUBEVIRTCI_CONTAINER_ORG} ]]; then
             params=" --container-org=$KUBEVIRTCI_CONTAINER_ORG $params"
         fi
 
-        if [ -n $KUBEVIRTCI_CONTAINER_SUFFIX ]; then
+        if [[ -n ${KUBEVIRTCI_CONTAINER_SUFFIX} ]]; then
             params=" --container-suffix=:$KUBEVIRTCI_CONTAINER_SUFFIX $params"
         fi
 


### PR DESCRIPTION
bash `-n` must come either with quotes or "[[" (which eliminate the need to use quotes).

It will ensure bash evaluate it as
```
if [ -n "$KUBEVIRTCI_CONTAINER_REGISTRY" ]; then
   echo abc
fi
```
instead of 
```
if [ -n ]; then
   echo abc
fi
```
on the 2nd case it will print even if the variable is empty or not defined, which is not what we need.

Fixes "Error response from daemon: normalizing image: normalizing name for compat API: invalid reference format"