### PR TITLE
Enable unprivileged_userfaultfd on centos 9 to support post-copy migration

### DIFF
--- a/cluster-provision/k8s/1.26-centos9/k8s_provision.sh
+++ b/cluster-provision/k8s/1.26-centos9/k8s_provision.sh
@@ -13,6 +13,10 @@ cat <<EOT >/etc/sysconfig/kubelet
 KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice  --fail-swap-on=false --kubelet-cgroups=/systemd/system.slice
 EOT
 
+# Enable userfaultfd for centos9 to support post-copy live migration.
+# For more info: https://github.com/openshift/machine-config-operator/pull/3724
+echo "vm.unprivileged_userfaultfd = 1" > /etc/sysctl.d/enable-userfaultfd.conf
+
 # Needed for kubernetes service routing and dns
 # https://github.com/kubernetes/kubernetes/issues/33798#issuecomment-250962627
 modprobe bridge

--- a/cluster-provision/k8s/1.27/k8s_provision.sh
+++ b/cluster-provision/k8s/1.27/k8s_provision.sh
@@ -13,6 +13,10 @@ cat <<EOT >/etc/sysconfig/kubelet
 KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice  --fail-swap-on=false --kubelet-cgroups=/systemd/system.slice
 EOT
 
+# Enable userfaultfd for centos9 to support post-copy live migration.
+# For more info: https://github.com/openshift/machine-config-operator/pull/3724
+echo "vm.unprivileged_userfaultfd = 1" > /etc/sysctl.d/enable-userfaultfd.conf
+
 # Needed for kubernetes service routing and dns
 # https://github.com/kubernetes/kubernetes/issues/33798#issuecomment-250962627
 modprobe bridge

--- a/cluster-provision/k8s/1.28/k8s_provision.sh
+++ b/cluster-provision/k8s/1.28/k8s_provision.sh
@@ -13,6 +13,10 @@ cat <<EOT >/etc/sysconfig/kubelet
 KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice  --fail-swap-on=false --kubelet-cgroups=/systemd/system.slice
 EOT
 
+# Enable userfaultfd for centos9 to support post-copy live migration.
+# For more info: https://github.com/openshift/machine-config-operator/pull/3724
+echo "vm.unprivileged_userfaultfd = 1" > /etc/sysctl.d/enable-userfaultfd.conf
+
 # Needed for kubernetes service routing and dns
 # https://github.com/kubernetes/kubernetes/issues/33798#issuecomment-250962627
 modprobe bridge


### PR DESCRIPTION
For more info, please look at
https://github.com/openshift/machine-config-operator/pull/3724