### PR TITLE
Remove NoSchedule taints for control-planes as well as masters

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -171,7 +171,7 @@ function _fix_node_labels() {
     master_nodes=$(_get_nodes | grep -i $MASTER_NODES_PATTERN | awk '{print $1}')
     for node in ${master_nodes[@]}; do
         # removing NoSchedule taint if is there
-        if _kubectl taint nodes $node node-role.kubernetes.io/master:NoSchedule-; then
+        if _kubectl taint nodes $node node-role.kubernetes.io/master:NoSchedule- || _kubectl taint nodes $node node-role.kubernetes.io/control-plane:NoSchedule-; then
             _kubectl label node $node kubevirt.io/schedulable=true
         fi
     done


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the `NoSchedule` taints for control-planes as well as masters.

**Special notes for your reviewer**:
This PR https://github.com/kubevirt/kubevirt/pull/11659 is requiring Kubevirt's infra components to run on CP nodes by default. However, the `pull-kubevirt-e2e-kind-sriov` lane is failing since its single CP node has a NoShedule taint:
```yaml
"taints": [
    {
        "key": "node-role.kubernetes.io/control-plane",
        "effect": "NoSchedule"
    }
]
```

After this PR this taint should not exist.

A PR to test these changes: https://github.com/kubevirt/kubevirt/pull/11730.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove NoSchedule taints for control-planes as well as masters
```
