### PR TITLE
pman: Update rules.yaml with k8s-1.28

### DIFF
--- a/hack/pman/rules.yaml
+++ b/hack/pman/rules.yaml
@@ -28,8 +28,10 @@ exclude:
     exclude:
       - 1.26-centos9
       - 1.27
+      - 1.28
 specific:
   - pattern: cluster-provision/centos9/*
     targets:
       - 1.26-centos9
       - 1.27
+      - 1.28


### PR DESCRIPTION
Once we remove centos8 folder we won't need to do as such anymore.