### PR TITLE
Update fedora test VMs from version 35 to 39

### DIFF
--- a/cluster-provision/images/vm-image-builder/example/image-url
+++ b/cluster-provision/images/vm-image-builder/example/image-url
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/example/os-variant
+++ b/cluster-provision/images/vm-image-builder/example/os-variant
@@ -1,1 +1,1 @@
-fedora32
+fedora39

--- a/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url
+++ b/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url
@@ -1,1 +1,1 @@
-https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2
+https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-kubeadm/os-variant
+++ b/cluster-provision/images/vm-image-builder/fedora-kubeadm/os-variant
@@ -1,1 +1,1 @@
-fedora35
+fedora39

--- a/cluster-provision/images/vm-image-builder/fedora-realtime/image-url
+++ b/cluster-provision/images/vm-image-builder/fedora-realtime/image-url
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-realtime/os-variant
+++ b/cluster-provision/images/vm-image-builder/fedora-realtime/os-variant
@@ -1,1 +1,1 @@
-fedora32
+fedora39

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2
+https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/os-variant
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/os-variant
@@ -1,1 +1,1 @@
-fedora35
+fedora39


### PR DESCRIPTION
Fedora 35 has been EOL for some time now - there is no point testing
against it. The e2e tests should make use of fedora 39 VMs