### PR TITLE
centos,base: Follow up changes to tidy up some leftovers

### DIFF
--- a/cluster-provision/k8s/1.27/provision.sh
+++ b/cluster-provision/k8s/1.27/provision.sh
@@ -54,7 +54,7 @@ export PATH="$ISTIO_BIN_DIR:$PATH"
   chmod +x "$ISTIO_BIN_DIR/istioctl"
 )
 
-dnf install -y libseccomp-devel
+dnf install -y libseccomp-devel container-selinux
 
 
 dnf install -y centos-release-nfv-openvswitch

--- a/cluster-provision/k8s/1.28/provision.sh
+++ b/cluster-provision/k8s/1.28/provision.sh
@@ -54,16 +54,6 @@ export PATH="$ISTIO_BIN_DIR:$PATH"
   chmod +x "$ISTIO_BIN_DIR/istioctl"
 )
 
-export CRIO_VERSION=1.28
-cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}.repo
-[isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}]
-name=CRI-O v${CRIO_VERSION} (Stable) (rpm)
-type=rpm-md
-baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/isv_kubernetes_addons_cri-o_stable_v${CRIO_VERSION}
-gpgcheck=0
-enabled=1
-EOF
-
 dnf install -y container-selinux
 
 dnf install -y libseccomp-devel

--- a/cluster-provision/k8s/provision.sh
+++ b/cluster-provision/k8s/provision.sh
@@ -40,7 +40,7 @@ fi
 
 ../gocli/build/cli provision ${provision_dir} --phases ${PHASES} ${SLIM_MODE}
 
-if [[ $PHASES == $PHASES_DEFAULT ]] || [[ $CHECK_CLUSTER == true ]]; then
+if [[ $PHASES == *"k8s" ]] || [[ $CHECK_CLUSTER == true ]]; then
    if [[ $PHASES == "linux" ]]; then
      echo "skipping cluster check when running linux only phase"
      exit 0

--- a/cluster-provision/k8s/provision.sh
+++ b/cluster-provision/k8s/provision.sh
@@ -40,10 +40,9 @@ fi
 
 ../gocli/build/cli provision ${provision_dir} --phases ${PHASES} ${SLIM_MODE}
 
-if [[ $PHASES == *"k8s" ]] || [[ $CHECK_CLUSTER == true ]]; then
-   if [[ $PHASES == "linux" ]]; then
-     echo "skipping cluster check when running linux only phase"
-     exit 0
-   fi
-  ./check-cluster-up.sh ${provision_dir}
+if [[ $CHECK_CLUSTER != true ]] || [[ $PHASES == "linux" ]]; then
+  echo "skipping cluster check when running linux only phase"
+  exit 0
 fi
+
+./check-cluster-up.sh ${provision_dir}

--- a/publish.sh
+++ b/publish.sh
@@ -47,18 +47,10 @@ function build_gocli() {
   ${CRI_BIN} tag ${TARGET_REPO}/gocli ${TARGET_REPO}/gocli:${KUBEVIRTCI_TAG}
 }
 
-function build_centos9_base_image() {
-  (cd cluster-provision/centos9 && ./build.sh)
-}
-
 function build_centos9_base_image_with_deps() {
+  (cd cluster-provision/centos9 && ./build.sh)
   IMAGE_TO_BUILD="$(find cluster-provision/k8s/* -maxdepth 0 -type d -printf '%f\n' | head -1)"
   (cd cluster-provision/k8s/${IMAGE_TO_BUILD} && ../provision.sh)
-}
-
-function build_base_images() {
-    build_centos9_base_image
-    build_centos9_base_image_with_deps
 }
 
 function build_clusters() {
@@ -106,7 +98,7 @@ function push_gocli() {
 }
 
 function publish_node_base_image() {
-  build_base_images
+  build_centos9_base_image_with_deps
   push_node_base_image
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

[centos: preinstall container-selinux which is required for cri-o](https://github.com/kubevirt/kubevirtci/commit/09435209e88e3e804c578e5e74987a72179819bc)

[Remove duplicated addition of cri-o repo in k8s-1.28](https://github.com/kubevirt/kubevirtci/commit/9efc4b118ee83ed152b51bccbf4a036e978f0463)

[publish: Inline some of the base image functions](https://github.com/kubevirt/kubevirtci/commit/41082c2fb865b0f876899b5e35d858e578032d21)

[conformance: run conformance tests after k8s phase](https://github.com/kubevirt/kubevirtci/pull/1145/commits/e06f0f93238d95ddbe7eac03f941e790550e3cb2)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
