### PR TITLE
Pin to earlier versions of vmlinuz and initrd.img due to issue with latest

### DIFF
--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -27,8 +27,11 @@ ENV CENTOS_URL https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Str
 
 RUN /download_box.sh ${CENTOS_URL}
 
+# Pin to earlier versions of vmlinuz & initrd.img due to issue with latest
+RUN curl -L -o /initrd.img https://composes.stream.centos.org/production/CentOS-Stream-9-20230821.0/compose/BaseOS/x86_64/os/images/pxeboot/initrd.img
+RUN curl -L -o /vmlinuz https://composes.stream.centos.org/production/CentOS-Stream-9-20230821.0/compose/BaseOS/x86_64/os/images/pxeboot/vmlinuz
 
-RUN curl -L -o /initrd.img http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/images/pxeboot/initrd.img
-RUN curl -L -o /vmlinuz http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz
+#RUN curl -L -o /initrd.img http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/images/pxeboot/initrd.img
+#RUN curl -L -o /vmlinuz http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz
 
 COPY scripts/* /


### PR DESCRIPTION
There is an issue with powering off the VM[1] with the latest kernel 5.14.0-361.el9.x86_64 that prevents the VM from stopping successfully

The kernel version is determined by vmlinuz so lets pin to the previous working version - CentOS-Stream-9-20230821.0

https://github.com/kubevirt/kubevirtci/blob/8dc9a8349f98e547acfac24ee4d89e323825578a/cluster-provision/centos9/scripts/vm.sh#L160

This will help us to unblock delivery of kubevirtci until the CentOS issue is resolved. 

[1] https://github.com/kubevirt/kubevirtci/pull/1049#issuecomment-1698742595