### PR TITLE
Increase k8s provider number of cpus to 8

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -87,7 +87,7 @@ function _registry_volume() {
 
 function _add_common_params() {
     # shellcheck disable=SC2155
-    local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 6 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --random-ports --background --prefix $provider_prefix ${KUBEVIRT_PROVIDER} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
+    local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 8 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --random-ports --background --prefix $provider_prefix ${KUBEVIRT_PROVIDER} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
 
     params=" --dns-port $KUBEVIRT_DNS_HOST_PORT $params"
 


### PR DESCRIPTION
Needed in order to support `isolateEmulatorThread with full-pcpus-only enabled` e2e test [0], added on https://github.com/kubevirt/kubevirt/pull/10783. 
VMI on e2e test is stuck on:
```
            "status": {
                "conditions": [
                    {
                        "type": "Ready",
                        "status": "False",
                        "lastProbeTime": "2023-11-26T15:34:56Z",
                        "lastTransitionTime": "2023-11-26T15:34:56Z",
                        "reason": "GuestNotRunning",
                        "message": "Guest VM is not reported as running"
                    },
                    {
                        "type": "PodScheduled",
                        "status": "False",
                        "lastProbeTime": null,
                        "lastTransitionTime": "2023-11-26T15:34:56Z",
                        "reason": "Unschedulable",
                        "message": "0/2 nodes are available: 1 Insufficient cpu, 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/2 nodes are available: 1 No preemption victims found for incoming pod, 1 Preemption is not helpful for scheduling.."
                    }
```

[0] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/10783/pull-kubevirt-check-tests-for-flakes/1728764030379626496#1:build-log.txt%3A2953