### PR TITLE
gocli: provision: tell qemu to avoid rebooting

### DIFF
--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/alessio/shellescape"
@@ -176,9 +175,6 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 
-	if len(qemuArgs) > 0 {
-		qemuArgs = "--qemu-args " + qemuArgs
-	}
 	node, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: base,
 		Env: []string{
@@ -188,7 +184,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 			"/var/run/disk":     {},
 			"/var/lib/registry": {},
 		},
-		Cmd: []string{"/bin/bash", "-c", fmt.Sprintf("/vm.sh --memory %s --cpu %s %s", memory, strconv.Itoa(int(cpu)), qemuArgs)},
+		Cmd: []string{"/bin/bash", "-c", fmt.Sprintf(`/vm.sh --memory %s --cpu %d --qemu-args "-no-reboot %s"`, memory, cpu, qemuArgs)},
 	}, &container.HostConfig{
 		Mounts: []mount.Mount{
 			{


### PR DESCRIPTION
For some reason, sometimes VM shutdown leads to a reboot, breaking the provisioning process. That would happen if for example the VM looks like it crashed instead of just shutdown. Telling qemu to never reboot should fix the problem, and avoid many provisionning failures.