### PR TITLE
Build kubevirtci nodes from static centos stream base image

### DIFF
--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -52,12 +52,12 @@ func NewProvisionCommand() *cobra.Command {
 func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 	var base string
 	packagePath := args[0]
-	versionBytes, err := ioutil.ReadFile(filepath.Join(packagePath, "version"))
+	versionBytes, err := os.ReadFile(filepath.Join(packagePath, "version"))
 	if err != nil {
 		return err
 	}
 	version := strings.TrimSpace(string(versionBytes))
-	baseBytes, err := ioutil.ReadFile(filepath.Join(packagePath, "base"))
+	baseBytes, err := os.ReadFile(filepath.Join(packagePath, "base"))
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		base = fmt.Sprintf("quay.io/kubevirtci/%s", strings.TrimSpace(string(baseBytes)))
 	} else {
 		k8sPath := fmt.Sprintf("%s/../", packagePath)
-		baseImageBytes, err := ioutil.ReadFile(filepath.Join(k8sPath, "base-image"))
+		baseImageBytes, err := os.ReadFile(filepath.Join(k8sPath, "base-image"))
 		if err != nil {
 			return err
 		}

--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -90,7 +90,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 	scripts := filepath.Join(packagePath)
 
 	if phases == "linux" {
-		target = base + "-dev"
+		target = base + "-base"
 	}
 
 	memory, err := cmd.Flags().GetString("memory")

--- a/cluster-provision/k8s/1.27/k8s_provision.sh
+++ b/cluster-provision/k8s/1.27/k8s_provision.sh
@@ -4,7 +4,157 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
+function getKubernetesClosestStableVersion() {
+  kubernetes_version=$version
+  packages_version=$kubernetes_version
+  if [[ $kubernetes_version == *"alpha"* ]] || [[ $kubernetes_version == *"beta"* ]] || [[ $kubernetes_version == *"rc"* ]]; then
+    kubernetes_minor_version=$(echo $kubernetes_version | cut -d. -f2)
+    packages_major_version=$(echo $kubernetes_version | cut -d. -f1)
+    packages_minor_version=$((kubernetes_minor_version-1))
+    packages_version="$(curl --fail -L "https://storage.googleapis.com/kubernetes-release/release/stable-${packages_major_version}.${packages_minor_version}.txt" | sed 's/^v//')"
+  fi
+  echo $packages_version
+}
+
+function replaceKubeadmBinary() {
+  dnf install -y which
+  rm -f `which kubeadm`
+
+  DOWNLOAD_DIR="/usr/bin"
+  mkdir -p "$DOWNLOAD_DIR"
+  RELEASE="v$version"
+
+  ARCH="amd64"
+  cd $DOWNLOAD_DIR
+  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubeadm
+  chmod +x kubeadm
+  cd -
+}
+
+function pull_container_retry() {
+    retry=0
+    maxRetries=5
+    retryAfterSeconds=3
+    until [ ${retry} -ge ${maxRetries} ]; do
+        crictl pull "$@" && break
+        retry=$((${retry} + 1))
+        echo "Retrying ${FUNCNAME[0]} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
+        sleep ${retryAfterSeconds}
+    done
+
+    if [ ${retry} -ge ${maxRetries} ]; then
+        echo "${FUNCNAME[0]} Failed after ${maxRetries} attempts!"
+        exit 1
+    fi
+}
+
+if [ ! -f "/tmp/extra-pre-pull-images" ]; then
+    echo "ERROR: extra-pre-pull-images list missing"
+    exit 1
+fi
+if [ ! -f "/tmp/fetch-images.sh" ]; then
+    echo "ERROR: fetch-images.sh missing"
+    exit 1
+fi
+
+if grep -q "CentOS Stream 9" /etc/os-release; then
+  release="centos9"
+else
+  echo "ERROR: Could not recognize guest OS"
+  exit 1
+fi
+
+export CRIO_VERSION=1.27
+cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo
+[devel_kubic_libcontainers_stable]
+name=Stable Releases of Upstream github.com/containers packages (CentOS_9_Stream)
+type=rpm-md
+baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcontainers_stable/
+gpgcheck=0
+enabled=1
+EOF
+cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}.repo
+[devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}]
+name=devel:kubic:libcontainers:stable:cri-o:${CRIO_VERSION} (CentOS_9_Stream)
+type=rpm-md
+baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}
+gpgcheck=0
+enabled=1
+EOF
+
+dnf install -y cri-o
+
+systemctl enable --now crio
+
+cat << EOF > /etc/containers/registries.conf
+[registries.search]
+registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
+
+[registries.insecure]
+registries = ['registry:5000']
+
+[registries.block]
+registries = []
+EOF
+
+packages_version=$(getKubernetesClosestStableVersion)
+
+# Add Kubernetes release repository.
+# use repodata from GCS bucket, since the release repo might not have it right after the release
+# we deduce the https path from the gcs path gs://kubernetes-release/release/${version}/rpm/x86_64/
+# see https://github.com/kubernetes/kubeadm/blob/main/docs/testing-pre-releases.md#availability-of-pre-compiled-release-artifacts
+cat <<EOF >/etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes Release
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.27/rpm
+enabled=1
+gpgcheck=0
+repo_gpgcheck=0
+EOF
+
+# Install Kubernetes CNI.
+dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
+    kubectl-${packages_version} \
+    kubeadm-${packages_version} \
+    kubelet-${packages_version} \
+    kubernetes-cni
+
+# In case the version is unstable the package manager recognizes only the closest stable version
+# But it's unsafe using older kubeadm version than kubernetes version according to:
+# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#kubeadm-s-skew-against-the-kubernetes-version
+# The reason we install kubeadm using dnf is for the dependencies packages.
+if [[ $version != $packages_version ]]; then
+   replaceKubeadmBinary
+fi
+
+kubeadm config images pull --kubernetes-version ${version}
+
+kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
+mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
+
+if [[ ${slim} == false ]]; then
+    # Pre pull all images from the manifests
+    for image in $(/tmp/fetch-images.sh /tmp); do
+        pull_container_retry "${image}"
+    done
+
+    # Pre pull additional images from list
+    for image in $(cat "/tmp/extra-pre-pull-images"); do
+        pull_container_retry "${image}"
+    done
+fi
+
+mkdir -p /provision
+
 cni_manifest="/provision/cni.yaml"
+cni_diff="/tmp/cni.diff"
+cni_manifest_ipv6="/provision/cni_ipv6.yaml"
+cni_ipv6_diff="/tmp/cni_ipv6.diff"
+
+cp /tmp/cni.do-not-change.yaml $cni_manifest
+mv /tmp/cni.do-not-change.yaml $cni_manifest_ipv6
+patch $cni_manifest $cni_diff
+patch $cni_manifest_ipv6 $cni_ipv6_diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 
@@ -44,8 +194,6 @@ rm -f /etc/cni/net.d/*
 
 systemctl daemon-reload
 systemctl enable crio kubelet --now
-
-dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -225,8 +373,6 @@ cp -rf /tmp/cdi*.yaml /opt/
 mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
-
-dnf install -y NetworkManager-config-server
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.27/provision.sh
+++ b/cluster-provision/k8s/1.27/provision.sh
@@ -2,49 +2,6 @@
 
 set -ex
 
-function getKubernetesClosestStableVersion() {
-  kubernetes_version=$version
-  packages_version=$kubernetes_version
-  if [[ $kubernetes_version == *"alpha"* ]] || [[ $kubernetes_version == *"beta"* ]] || [[ $kubernetes_version == *"rc"* ]]; then
-    kubernetes_minor_version=$(echo $kubernetes_version | cut -d. -f2)
-    packages_major_version=$(echo $kubernetes_version | cut -d. -f1)
-    packages_minor_version=$((kubernetes_minor_version-1))
-    packages_version="$(curl --fail -L "https://storage.googleapis.com/kubernetes-release/release/stable-${packages_major_version}.${packages_minor_version}.txt" | sed 's/^v//')"
-  fi
-  echo $packages_version
-}
-
-function replaceKubeadmBinary() {
-  dnf install -y which
-  rm -f `which kubeadm`
-
-  DOWNLOAD_DIR="/usr/bin"
-  mkdir -p "$DOWNLOAD_DIR"
-  RELEASE="v$version"
-
-  ARCH="amd64"
-  cd $DOWNLOAD_DIR
-  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubeadm
-  chmod +x kubeadm
-  cd -
-}
-
-if [ ! -f "/tmp/extra-pre-pull-images" ]; then
-    echo "ERROR: extra-pre-pull-images list missing"
-    exit 1
-fi
-if [ ! -f "/tmp/fetch-images.sh" ]; then
-    echo "ERROR: fetch-images.sh missing"
-    exit 1
-fi
-
-if grep -q "CentOS Stream 9" /etc/os-release; then
-  release="centos9"
-else
-  echo "ERROR: Could not recognize guest OS"
-  exit 1
-fi
-
 KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
 mkdir -p $KUBEVIRTCI_SHARED_DIR
 export ISTIO_VERSION=1.15.0
@@ -56,23 +13,6 @@ export ISTIO_VERSION=${ISTIO_VERSION}
 export ISTIO_BIN_DIR="/opt/istio-${ISTIO_VERSION}/bin"
 EOF
 source $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
-
-function pull_container_retry() {
-    retry=0
-    maxRetries=5
-    retryAfterSeconds=3
-    until [ ${retry} -ge ${maxRetries} ]; do
-        crictl pull "$@" && break
-        retry=$((${retry} + 1))
-        echo "Retrying ${FUNCNAME[0]} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
-        sleep ${retryAfterSeconds}
-    done
-
-    if [ ${retry} -ge ${maxRetries} ]; then
-        echo "${FUNCNAME[0]} Failed after ${maxRetries} attempts!"
-        exit 1
-    fi
-}
 
 # Install modules of the initrd kernel
 dnf install -y "kernel-modules-$(uname -r)"
@@ -114,99 +54,10 @@ export PATH="$ISTIO_BIN_DIR:$PATH"
   chmod +x "$ISTIO_BIN_DIR/istioctl"
 )
 
-export CRIO_VERSION=1.27
-cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable.repo
-[devel_kubic_libcontainers_stable]
-name=Stable Releases of Upstream github.com/containers packages (CentOS_9_Stream)
-type=rpm-md
-baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcontainers_stable/
-gpgcheck=0
-enabled=1
-EOF
-cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}.repo
-[devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}]
-name=devel:kubic:libcontainers:stable:cri-o:${CRIO_VERSION} (CentOS_9_Stream)
-type=rpm-md
-baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}
-gpgcheck=0
-enabled=1
-EOF
-
-dnf install -y cri-o
-
-systemctl enable --now crio
-
 dnf install -y libseccomp-devel
 
-cat << EOF > /etc/containers/registries.conf
-[registries.search]
-registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
-
-[registries.insecure]
-registries = ['registry:5000']
-
-[registries.block]
-registries = []
-EOF
-
-packages_version=$(getKubernetesClosestStableVersion)
-
-# Add Kubernetes release repository.
-# use repodata from GCS bucket, since the release repo might not have it right after the release
-# we deduce the https path from the gcs path gs://kubernetes-release/release/${version}/rpm/x86_64/
-# see https://github.com/kubernetes/kubeadm/blob/main/docs/testing-pre-releases.md#availability-of-pre-compiled-release-artifacts
-cat <<EOF >/etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes Release
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.27/rpm
-enabled=1
-gpgcheck=0
-repo_gpgcheck=0
-EOF
-
-# Install Kubernetes CNI.
-dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
-    kubectl-${packages_version} \
-    kubeadm-${packages_version} \
-    kubelet-${packages_version} \
-    kubernetes-cni
-
-# In case the version is unstable the package manager recognizes only the closest stable version
-# But it's unsafe using older kubeadm version than kubernetes version according to:
-# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#kubeadm-s-skew-against-the-kubernetes-version
-# The reason we install kubeadm using dnf is for the dependencies packages.
-if [[ $version != $packages_version ]]; then
-   replaceKubeadmBinary
-fi
-
-kubeadm config images pull --kubernetes-version ${version}
 
 dnf install -y centos-release-nfv-openvswitch
 dnf install -y openvswitch2.16
 
-mkdir -p /provision
-
-cni_manifest="/provision/cni.yaml"
-cni_diff="/tmp/cni.diff"
-cni_manifest_ipv6="/provision/cni_ipv6.yaml"
-cni_ipv6_diff="/tmp/cni_ipv6.diff"
-
-cp /tmp/cni.do-not-change.yaml $cni_manifest
-mv /tmp/cni.do-not-change.yaml $cni_manifest_ipv6
-patch $cni_manifest $cni_diff
-patch $cni_manifest_ipv6 $cni_ipv6_diff
-
-kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
-mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
-
-if [[ ${slim} == false ]]; then
-    # Pre pull all images from the manifests
-    for image in $(/tmp/fetch-images.sh /tmp); do
-        pull_container_retry "${image}"
-    done
-
-    # Pre pull additional images from list
-    for image in $(cat "/tmp/extra-pre-pull-images"); do
-        pull_container_retry "${image}"
-    done
-fi
+dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server

--- a/cluster-provision/k8s/1.28/k8s_provision.sh
+++ b/cluster-provision/k8s/1.28/k8s_provision.sh
@@ -4,7 +4,151 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
+function getKubernetesClosestStableVersion() {
+  kubernetes_version=$version
+  packages_version=$kubernetes_version
+  if [[ $kubernetes_version == *"alpha"* ]] || [[ $kubernetes_version == *"beta"* ]] || [[ $kubernetes_version == *"rc"* ]]; then
+    kubernetes_minor_version=$(echo $kubernetes_version | cut -d. -f2)
+    packages_major_version=$(echo $kubernetes_version | cut -d. -f1)
+    packages_minor_version=$((kubernetes_minor_version-1))
+    packages_version="$(curl --fail -L "https://storage.googleapis.com/kubernetes-release/release/stable-${packages_major_version}.${packages_minor_version}.txt" | sed 's/^v//')"
+  fi
+  echo $packages_version
+}
+
+function replaceKubeadmBinary() {
+  dnf install -y which
+  rm -f `which kubeadm`
+
+  DOWNLOAD_DIR="/usr/bin"
+  mkdir -p "$DOWNLOAD_DIR"
+  RELEASE="v$version"
+
+  ARCH="amd64"
+  cd $DOWNLOAD_DIR
+  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubeadm
+  chmod +x kubeadm
+  cd -
+}
+
+function pull_container_retry() {
+    retry=0
+    maxRetries=5
+    retryAfterSeconds=3
+    until [ ${retry} -ge ${maxRetries} ]; do
+        crictl pull "$@" && break
+        retry=$((${retry} + 1))
+        echo "Retrying ${FUNCNAME[0]} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
+        sleep ${retryAfterSeconds}
+    done
+
+    if [ ${retry} -ge ${maxRetries} ]; then
+        echo "${FUNCNAME[0]} Failed after ${maxRetries} attempts!"
+        exit 1
+    fi
+}
+
+if [ ! -f "/tmp/extra-pre-pull-images" ]; then
+    echo "ERROR: extra-pre-pull-images list missing"
+    exit 1
+fi
+if [ ! -f "/tmp/fetch-images.sh" ]; then
+    echo "ERROR: fetch-images.sh missing"
+    exit 1
+fi
+
+if grep -q "CentOS Stream 9" /etc/os-release; then
+  release="centos9"
+else
+  echo "ERROR: Could not recognize guest OS"
+  exit 1
+fi
+
+
+export CRIO_VERSION=1.28
+cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}.repo
+[isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}]
+name=CRI-O v${CRIO_VERSION} (Stable) (rpm)
+type=rpm-md
+baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}
+gpgcheck=0
+enabled=1
+EOF
+
+dnf install -y cri-o
+
+systemctl enable --now crio
+
+
+cat << EOF > /etc/containers/registries.conf
+[registries.search]
+registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
+
+[registries.insecure]
+registries = ['registry:5000']
+
+[registries.block]
+registries = []
+EOF
+
+packages_version=$(getKubernetesClosestStableVersion)
+major_version=$(echo $packages_version | cut -d "." -f 2)
+# Add Kubernetes release repository.
+# use repodata from GCS bucket, since the release repo might not have it right after the release
+# we deduce the https path from the gcs path gs://kubernetes-release/release/${version}/rpm/x86_64/
+# see https://github.com/kubernetes/kubeadm/blob/main/docs/testing-pre-releases.md#availability-of-pre-compiled-release-artifacts
+cat <<EOF >/etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes Release
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.${major_version}/rpm
+enabled=1
+gpgcheck=0
+repo_gpgcheck=0
+EOF
+
+# Install Kubernetes CNI.
+dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
+    kubectl-${packages_version} \
+    kubeadm-${packages_version} \
+    kubelet-${packages_version} \
+    kubernetes-cni
+
+# In case the version is unstable the package manager recognizes only the closest stable version
+# But it's unsafe using older kubeadm version than kubernetes version according to:
+# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#kubeadm-s-skew-against-the-kubernetes-version
+# The reason we install kubeadm using dnf is for the dependencies packages.
+if [[ $version != $packages_version ]]; then
+   replaceKubeBinaries
+fi
+
+kubeadm config images pull --kubernetes-version ${version}
+
+kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
+mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
+
+if [[ ${slim} == false ]]; then
+    # Pre pull all images from the manifests
+    for image in $(/tmp/fetch-images.sh /tmp); do
+        pull_container_retry "${image}"
+    done
+
+    # Pre pull additional images from list
+    for image in $(cat "/tmp/extra-pre-pull-images"); do
+        pull_container_retry "${image}"
+    done
+fi
+
+mkdir -p /provision
+
 cni_manifest="/provision/cni.yaml"
+cni_diff="/tmp/cni.diff"
+cni_manifest_ipv6="/provision/cni_ipv6.yaml"
+cni_ipv6_diff="/tmp/cni_ipv6.diff"
+
+cp /tmp/cni.do-not-change.yaml $cni_manifest
+mv /tmp/cni.do-not-change.yaml $cni_manifest_ipv6
+patch $cni_manifest $cni_diff
+patch $cni_manifest_ipv6 $cni_ipv6_diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 
@@ -44,8 +188,6 @@ rm -f /etc/cni/net.d/*
 
 systemctl daemon-reload
 systemctl enable crio kubelet --now
-
-dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -225,8 +367,6 @@ cp -rf /tmp/cdi*.yaml /opt/
 mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
-
-dnf install -y NetworkManager-config-server
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.28/provision.sh
+++ b/cluster-provision/k8s/1.28/provision.sh
@@ -2,47 +2,6 @@
 
 set -ex
 
-function getKubernetesClosestStableVersion() {
-  kubernetes_version=$version
-  packages_version=$kubernetes_version
-  if [[ $kubernetes_version == *"alpha"* ]] || [[ $kubernetes_version == *"beta"* ]] || [[ $kubernetes_version == *"rc"* ]]; then
-    kubernetes_minor_version=$(echo $kubernetes_version | cut -d. -f2)
-    packages_major_version=$(echo $kubernetes_version | cut -d. -f1)
-    packages_minor_version=$((kubernetes_minor_version-1))
-    packages_version="$(curl --fail -L "https://storage.googleapis.com/kubernetes-release/release/stable-${packages_major_version}.${packages_minor_version}.txt" | sed 's/^v//')"
-  fi
-  echo $packages_version
-}
-
-function replaceKubeBinaries() {
-  dnf install -y which
-  rm -f $(which kubeadm kubelet)
-
-  BIN_DIR="/usr/bin"
-  RELEASE="v$version"
-  ARCH="amd64"
-
-  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubeadm -o ${BIN_DIR}/kubeadm
-  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubelet -o ${BIN_DIR}/kubelet
-  chmod +x ${BIN_DIR}/kubeadm ${BIN_DIR}/kubelet
-}
-
-if [ ! -f "/tmp/extra-pre-pull-images" ]; then
-    echo "ERROR: extra-pre-pull-images list missing"
-    exit 1
-fi
-if [ ! -f "/tmp/fetch-images.sh" ]; then
-    echo "ERROR: fetch-images.sh missing"
-    exit 1
-fi
-
-if grep -q "CentOS Stream 9" /etc/os-release; then
-  release="centos9"
-else
-  echo "ERROR: Could not recognize guest OS"
-  exit 1
-fi
-
 KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
 mkdir -p $KUBEVIRTCI_SHARED_DIR
 export ISTIO_VERSION=1.15.0
@@ -54,23 +13,6 @@ export ISTIO_VERSION=${ISTIO_VERSION}
 export ISTIO_BIN_DIR="/opt/istio-${ISTIO_VERSION}/bin"
 EOF
 source $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
-
-function pull_container_retry() {
-    retry=0
-    maxRetries=5
-    retryAfterSeconds=3
-    until [ ${retry} -ge ${maxRetries} ]; do
-        crictl pull "$@" && break
-        retry=$((${retry} + 1))
-        echo "Retrying ${FUNCNAME[0]} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
-        sleep ${retryAfterSeconds}
-    done
-
-    if [ ${retry} -ge ${maxRetries} ]; then
-        echo "${FUNCNAME[0]} Failed after ${maxRetries} attempts!"
-        exit 1
-    fi
-}
 
 # Install modules of the initrd kernel
 dnf install -y "kernel-modules-$(uname -r)"
@@ -122,81 +64,11 @@ gpgcheck=0
 enabled=1
 EOF
 
-dnf install -y cri-o container-selinux
-
-systemctl enable --now crio
+dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
-
-cat << EOF > /etc/containers/registries.conf
-[registries.search]
-registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
-
-[registries.insecure]
-registries = ['registry:5000']
-
-[registries.block]
-registries = []
-EOF
-
-packages_version=$(getKubernetesClosestStableVersion)
-major_version=$(echo $packages_version | cut -d "." -f 2)
-# Add Kubernetes release repository.
-# use repodata from GCS bucket, since the release repo might not have it right after the release
-# we deduce the https path from the gcs path gs://kubernetes-release/release/${version}/rpm/x86_64/
-# see https://github.com/kubernetes/kubeadm/blob/main/docs/testing-pre-releases.md#availability-of-pre-compiled-release-artifacts
-cat <<EOF >/etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes Release
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.${major_version}/rpm
-enabled=1
-gpgcheck=0
-repo_gpgcheck=0
-EOF
-
-# Install Kubernetes CNI.
-dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
-    kubectl-${packages_version} \
-    kubeadm-${packages_version} \
-    kubelet-${packages_version} \
-    kubernetes-cni
-
-# In case the version is unstable the package manager recognizes only the closest stable version
-# But it's unsafe using older kubeadm version than kubernetes version according to:
-# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#kubeadm-s-skew-against-the-kubernetes-version
-# The reason we install kubeadm using dnf is for the dependencies packages.
-if [[ $version != $packages_version ]]; then
-   replaceKubeBinaries
-fi
-
-kubeadm config images pull --kubernetes-version ${version}
 
 dnf install -y centos-release-nfv-openvswitch
 dnf install -y openvswitch2.16
 
-mkdir -p /provision
-
-cni_manifest="/provision/cni.yaml"
-cni_diff="/tmp/cni.diff"
-cni_manifest_ipv6="/provision/cni_ipv6.yaml"
-cni_ipv6_diff="/tmp/cni_ipv6.diff"
-
-cp /tmp/cni.do-not-change.yaml $cni_manifest
-mv /tmp/cni.do-not-change.yaml $cni_manifest_ipv6
-patch $cni_manifest $cni_diff
-patch $cni_manifest_ipv6 $cni_ipv6_diff
-
-kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
-mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
-
-if [[ ${slim} == false ]]; then
-    # Pre pull all images from the manifests
-    for image in $(/tmp/fetch-images.sh /tmp); do
-        pull_container_retry "${image}"
-    done
-
-    # Pre pull additional images from list
-    for image in $(cat "/tmp/extra-pre-pull-images"); do
-        pull_container_retry "${image}"
-    done
-fi
+dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server

--- a/cluster-provision/k8s/1.29/k8s_provision.sh
+++ b/cluster-provision/k8s/1.29/k8s_provision.sh
@@ -4,7 +4,140 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
+function getKubernetesClosestStableVersion() {
+  kubernetes_version=$version
+  packages_version=$kubernetes_version
+  if [[ $kubernetes_version == *"alpha"* ]] || [[ $kubernetes_version == *"beta"* ]] || [[ $kubernetes_version == *"rc"* ]]; then
+    kubernetes_minor_version=$(echo $kubernetes_version | cut -d. -f2)
+    packages_major_version=$(echo $kubernetes_version | cut -d. -f1)
+    packages_minor_version=$((kubernetes_minor_version-1))
+    packages_version="$(curl --fail -L "https://storage.googleapis.com/kubernetes-release/release/stable-${packages_major_version}.${packages_minor_version}.txt" | sed 's/^v//')"
+  fi
+  echo $packages_version
+}
+
+function replaceKubeBinaries() {
+  dnf install -y which
+  rm -f $(which kubeadm kubelet)
+
+  BIN_DIR="/usr/bin"
+  RELEASE="v$version"
+  ARCH="amd64"
+
+  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubeadm -o ${BIN_DIR}/kubeadm
+  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubelet -o ${BIN_DIR}/kubelet
+  chmod +x ${BIN_DIR}/kubeadm ${BIN_DIR}/kubelet
+}
+
+function pull_container_retry() {
+    retry=0
+    maxRetries=5
+    retryAfterSeconds=3
+    until [ ${retry} -ge ${maxRetries} ]; do
+        crictl pull "$@" && break
+        retry=$((${retry} + 1))
+        echo "Retrying ${FUNCNAME[0]} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
+        sleep ${retryAfterSeconds}
+    done
+
+    if [ ${retry} -ge ${maxRetries} ]; then
+        echo "${FUNCNAME[0]} Failed after ${maxRetries} attempts!"
+        exit 1
+    fi
+}
+
+if [ ! -f "/tmp/extra-pre-pull-images" ]; then
+    echo "ERROR: extra-pre-pull-images list missing"
+    exit 1
+fi
+if [ ! -f "/tmp/fetch-images.sh" ]; then
+    echo "ERROR: fetch-images.sh missing"
+    exit 1
+fi
+
+export CRIO_VERSION=1.29
+cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}.repo
+[isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}]
+name=CRI-O v${CRIO_VERSION} (Stable) (rpm)
+type=rpm-md
+baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}
+gpgcheck=0
+enabled=1
+EOF
+
+dnf install -y cri-o
+
+systemctl enable --now crio
+
+cat << EOF > /etc/containers/registries.conf
+[registries.search]
+registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
+
+[registries.insecure]
+registries = ['registry:5000']
+
+[registries.block]
+registries = []
+EOF
+
+packages_version=$(getKubernetesClosestStableVersion)
+major_version=$(echo $packages_version | cut -d "." -f 2)
+# Add Kubernetes release repository.
+# use repodata from GCS bucket, since the release repo might not have it right after the release
+# we deduce the https path from the gcs path gs://kubernetes-release/release/${version}/rpm/x86_64/
+# see https://github.com/kubernetes/kubeadm/blob/main/docs/testing-pre-releases.md#availability-of-pre-compiled-release-artifacts
+cat <<EOF >/etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes Release
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.${major_version}/rpm
+enabled=1
+gpgcheck=0
+repo_gpgcheck=0
+EOF
+
+# Install Kubernetes CNI.
+dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
+    kubectl-${packages_version} \
+    kubeadm-${packages_version} \
+    kubelet-${packages_version} \
+    kubernetes-cni
+
+# In case the version is unstable the package manager recognizes only the closest stable version
+# But it's unsafe using older kubeadm version than kubernetes version according to:
+# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#kubeadm-s-skew-against-the-kubernetes-version
+# The reason we install kubeadm using dnf is for the dependencies packages.
+if [[ $version != $packages_version ]]; then
+   replaceKubeBinaries
+fi
+
+kubeadm config images pull --kubernetes-version ${version}
+
+kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
+mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
+
+if [[ ${slim} == false ]]; then
+    # Pre pull all images from the manifests
+    for image in $(/tmp/fetch-images.sh /tmp); do
+        pull_container_retry "${image}"
+    done
+
+    # Pre pull additional images from list
+    for image in $(cat "/tmp/extra-pre-pull-images"); do
+        pull_container_retry "${image}"
+    done
+fi
+
+mkdir -p /provision
+
 cni_manifest="/provision/cni.yaml"
+cni_diff="/tmp/cni.diff"
+cni_manifest_ipv6="/provision/cni_ipv6.yaml"
+cni_ipv6_diff="/tmp/cni_ipv6.diff"
+
+cp /tmp/cni.do-not-change.yaml $cni_manifest
+mv /tmp/cni.do-not-change.yaml $cni_manifest_ipv6
+patch $cni_manifest $cni_diff
+patch $cni_manifest_ipv6 $cni_ipv6_diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 
@@ -44,8 +177,6 @@ rm -f /etc/cni/net.d/*
 
 systemctl daemon-reload
 systemctl enable crio kubelet --now
-
-dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -225,8 +356,6 @@ cp -rf /tmp/cdi*.yaml /opt/
 mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
-
-dnf install -y NetworkManager-config-server
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.29/provision.sh
+++ b/cluster-provision/k8s/1.29/provision.sh
@@ -2,40 +2,6 @@
 
 set -ex
 
-function getKubernetesClosestStableVersion() {
-  kubernetes_version=$version
-  packages_version=$kubernetes_version
-  if [[ $kubernetes_version == *"alpha"* ]] || [[ $kubernetes_version == *"beta"* ]] || [[ $kubernetes_version == *"rc"* ]]; then
-    kubernetes_minor_version=$(echo $kubernetes_version | cut -d. -f2)
-    packages_major_version=$(echo $kubernetes_version | cut -d. -f1)
-    packages_minor_version=$((kubernetes_minor_version-1))
-    packages_version="$(curl --fail -L "https://storage.googleapis.com/kubernetes-release/release/stable-${packages_major_version}.${packages_minor_version}.txt" | sed 's/^v//')"
-  fi
-  echo $packages_version
-}
-
-function replaceKubeBinaries() {
-  dnf install -y which
-  rm -f $(which kubeadm kubelet)
-
-  BIN_DIR="/usr/bin"
-  RELEASE="v$version"
-  ARCH="amd64"
-
-  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubeadm -o ${BIN_DIR}/kubeadm
-  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubelet -o ${BIN_DIR}/kubelet
-  chmod +x ${BIN_DIR}/kubeadm ${BIN_DIR}/kubelet
-}
-
-if [ ! -f "/tmp/extra-pre-pull-images" ]; then
-    echo "ERROR: extra-pre-pull-images list missing"
-    exit 1
-fi
-if [ ! -f "/tmp/fetch-images.sh" ]; then
-    echo "ERROR: fetch-images.sh missing"
-    exit 1
-fi
-
 if grep -q "CentOS Stream 9" /etc/os-release; then
   release="centos9"
 else
@@ -54,23 +20,6 @@ export ISTIO_VERSION=${ISTIO_VERSION}
 export ISTIO_BIN_DIR="/opt/istio-${ISTIO_VERSION}/bin"
 EOF
 source $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
-
-function pull_container_retry() {
-    retry=0
-    maxRetries=5
-    retryAfterSeconds=3
-    until [ ${retry} -ge ${maxRetries} ]; do
-        crictl pull "$@" && break
-        retry=$((${retry} + 1))
-        echo "Retrying ${FUNCNAME[0]} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
-        sleep ${retryAfterSeconds}
-    done
-
-    if [ ${retry} -ge ${maxRetries} ]; then
-        echo "${FUNCNAME[0]} Failed after ${maxRetries} attempts!"
-        exit 1
-    fi
-}
 
 # Install modules of the initrd kernel
 dnf install -y "kernel-modules-$(uname -r)"
@@ -112,91 +61,12 @@ export PATH="$ISTIO_BIN_DIR:$PATH"
   chmod +x "$ISTIO_BIN_DIR/istioctl"
 )
 
-export CRIO_VERSION=1.29
-cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}.repo
-[isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}]
-name=CRI-O v${CRIO_VERSION} (Stable) (rpm)
-type=rpm-md
-baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}
-gpgcheck=0
-enabled=1
-EOF
-
-dnf install -y cri-o container-selinux
-
-systemctl enable --now crio
+dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
-
-cat << EOF > /etc/containers/registries.conf
-[registries.search]
-registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
-
-[registries.insecure]
-registries = ['registry:5000']
-
-[registries.block]
-registries = []
-EOF
-
-packages_version=$(getKubernetesClosestStableVersion)
-major_version=$(echo $packages_version | cut -d "." -f 2)
-# Add Kubernetes release repository.
-# use repodata from GCS bucket, since the release repo might not have it right after the release
-# we deduce the https path from the gcs path gs://kubernetes-release/release/${version}/rpm/x86_64/
-# see https://github.com/kubernetes/kubeadm/blob/main/docs/testing-pre-releases.md#availability-of-pre-compiled-release-artifacts
-cat <<EOF >/etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes Release
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.${major_version}/rpm
-enabled=1
-gpgcheck=0
-repo_gpgcheck=0
-EOF
-
-# Install Kubernetes CNI.
-dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
-    kubectl-${packages_version} \
-    kubeadm-${packages_version} \
-    kubelet-${packages_version} \
-    kubernetes-cni
-
-# In case the version is unstable the package manager recognizes only the closest stable version
-# But it's unsafe using older kubeadm version than kubernetes version according to:
-# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#kubeadm-s-skew-against-the-kubernetes-version
-# The reason we install kubeadm using dnf is for the dependencies packages.
-if [[ $version != $packages_version ]]; then
-   replaceKubeBinaries
-fi
-
-kubeadm config images pull --kubernetes-version ${version}
 
 dnf install -y centos-release-nfv-openvswitch
 dnf install -y openvswitch2.16
 
-mkdir -p /provision
+dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 
-cni_manifest="/provision/cni.yaml"
-cni_diff="/tmp/cni.diff"
-cni_manifest_ipv6="/provision/cni_ipv6.yaml"
-cni_ipv6_diff="/tmp/cni_ipv6.diff"
-
-cp /tmp/cni.do-not-change.yaml $cni_manifest
-mv /tmp/cni.do-not-change.yaml $cni_manifest_ipv6
-patch $cni_manifest $cni_diff
-patch $cni_manifest_ipv6 $cni_ipv6_diff
-
-kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
-mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
-
-if [[ ${slim} == false ]]; then
-    # Pre pull all images from the manifests
-    for image in $(/tmp/fetch-images.sh /tmp); do
-        pull_container_retry "${image}"
-    done
-
-    # Pre pull additional images from list
-    for image in $(cat "/tmp/extra-pre-pull-images"); do
-        pull_container_retry "${image}"
-    done
-fi

--- a/cluster-provision/k8s/1.30/k8s_provision.sh
+++ b/cluster-provision/k8s/1.30/k8s_provision.sh
@@ -4,7 +4,147 @@ set -ex
 
 source /var/lib/kubevirtci/shared_vars.sh
 
+function getKubernetesClosestStableVersion() {
+  kubernetes_version=$version
+  packages_version=$kubernetes_version
+  if [[ $kubernetes_version == *"alpha"* ]] || [[ $kubernetes_version == *"beta"* ]] || [[ $kubernetes_version == *"rc"* ]]; then
+    kubernetes_minor_version=$(echo $kubernetes_version | cut -d. -f2)
+    packages_major_version=$(echo $kubernetes_version | cut -d. -f1)
+    packages_minor_version=$((kubernetes_minor_version-1))
+    packages_version="$(curl --fail -L "https://storage.googleapis.com/kubernetes-release/release/stable-${packages_major_version}.${packages_minor_version}.txt" | sed 's/^v//')"
+  fi
+  echo $packages_version
+}
+
+function replaceKubeBinaries() {
+  dnf install -y which
+  rm -f $(which kubeadm kubelet)
+
+  BIN_DIR="/usr/bin"
+  RELEASE="v$version"
+  ARCH="amd64"
+
+  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubeadm -o ${BIN_DIR}/kubeadm
+  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubelet -o ${BIN_DIR}/kubelet
+  chmod +x ${BIN_DIR}/kubeadm ${BIN_DIR}/kubelet
+}
+
+if [ ! -f "/tmp/extra-pre-pull-images" ]; then
+    echo "ERROR: extra-pre-pull-images list missing"
+    exit 1
+fi
+if [ ! -f "/tmp/fetch-images.sh" ]; then
+    echo "ERROR: fetch-images.sh missing"
+    exit 1
+fi
+
+if grep -q "CentOS Stream 9" /etc/os-release; then
+  release="centos9"
+else
+  echo "ERROR: Could not recognize guest OS"
+  exit 1
+fi
+
+function pull_container_retry() {
+    retry=0
+    maxRetries=5
+    retryAfterSeconds=3
+    until [ ${retry} -ge ${maxRetries} ]; do
+        crictl pull "$@" && break
+        retry=$((${retry} + 1))
+        echo "Retrying ${FUNCNAME[0]} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
+        sleep ${retryAfterSeconds}
+    done
+
+    if [ ${retry} -ge ${maxRetries} ]; then
+        echo "${FUNCNAME[0]} Failed after ${maxRetries} attempts!"
+        exit 1
+    fi
+}
+
+export CRIO_VERSION=1.29
+cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}.repo
+[isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}]
+name=CRI-O v${CRIO_VERSION} (Stable) (rpm)
+type=rpm-md
+baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}
+gpgcheck=0
+enabled=1
+EOF
+
+dnf install -y cri-o
+
+systemctl enable --now crio
+
+cat << EOF > /etc/containers/registries.conf
+[registries.search]
+registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
+
+[registries.insecure]
+registries = ['registry:5000']
+
+[registries.block]
+registries = []
+EOF
+
+packages_version=$(getKubernetesClosestStableVersion)
+major_version=$(echo $packages_version | cut -d "." -f 2)
+# Add Kubernetes release repository.
+# use repodata from GCS bucket, since the release repo might not have it right after the release
+# we deduce the https path from the gcs path gs://kubernetes-release/release/${version}/rpm/x86_64/
+# see https://github.com/kubernetes/kubeadm/blob/main/docs/testing-pre-releases.md#availability-of-pre-compiled-release-artifacts
+cat <<EOF >/etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes Release
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.${major_version}/rpm
+enabled=1
+gpgcheck=0
+repo_gpgcheck=0
+EOF
+
+# Install Kubernetes CNI.
+dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
+    kubectl-${packages_version} \
+    kubeadm-${packages_version} \
+    kubelet-${packages_version} \
+    kubernetes-cni
+
+# In case the version is unstable the package manager recognizes only the closest stable version
+# But it's unsafe using older kubeadm version than kubernetes version according to:
+# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#kubeadm-s-skew-against-the-kubernetes-version
+# The reason we install kubeadm using dnf is for the dependencies packages.
+if [[ $version != $packages_version ]]; then
+   replaceKubeBinaries
+fi
+
+kubeadm config images pull --kubernetes-version ${version}
+
+kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
+mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
+
+if [[ ${slim} == false ]]; then
+    # Pre pull all images from the manifests
+    for image in $(/tmp/fetch-images.sh /tmp); do
+        pull_container_retry "${image}"
+    done
+
+    # Pre pull additional images from list
+    for image in $(cat "/tmp/extra-pre-pull-images"); do
+        pull_container_retry "${image}"
+    done
+fi
+
+mkdir -p /provision
+
 cni_manifest="/provision/cni.yaml"
+cni_diff="/tmp/cni.diff"
+cni_manifest_ipv6="/provision/cni_ipv6.yaml"
+cni_ipv6_diff="/tmp/cni_ipv6.diff"
+
+cp /tmp/cni.do-not-change.yaml $cni_manifest
+mv /tmp/cni.do-not-change.yaml $cni_manifest_ipv6
+patch $cni_manifest $cni_diff
+patch $cni_manifest_ipv6 $cni_ipv6_diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 
@@ -44,8 +184,6 @@ rm -f /etc/cni/net.d/*
 
 systemctl daemon-reload
 systemctl enable crio kubelet --now
-
-dnf install -y NetworkManager NetworkManager-ovs
 
 # configure additional settings for cni plugin
 cat <<EOF >/etc/NetworkManager/conf.d/001-calico.conf
@@ -225,8 +363,6 @@ cp -rf /tmp/cdi*.yaml /opt/
 mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests
 echo "tmpfs /var/provision/kubevirt.io/tests tmpfs rw,context=system_u:object_r:container_file_t:s0 0 1" >> /etc/fstab
-
-dnf install -y NetworkManager-config-server
 
 # Cleanup the existing NetworkManager profiles so the VM instances will come
 # up with the default profiles. (Base VM image includes non default settings)

--- a/cluster-provision/k8s/1.30/provision.sh
+++ b/cluster-provision/k8s/1.30/provision.sh
@@ -2,47 +2,6 @@
 
 set -ex
 
-function getKubernetesClosestStableVersion() {
-  kubernetes_version=$version
-  packages_version=$kubernetes_version
-  if [[ $kubernetes_version == *"alpha"* ]] || [[ $kubernetes_version == *"beta"* ]] || [[ $kubernetes_version == *"rc"* ]]; then
-    kubernetes_minor_version=$(echo $kubernetes_version | cut -d. -f2)
-    packages_major_version=$(echo $kubernetes_version | cut -d. -f1)
-    packages_minor_version=$((kubernetes_minor_version-1))
-    packages_version="$(curl --fail -L "https://storage.googleapis.com/kubernetes-release/release/stable-${packages_major_version}.${packages_minor_version}.txt" | sed 's/^v//')"
-  fi
-  echo $packages_version
-}
-
-function replaceKubeBinaries() {
-  dnf install -y which
-  rm -f $(which kubeadm kubelet)
-
-  BIN_DIR="/usr/bin"
-  RELEASE="v$version"
-  ARCH="amd64"
-
-  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubeadm -o ${BIN_DIR}/kubeadm
-  curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/kubelet -o ${BIN_DIR}/kubelet
-  chmod +x ${BIN_DIR}/kubeadm ${BIN_DIR}/kubelet
-}
-
-if [ ! -f "/tmp/extra-pre-pull-images" ]; then
-    echo "ERROR: extra-pre-pull-images list missing"
-    exit 1
-fi
-if [ ! -f "/tmp/fetch-images.sh" ]; then
-    echo "ERROR: fetch-images.sh missing"
-    exit 1
-fi
-
-if grep -q "CentOS Stream 9" /etc/os-release; then
-  release="centos9"
-else
-  echo "ERROR: Could not recognize guest OS"
-  exit 1
-fi
-
 KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
 mkdir -p $KUBEVIRTCI_SHARED_DIR
 export ISTIO_VERSION=1.15.0
@@ -54,23 +13,6 @@ export ISTIO_VERSION=${ISTIO_VERSION}
 export ISTIO_BIN_DIR="/opt/istio-${ISTIO_VERSION}/bin"
 EOF
 source $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
-
-function pull_container_retry() {
-    retry=0
-    maxRetries=5
-    retryAfterSeconds=3
-    until [ ${retry} -ge ${maxRetries} ]; do
-        crictl pull "$@" && break
-        retry=$((${retry} + 1))
-        echo "Retrying ${FUNCNAME[0]} [${retry}/${maxRetries}] in ${retryAfterSeconds}(s)"
-        sleep ${retryAfterSeconds}
-    done
-
-    if [ ${retry} -ge ${maxRetries} ]; then
-        echo "${FUNCNAME[0]} Failed after ${maxRetries} attempts!"
-        exit 1
-    fi
-}
 
 # Install modules of the initrd kernel
 dnf install -y "kernel-modules-$(uname -r)"
@@ -112,91 +54,12 @@ export PATH="$ISTIO_BIN_DIR:$PATH"
   chmod +x "$ISTIO_BIN_DIR/istioctl"
 )
 
-export CRIO_VERSION=1.29
-cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}.repo
-[isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}]
-name=CRI-O v${CRIO_VERSION} (Stable) (rpm)
-type=rpm-md
-baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}
-gpgcheck=0
-enabled=1
-EOF
-
-dnf install -y cri-o container-selinux
-
-systemctl enable --now crio
+dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
-
-cat << EOF > /etc/containers/registries.conf
-[registries.search]
-registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
-
-[registries.insecure]
-registries = ['registry:5000']
-
-[registries.block]
-registries = []
-EOF
-
-packages_version=$(getKubernetesClosestStableVersion)
-major_version=$(echo $packages_version | cut -d "." -f 2)
-# Add Kubernetes release repository.
-# use repodata from GCS bucket, since the release repo might not have it right after the release
-# we deduce the https path from the gcs path gs://kubernetes-release/release/${version}/rpm/x86_64/
-# see https://github.com/kubernetes/kubeadm/blob/main/docs/testing-pre-releases.md#availability-of-pre-compiled-release-artifacts
-cat <<EOF >/etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes Release
-baseurl=https://pkgs.k8s.io/core:/stable:/v1.${major_version}/rpm
-enabled=1
-gpgcheck=0
-repo_gpgcheck=0
-EOF
-
-# Install Kubernetes CNI.
-dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
-    kubectl-${packages_version} \
-    kubeadm-${packages_version} \
-    kubelet-${packages_version} \
-    kubernetes-cni
-
-# In case the version is unstable the package manager recognizes only the closest stable version
-# But it's unsafe using older kubeadm version than kubernetes version according to:
-# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#kubeadm-s-skew-against-the-kubernetes-version
-# The reason we install kubeadm using dnf is for the dependencies packages.
-if [[ $version != $packages_version ]]; then
-   replaceKubeBinaries
-fi
-
-kubeadm config images pull --kubernetes-version ${version}
 
 dnf install -y centos-release-nfv-openvswitch
 dnf install -y openvswitch2.16
 
-mkdir -p /provision
+dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 
-cni_manifest="/provision/cni.yaml"
-cni_diff="/tmp/cni.diff"
-cni_manifest_ipv6="/provision/cni_ipv6.yaml"
-cni_ipv6_diff="/tmp/cni_ipv6.diff"
-
-cp /tmp/cni.do-not-change.yaml $cni_manifest
-mv /tmp/cni.do-not-change.yaml $cni_manifest_ipv6
-patch $cni_manifest $cni_diff
-patch $cni_manifest_ipv6 $cni_ipv6_diff
-
-kubectl kustomize /tmp/prometheus/grafana > /tmp/grafana-deployment.yaml.tmp
-mv -f /tmp/grafana-deployment.yaml.tmp /tmp/prometheus/grafana/grafana-deployment.yaml
-
-if [[ ${slim} == false ]]; then
-    # Pre pull all images from the manifests
-    for image in $(/tmp/fetch-images.sh /tmp); do
-        pull_container_retry "${image}"
-    done
-
-    # Pre pull additional images from list
-    for image in $(cat "/tmp/extra-pre-pull-images"); do
-        pull_container_retry "${image}"
-    done
-fi

--- a/cluster-provision/k8s/base-image
+++ b/cluster-provision/k8s/base-image
@@ -1,0 +1,1 @@
+quay.io/kubevirtci/centos9:20240214

--- a/publish.sh
+++ b/publish.sh
@@ -75,7 +75,7 @@ function build_clusters() {
 function push_node_base_image() {
   TARGET_IMAGE="${TARGET_REPO}/centos9:${KUBEVIRTCI_TAG}"
   echo "INFO: push $TARGET_IMAGE"
-  skopeo copy "docker-daemon:${TARGET_REPO}/centos9-dev:latest" "docker://${TARGET_IMAGE}"
+  skopeo copy "docker-daemon:${TARGET_REPO}/centos9-base:latest" "docker://${TARGET_IMAGE}"
   echo ${TARGET_IMAGE} > cluster-provision/k8s/base-image
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR uses the existing phases (linux,k8s) in gocli to build and publish a CentOS Stream 9 base image that includes the majority of rpm dependencies required.

The kubevirtci node images will use this static base image to build from. 

This base image can be used to isolate the provisioning of cluster nodes from changes to Stream 9 kernels or packages. The base image will be updated every so often by a PR created via a periodic prowjob - The check-provision presubmit lanes will then verify this base-image bump. 

Issues have occurred recently where changes have been blocked because the kubevirtci nodes were constantly taking the latest from Stream 9 which was causing the check-provision lanes to fail[1]. These can be very difficult to troubleshoot as a large number of packages may have changed - moving the kubevirtci nodes to a static stream 9 base will help to narrow down the cause of these issues. 

[1] https://github.com/kubevirt/kubevirtci/issues/1133

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @ormergi 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
