### PR TITLE
Bump alpine to 3.19

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
@@ -22,6 +22,7 @@ sed -Ei \
 step 'Enable services'
 rc-update add qemu-guest-agent default
 rc-update add cloud-init default
+rc-update add cloud-init-local default
 rc-update add cloud-config default
 rc-update add cloud-final default
 rc-update add sshd default

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
@@ -25,4 +25,5 @@ rc-update add cloud-init default
 rc-update add cloud-init-local default
 rc-update add cloud-config default
 rc-update add cloud-final default
+rc-update add networking default
 rc-update add sshd default

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -22,10 +22,10 @@ fi
 
 docker run --rm --platform=$PLATFORM -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
 ./alpine-make-vm-image \
-	--image-format qcow2 \
-	--image-size 200M \
-    --branch v3.16 \
-	--packages \"$(cat packages)\" \
-	--serial-console \
-	--script-chroot \
-	$1 -- configure.sh"
+    --image-format qcow2 \
+    --image-size 200M \
+    --branch v3.19 \
+    --packages \"$(cat packages)\" \
+    --serial-console \
+    --script-chroot \
+    $1 -- configure.sh"

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
@@ -1,5 +1,6 @@
 qemu-guest-agent
 cloud-init
+py3-netifaces
 e2fsprogs-extra
 util-linux
 iputils


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Turns out the cloud-init-local service is now vital for cloud-init to work on Alpine:
https://leo.leung.xyz/wiki/Cloud-init
https://gitlab.com/redhat/centos-stream/rpms/cloud-init/-/blob/020655f489ca26b5830de8423354a14ccd0552db/cloud-init.spec#L138
I've double checked cloud-init breaks when I remove it.
(`quay.io/akalenyu/alpine-cloud-init:3.19-broken` vs `quay.io/akalenyu/alpine-cloud-init:3.19`)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
