### PR TITLE
fedora-with-test-tooling: use bosybox version netcat

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -43,7 +43,14 @@ write_files:
         bind 'set enable-bracketed-paste off'
 runcmd:
   - sudo systemctl daemon-reload
-  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng dmidecode virt-what vm-dump-metrics tpm2-tools nc sg3_utils iperf3
+  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng dmidecode virt-what vm-dump-metrics tpm2-tools nc sg3_utils iperf3 wget
+  # Download the busybox netcat and relpace it with the OpenBSD netcat
+  # To align with the netcat tool used in the Alpine image for network e2e testing
+  - if [ $(uname -m) == "aarch64" ]; then export CPUARCH="armv8l"; else export CPUARCH="x86_64"; fi
+  - sudo wget https://busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-${CPUARCH}
+  - sudo chmod +x busybox-${CPUARCH}
+  - sudo mv /usr/bin/nc /usr/bin/netcat-openbsd
+  - sudo mv busybox-${CPUARCH} /usr/bin/nc
   - sudo dnf clean all
   - sudo systemctl enable wait-for-cloud-init
   - sudo systemctl enable qemu-guest-agent.service


### PR DESCRIPTION
Download the busybox netcat and relpace it with the OpenBSD netcat To align with the netcat tool used in the Alpine image for network e2e testing