### PR TITLE
Install nftables on nodes as required by some network tests

### DIFF
--- a/cluster-provision/k8s/1.26-centos9/provision.sh
+++ b/cluster-provision/k8s/1.26-centos9/provision.sh
@@ -89,10 +89,13 @@ systemctl stop firewalld || :
 systemctl disable firewalld || :
 # Make sure the firewall is never enabled again
 # Enabling the firewall destroys the iptable rules
-yum -y remove firewalld
+dnf -y remove firewalld
 
 # Required for iscsi demo to work.
-yum -y install iscsi-initiator-utils
+dnf -y install iscsi-initiator-utils
+
+# required for some sig-network tests
+dnf -y install nftables
 
 # for rook ceph
 dnf -y install lvm2

--- a/cluster-provision/k8s/1.27/provision.sh
+++ b/cluster-provision/k8s/1.27/provision.sh
@@ -89,10 +89,13 @@ systemctl stop firewalld || :
 systemctl disable firewalld || :
 # Make sure the firewall is never enabled again
 # Enabling the firewall destroys the iptable rules
-yum -y remove firewalld
+dnf -y remove firewalld
 
 # Required for iscsi demo to work.
-yum -y install iscsi-initiator-utils
+dnf -y install iscsi-initiator-utils
+
+# required for some sig-network tests
+dnf -y install nftables
 
 # for rook ceph
 dnf -y install lvm2

--- a/cluster-provision/k8s/1.28/provision.sh
+++ b/cluster-provision/k8s/1.28/provision.sh
@@ -87,10 +87,13 @@ systemctl stop firewalld || :
 systemctl disable firewalld || :
 # Make sure the firewall is never enabled again
 # Enabling the firewall destroys the iptable rules
-yum -y remove firewalld
+dnf -y remove firewalld
 
 # Required for iscsi demo to work.
-yum -y install iscsi-initiator-utils
+dnf -y install iscsi-initiator-utils
+
+# required for some sig-network tests
+dnf -y install nftables
 
 # for rook ceph
 dnf -y install lvm2


### PR DESCRIPTION
The install of podman was removed previously[1] as the workaround it was used for was no longer needed.

nftables was installed as a dependency of podman so now it is missing from the nodes and the sig-network lanes are failing[2]

[1] https://github.com/kubevirt/kubevirtci/commit/b60c664ad09b672350fe1377cdf3af1d097de76f
[2] https://github.com/kubevirt/kubevirt/pull/10858#issuecomment-1847283993

/cc @dhiller @EdDev @oshoval 