### PR TITLE
Increase default disk size to avoid node disk pressure

### DIFF
--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -93,7 +93,7 @@ fi
 
 calc_next_disk
 
-default_disk_size=37580963840 # 35G
+default_disk_size=53687091200 # 50G
 disk_size=$(qemu-img info --output json ${last} | jq '.["virtual-size"]')
 if [ $disk_size -lt $default_disk_size ]; then
     disk_size=$default_disk_size


### PR DESCRIPTION
We saw node disk pressure on a [PR to fix a test](https://github.com/kubevirt/kubevirt/pull/10310). It was suggested to increase the disk size to avoid this.

Setting default disk size to 50G for now.

Original comment:

              Looking at the storage lane failure: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/10310/pull-kubevirt-e2e-k8s-1.27-sig-storage/1694671859703877632
```json
            "status": {
                "phase": "Failed",
                "conditions": [
                    {
                        "type": "kubevirt.io/virtual-machine-unpaused",
                        "status": "True",
                        "lastProbeTime": "2023-08-24T12:28:46Z",
                        "lastTransitionTime": "2023-08-24T12:28:46Z",
                        "reason": "NotPaused",
                        "message": "the virtual machine is not paused"
                    }
                ],
                "message": "Pod was rejected: The node had condition: [DiskPressure]. ",
                "reason": "Evicted",
                "startTime": "2023-08-24T12:28:46Z"
            }
```
> This can be observed in virt-launcher pod status https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/10310/pull-kubevirt-e2e-k8s-1.27-sig-storage/1694671859703877632/artifacts/k8s-reporter-parallel/1/1_pods.log. Seems that we may need more storage for the test jobs...

_Originally posted by @vasiliy-ul in https://github.com/kubevirt/kubevirt/issues/10310#issuecomment-1691640128_
            