### PR TITLE
cluster-up kind: enable the configuration of the ip family

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -8,6 +8,9 @@ function detect_cri() {
 
 export CRI_BIN=${CRI_BIN:-$(detect_cri)}
 CONFIG_WORKER_CPU_MANAGER=${CONFIG_WORKER_CPU_MANAGER:-false}
+# only setup ipFamily when the environmental variable is not empty
+# avaliable value: ipv4, ipv6, dual
+IPFAMILY=${IPFAMILY}
 
 # check CPU arch
 PLATFORM=$(uname -m)
@@ -286,10 +289,20 @@ EOF
     fi
 }
 
+function _setup_ipfamily() {
+    if [ $IPFAMILY != "" ]; then
+        cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+networking:
+  ipFamily: $IPFAMILY
+EOF
+        echo "KIND cluster ip family has been set to $IPFAMILY"
+    fi
+}
+
 function _prepare_kind_config() {
     _add_workers
     _add_kubeadm_config_patches
-
+    _setup_ipfamily
     echo "Final KIND config:"
     cat ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
 }


### PR DESCRIPTION
We need to setup ipv6 ip family in e2e tests.