### PR TITLE
Remove `--os-type` flag from customize-image.sh as it is deprecated

### DIFF
--- a/cluster-provision/images/vm-image-builder/customize-image.sh
+++ b/cluster-provision/images/vm-image-builder/customize-image.sh
@@ -79,7 +79,6 @@ virt-install \
   --name $DOMAIN_NAME \
   --disk "${SOURCE_IMAGE_PATH}",device=disk \
   --disk "${CLOUD_INIT_ISO}",device=cdrom \
-  --os-type Linux \
   --os-variant "${OS_VARIANT}" \
   --graphics none \
   --network default \


### PR DESCRIPTION
The following warning appears when building the test VM images:

"WARNING --os-type is deprecated and does nothing. Please stop using it"

/cc @enp0s3 