### PR TITLE
document podman.socket prerequisite for cluster-up

### DIFF
--- a/cluster-up/README.md
+++ b/cluster-up/README.md
@@ -1,4 +1,22 @@
-# How to use cluster-up
+# cluster-up
+
+## Prerequisites: podman or docker
+
+cluster-up requires that either podman or docker be installed on the host.
+
+If podman is being used, it is also necessary to enable podman socket with:
+
+```
+sudo systemctl enable podman.socket
+sudo systemctl start podman.socket
+```
+
+for more information see:
+
+https://github.com/kubevirt/kubevirtci/blob/main/PODMAN.md
+
+
+## How to use cluster-up
 
 This directory provides a wrapper around gocli. It can be vendored into other
 git repos and integrated to provide in the kubevirt well-known cluster commands


### PR DESCRIPTION
see issue #1116

This addresses issue #3052 in [kubevirt-cdi](https://github.com/kubevirt/containerized-data-importer) as well
see comments in [the related PR](https://github.com/kubevirt/containerized-data-importer/pull/3053)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The enablement of podman socket on the test host should be documented in cluster-up README.  
Without podman socket cluster-up fails 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1116

**Special notes for your reviewer**:
we ran into this setting up an external CI/CD system for kubevirt CDI on s390x but it applies to all platforms where `podman` is in use over `docker`.  

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

