### PR TITLE
Update to use the new kubernetes community repos

### DIFF
--- a/cluster-provision/k8s/1.26-centos9/provision.sh
+++ b/cluster-provision/k8s/1.26-centos9/provision.sh
@@ -172,7 +172,7 @@ packages_version=$(getKubernetesClosestStableVersion)
 cat <<EOF >/etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes Release
-baseurl=https://storage.googleapis.com/kubernetes-release/release/v${packages_version}/rpm/x86_64/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.26/rpm
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/cluster-provision/k8s/1.27/provision.sh
+++ b/cluster-provision/k8s/1.27/provision.sh
@@ -172,7 +172,7 @@ packages_version=$(getKubernetesClosestStableVersion)
 cat <<EOF >/etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes Release
-baseurl=https://storage.googleapis.com/kubernetes-release/release/v${packages_version}/rpm/x86_64/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.27/rpm
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/cluster-provision/k8s/1.28/provision.sh
+++ b/cluster-provision/k8s/1.28/provision.sh
@@ -170,7 +170,7 @@ packages_version=$(getKubernetesClosestStableVersion)
 cat <<EOF >/etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes Release
-baseurl=https://storage.googleapis.com/kubernetes-release/release/v${packages_version}/rpm/x86_64/
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.28/rpm
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0


### PR DESCRIPTION
https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/

This change is required to allow us to consume later patch versions such as in this PR - https://github.com/kubevirt/kubevirtci/pull/1090

/cc @dhiller @xpivarc  