### PR TITLE
add ability to deploy kwok when KUBEVIRT_DEPLOY_KWOK is set to true

### DIFF
--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -261,7 +261,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 			return err
 		}
 
-		err = _cmd(cli, nodeContainer(prefix, nodeName), "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i vagrant.key vagrant@192.168.66.101 'mkdir -p /tmp/ceph /tmp/cnao /tmp/nfs-csi /tmp/nodeports /tmp/prometheus /tmp/whereabouts'", "Create required manifest directories before copy")
+		err = _cmd(cli, nodeContainer(prefix, nodeName), "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i vagrant.key vagrant@192.168.66.101 'mkdir -p /tmp/ceph /tmp/cnao /tmp/nfs-csi /tmp/nodeports /tmp/prometheus /tmp/whereabouts /tmp/kwok'", "Create required manifest directories before copy")
 		if err != nil {
 			return err
 		}

--- a/cluster-provision/k8s/1.28/k8s_provision.sh
+++ b/cluster-provision/k8s/1.28/k8s_provision.sh
@@ -363,6 +363,9 @@ cp -rf /tmp/multus /opt/
 # copy cdi manifests
 cp -rf /tmp/cdi*.yaml /opt/
 
+# copy kwok manifests
+cp -rf /tmp/kwok /opt/
+
 # Create a properly labelled tmp directory for testing
 mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests

--- a/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/kustomization.yaml
+++ b/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac
+  - stage

--- a/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/rbac/kustomization.yaml
+++ b/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - role.yaml
+  - role-binding.yaml

--- a/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/rbac/role-binding.yaml
+++ b/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/rbac/role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kwok-with-vmi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kwok-with-vmi
+subjects:
+  - kind: ServiceAccount
+    name: kwok-controller
+    namespace: kube-system

--- a/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/rbac/role.yaml
+++ b/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/rbac/role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kwok-with-vmi
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachineinstances
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachineinstances/finalizers
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - impersonate

--- a/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/stage/kustomization.yaml
+++ b/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/stage/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vmi-delete.yaml
+  - vmi-ready.yaml

--- a/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/stage/vmi-delete.yaml
+++ b/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/stage/vmi-delete.yaml
@@ -1,0 +1,16 @@
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: vmi-delete
+spec:
+  resourceRef:
+    apiGroup: kubevirt.io/v1
+    kind: VirtualMachineInstance
+  selector:
+    matchExpressions:
+      - key: '.metadata.deletionTimestamp'
+        operator: 'Exists'
+  next:
+    finalizers:
+      empty: true
+    delete: true

--- a/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/stage/vmi-ready.yaml
+++ b/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/stage/vmi-ready.yaml
@@ -1,0 +1,47 @@
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: vmi-ready
+spec:
+  resourceRef:
+    apiGroup: kubevirt.io/v1
+    kind: VirtualMachineInstance
+  selector:
+    matchExpressions:
+      - key: '.metadata.deletionTimestamp'
+        operator: 'DoesNotExist'
+      - key: '.status.phase'
+        operator: 'NotIn'
+        values:
+          - 'Running'
+      - key: '.spec.nodeSelector.type'
+        operator: 'In'
+        values:
+          - 'kwok'
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      activePods:
+      {{ YAML .status.activePods 1 }}
+      conditions:
+      - type: Ready
+        status: "True"
+        lastTransitionTime: {{ $now }}
+      guestOSInfo: {}
+      launcherContainerImageVersion: {{ .status.launcherContainerImageVersion }}
+      memory:
+      {{ YAML .status.memory 1 }}
+      migrationTransport: Unix
+      nodeName: {{ .status.nodeName }}
+      phase: Running
+      phaseTransitionTimestamps:
+      {{ YAML .status.phaseTransitionTimestamps 0 }}
+      - phase: Running
+        phaseTransitionTimestamp: {{ $now }}
+      qosClass: {{ .status.qosClass }}
+      runtimeUser: {{ .status.runtimeUser }}
+      volumeStatus:
+      {{ YAML .status.volumeStatus 1 }}
+    statusSubresource: ""
+    statusPatchAs:
+      username: system:serviceaccount:kubevirt:kubevirt-controller

--- a/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/stage/vmi-ready.yaml
+++ b/cluster-provision/k8s/1.28/manifests/kwok/kubevirt/stage/vmi-ready.yaml
@@ -11,9 +11,9 @@ spec:
       - key: '.metadata.deletionTimestamp'
         operator: 'DoesNotExist'
       - key: '.status.phase'
-        operator: 'NotIn'
+        operator: 'In'
         values:
-          - 'Running'
+          - 'Scheduled'
       - key: '.spec.nodeSelector.type'
         operator: 'In'
         values:

--- a/cluster-provision/k8s/1.28/manifests/kwok/kwok.yaml
+++ b/cluster-provision/k8s/1.28/manifests/kwok/kwok.yaml
@@ -1,0 +1,2408 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: attaches.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Attach
+    listKind: AttachList
+    plural: attaches
+    singular: attach
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Attach provides attach configuration for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for attach
+            properties:
+              attaches:
+                description: Attaches is a list of attaches to configure.
+                items:
+                  description: AttachConfig holds information how to attach.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    logsFile:
+                      description: LogsFile is the file from which the attach starts
+                      type: string
+                  type: object
+                type: array
+            required:
+            - attaches
+            type: object
+          status:
+            description: Status holds status for attach
+            properties:
+              conditions:
+                description: Conditions holds conditions for attach
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterattaches.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterAttach
+    listKind: ClusterAttachList
+    plural: clusterattaches
+    singular: clusterattach
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterAttach provides cluster-wide logging configuration
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster attach.
+            properties:
+              attaches:
+                description: Attaches is a list of attach configurations.
+                items:
+                  description: AttachConfig holds information how to attach.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    logsFile:
+                      description: LogsFile is the file from which the attach starts
+                      type: string
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - attaches
+            type: object
+          status:
+            description: Status holds status for cluster attach
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster attach.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterexecs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterExec
+    listKind: ClusterExecList
+    plural: clusterexecs
+    singular: clusterexec
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterExec provides cluster-wide exec configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster exec.
+            properties:
+              execs:
+                description: Execs is a list of exec to configure.
+                items:
+                  description: ExecTarget holds information how to exec.
+                  properties:
+                    containers:
+                      description: |-
+                        Containers is a list of containers to exec.
+                        if not set, all containers will be execed.
+                      items:
+                        type: string
+                      type: array
+                    local:
+                      description: Local holds information how to exec to a local
+                        target.
+                      properties:
+                        envs:
+                          description: Envs is a list of environment variables to
+                            exec with.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable.
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value of the environment variable.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        securityContext:
+                          description: SecurityContext is the user context to exec.
+                          properties:
+                            runAsGroup:
+                              description: RunAsGroup is the existing gid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                            runAsUser:
+                              description: RunAsUser is the existing uid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                          type: object
+                        workDir:
+                          description: WorkDir is the working directory to exec with.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - execs
+            type: object
+          status:
+            description: Status holds status for cluster exec
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster exec.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterlogs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterLogs
+    listKind: ClusterLogsList
+    plural: clusterlogs
+    singular: clusterlogs
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterLogs provides cluster-wide logging configuration
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster logs.
+            properties:
+              logs:
+                description: Forwards is a list of log configurations.
+                items:
+                  description: Log holds information how to forward logs.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    follow:
+                      description: Follow up if true
+                      type: boolean
+                    logsFile:
+                      description: LogsFile is the file from which the log forward
+                        starts
+                      type: string
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - logs
+            type: object
+          status:
+            description: Status holds status for cluster logs
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster logs.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterportforwards.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterPortForward
+    listKind: ClusterPortForwardList
+    plural: clusterportforwards
+    singular: clusterportforward
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPortForward provides cluster-wide port forward configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster port forward.
+            properties:
+              forwards:
+                description: Forwards is a list of forwards to configure.
+                items:
+                  description: Forward holds information how to forward based on ports.
+                  properties:
+                    command:
+                      description: |-
+                        Command is the command to run to forward with stdin/stdout.
+                        if set, Target will be ignored.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: |-
+                        Ports is a list of ports to forward.
+                        if not set, all ports will be forwarded.
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                    target:
+                      description: Target is the target to forward to.
+                      properties:
+                        address:
+                          description: Address is the address to forward to.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Port is the port to forward to.
+                          format: int32
+                          maximum: 65535
+                          minimum: 0
+                          type: integer
+                      required:
+                      - address
+                      - port
+                      type: object
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - forwards
+            type: object
+          status:
+            description: Status holds status for cluster port forward
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster port forward.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterresourceusages.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterResourceUsage
+    listKind: ClusterResourceUsageList
+    plural: clusterresourceusages
+    singular: clusterresourceusage
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceUsage provides cluster-wide resource usage.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster resource usage.
+            properties:
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              usages:
+                description: Usages is a list of resource usage for the pod.
+                items:
+                  description: ResourceUsageContainer holds spec for resource usage
+                    container.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    usage:
+                      additionalProperties:
+                        description: ResourceUsageValue holds value for resource usage.
+                        properties:
+                          expression:
+                            description: Expression is the expression for resource
+                              usage.
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Value is the value for resource usage.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      description: Usage is a list of resource usage for the container.
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: Status holds status for cluster resource usage
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster resource usage
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: execs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Exec
+    listKind: ExecList
+    plural: execs
+    singular: exec
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Exec provides exec configuration for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for exec
+            properties:
+              execs:
+                description: Execs is a list of execs to configure.
+                items:
+                  description: ExecTarget holds information how to exec.
+                  properties:
+                    containers:
+                      description: |-
+                        Containers is a list of containers to exec.
+                        if not set, all containers will be execed.
+                      items:
+                        type: string
+                      type: array
+                    local:
+                      description: Local holds information how to exec to a local
+                        target.
+                      properties:
+                        envs:
+                          description: Envs is a list of environment variables to
+                            exec with.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable.
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value of the environment variable.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        securityContext:
+                          description: SecurityContext is the user context to exec.
+                          properties:
+                            runAsGroup:
+                              description: RunAsGroup is the existing gid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                            runAsUser:
+                              description: RunAsUser is the existing uid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                          type: object
+                        workDir:
+                          description: WorkDir is the working directory to exec with.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            required:
+            - execs
+            type: object
+          status:
+            description: Status holds status for exec
+            properties:
+              conditions:
+                description: Conditions holds conditions for exec
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: logs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Logs
+    listKind: LogsList
+    plural: logs
+    singular: logs
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Logs provides logging configuration for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for logs
+            properties:
+              logs:
+                description: Logs is a list of logs to configure.
+                items:
+                  description: Log holds information how to forward logs.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    follow:
+                      description: Follow up if true
+                      type: boolean
+                    logsFile:
+                      description: LogsFile is the file from which the log forward
+                        starts
+                      type: string
+                  type: object
+                type: array
+            required:
+            - logs
+            type: object
+          status:
+            description: Status holds status for logs
+            properties:
+              conditions:
+                description: Conditions holds conditions for logs
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: metrics.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Metric
+    listKind: MetricList
+    plural: metrics
+    singular: metric
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Metric provides metrics configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for metrics.
+            properties:
+              metrics:
+                description: Metrics is a list of metric configurations.
+                items:
+                  description: MetricConfig provides metric configuration to a single
+                    metric
+                  properties:
+                    buckets:
+                      description: Buckets is a list of buckets for a histogram metric.
+                      items:
+                        description: MetricBucket is a single bucket for a metric.
+                        properties:
+                          hidden:
+                            description: |-
+                              Hidden is means that this bucket not shown in the metric.
+                              but value will be calculated and cumulative into the next bucket.
+                            type: boolean
+                          le:
+                            description: Le is less-than or equal.
+                            minimum: 0
+                            type: number
+                          value:
+                            description: Value is a CEL expression.
+                            type: string
+                        required:
+                        - le
+                        - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - le
+                      x-kubernetes-list-type: map
+                    dimension:
+                      description: Dimension is a dimension of the metric.
+                      type: string
+                    help:
+                      description: Help provides information about this metric.
+                      type: string
+                    kind:
+                      description: Kind is kind of metric
+                      enum:
+                      - counter
+                      - gauge
+                      - histogram
+                      type: string
+                    labels:
+                      description: Labels are metric labels.
+                      items:
+                        description: MetricLabel holds label name and the value of
+                          the label.
+                        properties:
+                          name:
+                            description: Name is a label name.
+                            minLength: 1
+                            type: string
+                          value:
+                            description: Value is a CEL expression.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the fully-qualified name of the metric.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value is a CEL expression.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              path:
+                description: Path is a restful service path.
+                minLength: 1
+                type: string
+            required:
+            - metrics
+            - path
+            type: object
+          status:
+            description: Status holds status for metrics
+            properties:
+              conditions:
+                description: Conditions holds conditions for metrics.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: portforwards.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: PortForward
+    listKind: PortForwardList
+    plural: portforwards
+    singular: portforward
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PortForward provides port forward configuration for a single
+          pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for port forward.
+            properties:
+              forwards:
+                description: Forwards is a list of forwards to configure.
+                items:
+                  description: Forward holds information how to forward based on ports.
+                  properties:
+                    command:
+                      description: |-
+                        Command is the command to run to forward with stdin/stdout.
+                        if set, Target will be ignored.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: |-
+                        Ports is a list of ports to forward.
+                        if not set, all ports will be forwarded.
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                    target:
+                      description: Target is the target to forward to.
+                      properties:
+                        address:
+                          description: Address is the address to forward to.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Port is the port to forward to.
+                          format: int32
+                          maximum: 65535
+                          minimum: 0
+                          type: integer
+                      required:
+                      - address
+                      - port
+                      type: object
+                  type: object
+                type: array
+            required:
+            - forwards
+            type: object
+          status:
+            description: Status holds status for port forward
+            properties:
+              conditions:
+                description: Conditions holds conditions for port forward
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: resourceusages.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ResourceUsage
+    listKind: ResourceUsageList
+    plural: resourceusages
+    singular: resourceusage
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceUsage provides resource usage for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for resource usage.
+            properties:
+              usages:
+                description: Usages is a list of resource usage for the pod.
+                items:
+                  description: ResourceUsageContainer holds spec for resource usage
+                    container.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    usage:
+                      additionalProperties:
+                        description: ResourceUsageValue holds value for resource usage.
+                        properties:
+                          expression:
+                            description: Expression is the expression for resource
+                              usage.
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Value is the value for resource usage.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      description: Usage is a list of resource usage for the container.
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: Status holds status for resource usage
+            properties:
+              conditions:
+                description: Conditions holds conditions for resource usage
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: stages.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Stage
+    listKind: StageList
+    plural: stages
+    singular: stage
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Stage is an API that describes the staged change of a resource
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds information about the request being evaluated.
+            properties:
+              delay:
+                description: Delay means there is a delay in this stage.
+                properties:
+                  durationFrom:
+                    description: |-
+                      DurationFrom is the expression used to get the value.
+                      If it is a time.Time type, getting the value will be minus time.Now() to get DurationMilliseconds
+                      If it is a string type, the value get will be parsed by time.ParseDuration.
+                    properties:
+                      expressionFrom:
+                        description: ExpressionFrom is the expression used to get
+                          the value.
+                        type: string
+                    type: object
+                  durationMilliseconds:
+                    description: |-
+                      DurationMilliseconds indicates the stage delay time.
+                      If JitterDurationMilliseconds is less than DurationMilliseconds, then JitterDurationMilliseconds is used.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  jitterDurationFrom:
+                    description: |-
+                      JitterDurationFrom is the expression used to get the value.
+                      If it is a time.Time type, getting the value will be minus time.Now() to get JitterDurationMilliseconds
+                      If it is a string type, the value get will be parsed by time.ParseDuration.
+                    properties:
+                      expressionFrom:
+                        description: ExpressionFrom is the expression used to get
+                          the value.
+                        type: string
+                    type: object
+                  jitterDurationMilliseconds:
+                    description: |-
+                      JitterDurationMilliseconds is the duration plus an additional amount chosen uniformly
+                      at random from the interval between DurationMilliseconds and JitterDurationMilliseconds.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                type: object
+              immediateNextStage:
+                description: ImmediateNextStage means that the next stage of matching
+                  is performed immediately, without waiting for the Apiserver to push.
+                type: boolean
+              next:
+                description: Next indicates that this stage will be moved to.
+                properties:
+                  delete:
+                    description: Delete means that the resource will be deleted if
+                      true.
+                    type: boolean
+                  event:
+                    description: Event means that an event will be sent.
+                    properties:
+                      message:
+                        description: Message is a human-readable description of the
+                          status of this operation.
+                        type: string
+                      reason:
+                        description: Reason is why the action was taken. It is human-readable.
+                        type: string
+                      type:
+                        description: Type is the type of this event (Normal, Warning),
+                          It is machine-readable.
+                        type: string
+                    type: object
+                  finalizers:
+                    description: Finalizers means that finalizers will be modified.
+                    properties:
+                      add:
+                        description: Add means that the Finalizers will be added to
+                          the resource.
+                        items:
+                          description: FinalizerItem  describes the one of the finalizers.
+                          properties:
+                            value:
+                              description: Value is the value of the finalizer.
+                              type: string
+                          type: object
+                        type: array
+                      empty:
+                        description: Empty means that the Finalizers for that resource
+                          will be emptied.
+                        type: boolean
+                      remove:
+                        description: Remove means that the Finalizers will be removed
+                          from the resource.
+                        items:
+                          description: FinalizerItem  describes the one of the finalizers.
+                          properties:
+                            value:
+                              description: Value is the value of the finalizer.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  statusPatchAs:
+                    description: |-
+                      StatusPatchAs indicates the impersonating configuration for client when patching status.
+                      In most cases this will be empty, in which case the default client service account will be used.
+                      When this is not empty, a corresponding rbac change is required to grant `impersonate` privilege.
+                      The support for this field is not available in Pod and Node resources.
+                    properties:
+                      username:
+                        description: Username the target username for the client to
+                          impersonate
+                        type: string
+                    required:
+                    - username
+                    type: object
+                  statusSubresource:
+                    default: status
+                    description: |-
+                      StatusSubresource indicates the name of the subresource that will be patched. The support for
+                      this field is not available in Pod and Node resources.
+                    type: string
+                  statusTemplate:
+                    description: StatusTemplate indicates the template for modifying
+                      the status of the resource in the next.
+                    type: string
+                type: object
+              resourceRef:
+                description: ResourceRef specifies the Kind and version of the resource.
+                properties:
+                  apiGroup:
+                    default: v1
+                    description: APIGroup of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    type: string
+                required:
+                - kind
+                type: object
+              selector:
+                description: Selector specifies the stags will be applied to the selected
+                  resource.
+                properties:
+                  matchAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      MatchAnnotations is a map of {key,value} pairs. A single {key,value} in the matchAnnotations
+                      map is equivalent to an element of matchExpressions, whose key field is ".metadata.annotations[key]", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                  matchExpressions:
+                    description: MatchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        SelectorRequirement is a resource selector requirement is a selector that contains values, a key,
+                        and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: The name of the scope that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: Represents a scope's relationship to a set
+                            of values.
+                          type: string
+                        values:
+                          description: |-
+                            An array of string values.
+                            If the operator is In, NotIn, Intersection or NotIntersection, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values array must be empty.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is ".metadata.labels[key]", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              weight:
+                default: 0
+                description: |-
+                  Weight means when multiple stages share the same ResourceRef and Selector,
+                  a random stage will be matched as the next stage based on the weight.
+                minimum: 0
+                type: integer
+            required:
+            - next
+            - resourceRef
+            type: object
+          status:
+            description: Status holds status for the Stage
+            properties:
+              conditions:
+                description: Conditions holds conditions for the Stage.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - attaches
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - attaches/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterattaches
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterattaches/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterexecs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterexecs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterlogs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterlogs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterportforwards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterportforwards/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterresourceusages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterresourceusages/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - execs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - execs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - logs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - logs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - metrics
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - metrics/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - portforwards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - portforwards/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - resourceusages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - resourceusages/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - stages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - stages/status
+  verbs:
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kwok-controller
+subjects:
+- kind: ServiceAccount
+  name: kwok-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+  namespace: kube-system
+spec:
+  ports:
+  - name: http
+    port: 10247
+    protocol: TCP
+    targetPort: 10247
+  selector:
+    app: kwok-controller
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kwok-controller
+  template:
+    metadata:
+      labels:
+        app: kwok-controller
+    spec:
+      containers:
+      - args:
+        - --manage-all-nodes=false
+        - --manage-nodes-with-annotation-selector=kwok.x-k8s.io/node=fake
+        - --manage-nodes-with-label-selector=
+        - --manage-single-node=
+        - --disregard-status-with-annotation-selector=kwok.x-k8s.io/status=custom
+        - --disregard-status-with-label-selector=
+        - --node-ip=$(POD_IP)
+        - --node-port=10247
+        - --cidr=10.0.0.1/24
+        - --node-lease-duration-seconds=40
+        - --enable-crds=Stage
+        - --enable-crds=Metric
+        - --enable-crds=Attach
+        - --enable-crds=ClusterAttach
+        - --enable-crds=Exec
+        - --enable-crds=ClusterExec
+        - --enable-crds=Logs
+        - --enable-crds=ClusterLogs
+        - --enable-crds=PortForward
+        - --enable-crds=ClusterPortForward
+        - --enable-crds=ResourceUsage
+        - --enable-crds=ClusterResourceUsage
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: registry.k8s.io/kwok/kwok:v0.5.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 10247
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 10
+        name: kwok-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: 10247
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 20
+          timeoutSeconds: 2
+        startupProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10247
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          timeoutSeconds: 2
+      restartPolicy: Always
+      serviceAccountName: kwok-controller

--- a/cluster-provision/k8s/1.28/manifests/kwok/stage-fast.yaml
+++ b/cluster-provision/k8s/1.28/manifests/kwok/stage-fast.yaml
@@ -1,0 +1,255 @@
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: node-heartbeat-with-lease
+spec:
+  delay:
+    durationMilliseconds: 600000
+    jitterDurationMilliseconds: 610000
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      {{ $lastTransitionTime := or .metadata.creationTimestamp $now }}
+      conditions:
+      {{ range NodeConditions }}
+      - lastHeartbeatTime: {{ $now | Quote }}
+        lastTransitionTime: {{ $lastTransitionTime | Quote }}
+        message: {{ .message | Quote }}
+        reason: {{ .reason | Quote }}
+        status: {{ .status | Quote }}
+        type: {{ .type | Quote }}
+      {{ end }}
+
+      addresses:
+      {{ with .status.addresses }}
+      {{ YAML . 1 }}
+      {{ else }}
+      {{ with NodeIP }}
+      - address: {{ . | Quote }}
+        type: InternalIP
+      {{ end }}
+      {{ with NodeName }}
+      - address: {{ . | Quote }}
+        type: Hostname
+      {{ end }}
+      {{ end }}
+
+      {{ with NodePort }}
+      daemonEndpoints:
+        kubeletEndpoint:
+          Port: {{ . }}
+      {{ end }}
+  resourceRef:
+    apiGroup: v1
+    kind: Node
+  selector:
+    matchExpressions:
+    - key: .status.phase
+      operator: In
+      values:
+      - Running
+    - key: .status.conditions.[] | select( .type == "Ready" ) | .status
+      operator: In
+      values:
+      - "True"
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: node-initialize
+spec:
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      {{ $lastTransitionTime := or .metadata.creationTimestamp $now }}
+      conditions:
+      {{ range NodeConditions }}
+      - lastHeartbeatTime: {{ $now | Quote }}
+        lastTransitionTime: {{ $lastTransitionTime | Quote }}
+        message: {{ .message | Quote }}
+        reason: {{ .reason | Quote }}
+        status: {{ .status | Quote }}
+        type: {{ .type  | Quote}}
+      {{ end }}
+
+      addresses:
+      {{ with .status.addresses }}
+      {{ YAML . 1 }}
+      {{ else }}
+      {{ with NodeIP }}
+      - address: {{ . | Quote }}
+        type: InternalIP
+      {{ end }}
+      {{ with NodeName }}
+      - address: {{ . | Quote }}
+        type: Hostname
+      {{ end }}
+      {{ end }}
+
+      {{ with NodePort }}
+      daemonEndpoints:
+        kubeletEndpoint:
+          Port: {{ . }}
+      {{ end }}
+
+      allocatable:
+      {{ with .status.allocatable }}
+      {{ YAML . 1 }}
+      {{ else }}
+        cpu: 1k
+        memory: 1Ti
+        pods: 1M
+      {{ end }}
+      capacity:
+      {{ with .status.capacity }}
+      {{ YAML . 1 }}
+      {{ else }}
+        cpu: 1k
+        memory: 1Ti
+        pods: 1M
+      {{ end }}
+      {{ with .status.nodeInfo }}
+      nodeInfo:
+        architecture: {{ with .architecture }} {{ . }} {{ else }} "amd64" {{ end }}
+        bootID: {{ with .bootID }} {{ . }} {{ else }} "" {{ end }}
+        containerRuntimeVersion: {{ with .containerRuntimeVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        kernelVersion: {{ with .kernelVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        kubeProxyVersion: {{ with .kubeProxyVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        kubeletVersion: {{ with .kubeletVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        machineID: {{ with .machineID }} {{ . }} {{ else }} "" {{ end }}
+        operatingSystem: {{ with .operatingSystem }} {{ . }} {{ else }} "linux" {{ end }}
+        osImage: {{ with .osImage }} {{ . }} {{ else }} "" {{ end }}
+        systemUUID: {{ with .systemUUID }} {{ . }} {{ else }} "" {{ end }}
+      {{ end }}
+      phase: Running
+  resourceRef:
+    apiGroup: v1
+    kind: Node
+  selector:
+    matchExpressions:
+    - key: .status.conditions.[] | select( .type == "Ready" ) | .status
+      operator: NotIn
+      values:
+      - "True"
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-complete
+spec:
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      {{ $root := . }}
+      containerStatuses:
+      {{ range $index, $item := .spec.containers }}
+      {{ $origin := index $root.status.containerStatuses $index }}
+      - image: {{ $item.image | Quote }}
+        name: {{ $item.name | Quote }}
+        ready: false
+        restartCount: 0
+        started: false
+        state:
+          terminated:
+            exitCode: 0
+            finishedAt: {{ $now | Quote }}
+            reason: Completed
+            startedAt: {{ $now | Quote }}
+      {{ end }}
+      phase: Succeeded
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: .metadata.deletionTimestamp
+      operator: DoesNotExist
+    - key: .status.phase
+      operator: In
+      values:
+      - Running
+    - key: .metadata.ownerReferences.[].kind
+      operator: In
+      values:
+      - Job
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-delete
+spec:
+  next:
+    delete: true
+    finalizers:
+      empty: true
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: .metadata.deletionTimestamp
+      operator: Exists
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-ready
+spec:
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+
+      conditions:
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: Initialized
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: Ready
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: ContainersReady
+      {{ range .spec.readinessGates }}
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: {{ .conditionType | Quote }}
+      {{ end }}
+
+      containerStatuses:
+      {{ range .spec.containers }}
+      - image: {{ .image | Quote }}
+        name: {{ .name | Quote }}
+        ready: true
+        restartCount: 0
+        state:
+          running:
+            startedAt: {{ $now | Quote }}
+      {{ end }}
+
+      initContainerStatuses:
+      {{ range .spec.initContainers }}
+      - image: {{ .image | Quote }}
+        name: {{ .name | Quote }}
+        ready: true
+        restartCount: 0
+        state:
+          terminated:
+            exitCode: 0
+            finishedAt: {{ $now | Quote }}
+            reason: Completed
+            startedAt: {{ $now | Quote }}
+      {{ end }}
+
+      hostIP: {{ NodeIPWith .spec.nodeName | Quote }}
+      podIP: {{ PodIPWith .spec.nodeName ( or .spec.hostNetwork false ) ( or .metadata.uid "" ) ( or .metadata.name "" ) ( or .metadata.namespace "" ) | Quote }}
+      phase: Running
+      startTime: {{ $now | Quote }}
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: .metadata.deletionTimestamp
+      operator: DoesNotExist
+    - key: .status.podIP
+      operator: DoesNotExist

--- a/cluster-provision/k8s/1.29/k8s_provision.sh
+++ b/cluster-provision/k8s/1.29/k8s_provision.sh
@@ -352,6 +352,9 @@ cp -rf /tmp/multus /opt/
 # copy cdi manifests
 cp -rf /tmp/cdi*.yaml /opt/
 
+# copy kwok manifests
+cp -rf /tmp/kwok /opt/
+
 # Create a properly labelled tmp directory for testing
 mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests

--- a/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/kustomization.yaml
+++ b/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - rbac
+  - stage

--- a/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/rbac/kustomization.yaml
+++ b/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - role.yaml
+  - role-binding.yaml

--- a/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/rbac/role-binding.yaml
+++ b/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/rbac/role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kwok-with-vmi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kwok-with-vmi
+subjects:
+  - kind: ServiceAccount
+    name: kwok-controller
+    namespace: kube-system

--- a/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/rbac/role.yaml
+++ b/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/rbac/role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kwok-with-vmi
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachineinstances
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachineinstances/finalizers
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - impersonate

--- a/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/stage/kustomization.yaml
+++ b/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/stage/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vmi-delete.yaml
+  - vmi-ready.yaml

--- a/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/stage/vmi-delete.yaml
+++ b/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/stage/vmi-delete.yaml
@@ -1,0 +1,16 @@
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: vmi-delete
+spec:
+  resourceRef:
+    apiGroup: kubevirt.io/v1
+    kind: VirtualMachineInstance
+  selector:
+    matchExpressions:
+      - key: '.metadata.deletionTimestamp'
+        operator: 'Exists'
+  next:
+    finalizers:
+      empty: true
+    delete: true

--- a/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/stage/vmi-ready.yaml
+++ b/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/stage/vmi-ready.yaml
@@ -1,0 +1,47 @@
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: vmi-ready
+spec:
+  resourceRef:
+    apiGroup: kubevirt.io/v1
+    kind: VirtualMachineInstance
+  selector:
+    matchExpressions:
+      - key: '.metadata.deletionTimestamp'
+        operator: 'DoesNotExist'
+      - key: '.status.phase'
+        operator: 'NotIn'
+        values:
+          - 'Running'
+      - key: '.spec.nodeSelector.type'
+        operator: 'In'
+        values:
+          - 'kwok'
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      activePods:
+      {{ YAML .status.activePods 1 }}
+      conditions:
+      - type: Ready
+        status: "True"
+        lastTransitionTime: {{ $now }}
+      guestOSInfo: {}
+      launcherContainerImageVersion: {{ .status.launcherContainerImageVersion }}
+      memory:
+      {{ YAML .status.memory 1 }}
+      migrationTransport: Unix
+      nodeName: {{ .status.nodeName }}
+      phase: Running
+      phaseTransitionTimestamps:
+      {{ YAML .status.phaseTransitionTimestamps 0 }}
+      - phase: Running
+        phaseTransitionTimestamp: {{ $now }}
+      qosClass: {{ .status.qosClass }}
+      runtimeUser: {{ .status.runtimeUser }}
+      volumeStatus:
+      {{ YAML .status.volumeStatus 1 }}
+    statusSubresource: ""
+    statusPatchAs:
+      username: system:serviceaccount:kubevirt:kubevirt-controller

--- a/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/stage/vmi-ready.yaml
+++ b/cluster-provision/k8s/1.29/manifests/kwok/kubevirt/stage/vmi-ready.yaml
@@ -11,9 +11,9 @@ spec:
       - key: '.metadata.deletionTimestamp'
         operator: 'DoesNotExist'
       - key: '.status.phase'
-        operator: 'NotIn'
+        operator: 'In'
         values:
-          - 'Running'
+          - 'Scheduled'
       - key: '.spec.nodeSelector.type'
         operator: 'In'
         values:

--- a/cluster-provision/k8s/1.29/manifests/kwok/kwok.yaml
+++ b/cluster-provision/k8s/1.29/manifests/kwok/kwok.yaml
@@ -1,0 +1,2408 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: attaches.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Attach
+    listKind: AttachList
+    plural: attaches
+    singular: attach
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Attach provides attach configuration for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for attach
+            properties:
+              attaches:
+                description: Attaches is a list of attaches to configure.
+                items:
+                  description: AttachConfig holds information how to attach.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    logsFile:
+                      description: LogsFile is the file from which the attach starts
+                      type: string
+                  type: object
+                type: array
+            required:
+            - attaches
+            type: object
+          status:
+            description: Status holds status for attach
+            properties:
+              conditions:
+                description: Conditions holds conditions for attach
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterattaches.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterAttach
+    listKind: ClusterAttachList
+    plural: clusterattaches
+    singular: clusterattach
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterAttach provides cluster-wide logging configuration
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster attach.
+            properties:
+              attaches:
+                description: Attaches is a list of attach configurations.
+                items:
+                  description: AttachConfig holds information how to attach.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    logsFile:
+                      description: LogsFile is the file from which the attach starts
+                      type: string
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - attaches
+            type: object
+          status:
+            description: Status holds status for cluster attach
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster attach.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterexecs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterExec
+    listKind: ClusterExecList
+    plural: clusterexecs
+    singular: clusterexec
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterExec provides cluster-wide exec configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster exec.
+            properties:
+              execs:
+                description: Execs is a list of exec to configure.
+                items:
+                  description: ExecTarget holds information how to exec.
+                  properties:
+                    containers:
+                      description: |-
+                        Containers is a list of containers to exec.
+                        if not set, all containers will be execed.
+                      items:
+                        type: string
+                      type: array
+                    local:
+                      description: Local holds information how to exec to a local
+                        target.
+                      properties:
+                        envs:
+                          description: Envs is a list of environment variables to
+                            exec with.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable.
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value of the environment variable.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        securityContext:
+                          description: SecurityContext is the user context to exec.
+                          properties:
+                            runAsGroup:
+                              description: RunAsGroup is the existing gid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                            runAsUser:
+                              description: RunAsUser is the existing uid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                          type: object
+                        workDir:
+                          description: WorkDir is the working directory to exec with.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - execs
+            type: object
+          status:
+            description: Status holds status for cluster exec
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster exec.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterlogs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterLogs
+    listKind: ClusterLogsList
+    plural: clusterlogs
+    singular: clusterlogs
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterLogs provides cluster-wide logging configuration
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster logs.
+            properties:
+              logs:
+                description: Forwards is a list of log configurations.
+                items:
+                  description: Log holds information how to forward logs.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    follow:
+                      description: Follow up if true
+                      type: boolean
+                    logsFile:
+                      description: LogsFile is the file from which the log forward
+                        starts
+                      type: string
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - logs
+            type: object
+          status:
+            description: Status holds status for cluster logs
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster logs.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterportforwards.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterPortForward
+    listKind: ClusterPortForwardList
+    plural: clusterportforwards
+    singular: clusterportforward
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPortForward provides cluster-wide port forward configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster port forward.
+            properties:
+              forwards:
+                description: Forwards is a list of forwards to configure.
+                items:
+                  description: Forward holds information how to forward based on ports.
+                  properties:
+                    command:
+                      description: |-
+                        Command is the command to run to forward with stdin/stdout.
+                        if set, Target will be ignored.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: |-
+                        Ports is a list of ports to forward.
+                        if not set, all ports will be forwarded.
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                    target:
+                      description: Target is the target to forward to.
+                      properties:
+                        address:
+                          description: Address is the address to forward to.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Port is the port to forward to.
+                          format: int32
+                          maximum: 65535
+                          minimum: 0
+                          type: integer
+                      required:
+                      - address
+                      - port
+                      type: object
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - forwards
+            type: object
+          status:
+            description: Status holds status for cluster port forward
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster port forward.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterresourceusages.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterResourceUsage
+    listKind: ClusterResourceUsageList
+    plural: clusterresourceusages
+    singular: clusterresourceusage
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceUsage provides cluster-wide resource usage.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster resource usage.
+            properties:
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              usages:
+                description: Usages is a list of resource usage for the pod.
+                items:
+                  description: ResourceUsageContainer holds spec for resource usage
+                    container.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    usage:
+                      additionalProperties:
+                        description: ResourceUsageValue holds value for resource usage.
+                        properties:
+                          expression:
+                            description: Expression is the expression for resource
+                              usage.
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Value is the value for resource usage.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      description: Usage is a list of resource usage for the container.
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: Status holds status for cluster resource usage
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster resource usage
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: execs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Exec
+    listKind: ExecList
+    plural: execs
+    singular: exec
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Exec provides exec configuration for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for exec
+            properties:
+              execs:
+                description: Execs is a list of execs to configure.
+                items:
+                  description: ExecTarget holds information how to exec.
+                  properties:
+                    containers:
+                      description: |-
+                        Containers is a list of containers to exec.
+                        if not set, all containers will be execed.
+                      items:
+                        type: string
+                      type: array
+                    local:
+                      description: Local holds information how to exec to a local
+                        target.
+                      properties:
+                        envs:
+                          description: Envs is a list of environment variables to
+                            exec with.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable.
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value of the environment variable.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        securityContext:
+                          description: SecurityContext is the user context to exec.
+                          properties:
+                            runAsGroup:
+                              description: RunAsGroup is the existing gid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                            runAsUser:
+                              description: RunAsUser is the existing uid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                          type: object
+                        workDir:
+                          description: WorkDir is the working directory to exec with.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            required:
+            - execs
+            type: object
+          status:
+            description: Status holds status for exec
+            properties:
+              conditions:
+                description: Conditions holds conditions for exec
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: logs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Logs
+    listKind: LogsList
+    plural: logs
+    singular: logs
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Logs provides logging configuration for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for logs
+            properties:
+              logs:
+                description: Logs is a list of logs to configure.
+                items:
+                  description: Log holds information how to forward logs.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    follow:
+                      description: Follow up if true
+                      type: boolean
+                    logsFile:
+                      description: LogsFile is the file from which the log forward
+                        starts
+                      type: string
+                  type: object
+                type: array
+            required:
+            - logs
+            type: object
+          status:
+            description: Status holds status for logs
+            properties:
+              conditions:
+                description: Conditions holds conditions for logs
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: metrics.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Metric
+    listKind: MetricList
+    plural: metrics
+    singular: metric
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Metric provides metrics configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for metrics.
+            properties:
+              metrics:
+                description: Metrics is a list of metric configurations.
+                items:
+                  description: MetricConfig provides metric configuration to a single
+                    metric
+                  properties:
+                    buckets:
+                      description: Buckets is a list of buckets for a histogram metric.
+                      items:
+                        description: MetricBucket is a single bucket for a metric.
+                        properties:
+                          hidden:
+                            description: |-
+                              Hidden is means that this bucket not shown in the metric.
+                              but value will be calculated and cumulative into the next bucket.
+                            type: boolean
+                          le:
+                            description: Le is less-than or equal.
+                            minimum: 0
+                            type: number
+                          value:
+                            description: Value is a CEL expression.
+                            type: string
+                        required:
+                        - le
+                        - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - le
+                      x-kubernetes-list-type: map
+                    dimension:
+                      description: Dimension is a dimension of the metric.
+                      type: string
+                    help:
+                      description: Help provides information about this metric.
+                      type: string
+                    kind:
+                      description: Kind is kind of metric
+                      enum:
+                      - counter
+                      - gauge
+                      - histogram
+                      type: string
+                    labels:
+                      description: Labels are metric labels.
+                      items:
+                        description: MetricLabel holds label name and the value of
+                          the label.
+                        properties:
+                          name:
+                            description: Name is a label name.
+                            minLength: 1
+                            type: string
+                          value:
+                            description: Value is a CEL expression.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the fully-qualified name of the metric.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value is a CEL expression.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              path:
+                description: Path is a restful service path.
+                minLength: 1
+                type: string
+            required:
+            - metrics
+            - path
+            type: object
+          status:
+            description: Status holds status for metrics
+            properties:
+              conditions:
+                description: Conditions holds conditions for metrics.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: portforwards.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: PortForward
+    listKind: PortForwardList
+    plural: portforwards
+    singular: portforward
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PortForward provides port forward configuration for a single
+          pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for port forward.
+            properties:
+              forwards:
+                description: Forwards is a list of forwards to configure.
+                items:
+                  description: Forward holds information how to forward based on ports.
+                  properties:
+                    command:
+                      description: |-
+                        Command is the command to run to forward with stdin/stdout.
+                        if set, Target will be ignored.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: |-
+                        Ports is a list of ports to forward.
+                        if not set, all ports will be forwarded.
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                    target:
+                      description: Target is the target to forward to.
+                      properties:
+                        address:
+                          description: Address is the address to forward to.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Port is the port to forward to.
+                          format: int32
+                          maximum: 65535
+                          minimum: 0
+                          type: integer
+                      required:
+                      - address
+                      - port
+                      type: object
+                  type: object
+                type: array
+            required:
+            - forwards
+            type: object
+          status:
+            description: Status holds status for port forward
+            properties:
+              conditions:
+                description: Conditions holds conditions for port forward
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: resourceusages.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ResourceUsage
+    listKind: ResourceUsageList
+    plural: resourceusages
+    singular: resourceusage
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceUsage provides resource usage for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for resource usage.
+            properties:
+              usages:
+                description: Usages is a list of resource usage for the pod.
+                items:
+                  description: ResourceUsageContainer holds spec for resource usage
+                    container.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    usage:
+                      additionalProperties:
+                        description: ResourceUsageValue holds value for resource usage.
+                        properties:
+                          expression:
+                            description: Expression is the expression for resource
+                              usage.
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Value is the value for resource usage.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      description: Usage is a list of resource usage for the container.
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: Status holds status for resource usage
+            properties:
+              conditions:
+                description: Conditions holds conditions for resource usage
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: stages.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Stage
+    listKind: StageList
+    plural: stages
+    singular: stage
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Stage is an API that describes the staged change of a resource
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds information about the request being evaluated.
+            properties:
+              delay:
+                description: Delay means there is a delay in this stage.
+                properties:
+                  durationFrom:
+                    description: |-
+                      DurationFrom is the expression used to get the value.
+                      If it is a time.Time type, getting the value will be minus time.Now() to get DurationMilliseconds
+                      If it is a string type, the value get will be parsed by time.ParseDuration.
+                    properties:
+                      expressionFrom:
+                        description: ExpressionFrom is the expression used to get
+                          the value.
+                        type: string
+                    type: object
+                  durationMilliseconds:
+                    description: |-
+                      DurationMilliseconds indicates the stage delay time.
+                      If JitterDurationMilliseconds is less than DurationMilliseconds, then JitterDurationMilliseconds is used.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  jitterDurationFrom:
+                    description: |-
+                      JitterDurationFrom is the expression used to get the value.
+                      If it is a time.Time type, getting the value will be minus time.Now() to get JitterDurationMilliseconds
+                      If it is a string type, the value get will be parsed by time.ParseDuration.
+                    properties:
+                      expressionFrom:
+                        description: ExpressionFrom is the expression used to get
+                          the value.
+                        type: string
+                    type: object
+                  jitterDurationMilliseconds:
+                    description: |-
+                      JitterDurationMilliseconds is the duration plus an additional amount chosen uniformly
+                      at random from the interval between DurationMilliseconds and JitterDurationMilliseconds.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                type: object
+              immediateNextStage:
+                description: ImmediateNextStage means that the next stage of matching
+                  is performed immediately, without waiting for the Apiserver to push.
+                type: boolean
+              next:
+                description: Next indicates that this stage will be moved to.
+                properties:
+                  delete:
+                    description: Delete means that the resource will be deleted if
+                      true.
+                    type: boolean
+                  event:
+                    description: Event means that an event will be sent.
+                    properties:
+                      message:
+                        description: Message is a human-readable description of the
+                          status of this operation.
+                        type: string
+                      reason:
+                        description: Reason is why the action was taken. It is human-readable.
+                        type: string
+                      type:
+                        description: Type is the type of this event (Normal, Warning),
+                          It is machine-readable.
+                        type: string
+                    type: object
+                  finalizers:
+                    description: Finalizers means that finalizers will be modified.
+                    properties:
+                      add:
+                        description: Add means that the Finalizers will be added to
+                          the resource.
+                        items:
+                          description: FinalizerItem  describes the one of the finalizers.
+                          properties:
+                            value:
+                              description: Value is the value of the finalizer.
+                              type: string
+                          type: object
+                        type: array
+                      empty:
+                        description: Empty means that the Finalizers for that resource
+                          will be emptied.
+                        type: boolean
+                      remove:
+                        description: Remove means that the Finalizers will be removed
+                          from the resource.
+                        items:
+                          description: FinalizerItem  describes the one of the finalizers.
+                          properties:
+                            value:
+                              description: Value is the value of the finalizer.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  statusPatchAs:
+                    description: |-
+                      StatusPatchAs indicates the impersonating configuration for client when patching status.
+                      In most cases this will be empty, in which case the default client service account will be used.
+                      When this is not empty, a corresponding rbac change is required to grant `impersonate` privilege.
+                      The support for this field is not available in Pod and Node resources.
+                    properties:
+                      username:
+                        description: Username the target username for the client to
+                          impersonate
+                        type: string
+                    required:
+                    - username
+                    type: object
+                  statusSubresource:
+                    default: status
+                    description: |-
+                      StatusSubresource indicates the name of the subresource that will be patched. The support for
+                      this field is not available in Pod and Node resources.
+                    type: string
+                  statusTemplate:
+                    description: StatusTemplate indicates the template for modifying
+                      the status of the resource in the next.
+                    type: string
+                type: object
+              resourceRef:
+                description: ResourceRef specifies the Kind and version of the resource.
+                properties:
+                  apiGroup:
+                    default: v1
+                    description: APIGroup of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    type: string
+                required:
+                - kind
+                type: object
+              selector:
+                description: Selector specifies the stags will be applied to the selected
+                  resource.
+                properties:
+                  matchAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      MatchAnnotations is a map of {key,value} pairs. A single {key,value} in the matchAnnotations
+                      map is equivalent to an element of matchExpressions, whose key field is ".metadata.annotations[key]", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                  matchExpressions:
+                    description: MatchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        SelectorRequirement is a resource selector requirement is a selector that contains values, a key,
+                        and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: The name of the scope that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: Represents a scope's relationship to a set
+                            of values.
+                          type: string
+                        values:
+                          description: |-
+                            An array of string values.
+                            If the operator is In, NotIn, Intersection or NotIntersection, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values array must be empty.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is ".metadata.labels[key]", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              weight:
+                default: 0
+                description: |-
+                  Weight means when multiple stages share the same ResourceRef and Selector,
+                  a random stage will be matched as the next stage based on the weight.
+                minimum: 0
+                type: integer
+            required:
+            - next
+            - resourceRef
+            type: object
+          status:
+            description: Status holds status for the Stage
+            properties:
+              conditions:
+                description: Conditions holds conditions for the Stage.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - attaches
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - attaches/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterattaches
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterattaches/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterexecs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterexecs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterlogs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterlogs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterportforwards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterportforwards/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterresourceusages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterresourceusages/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - execs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - execs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - logs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - logs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - metrics
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - metrics/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - portforwards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - portforwards/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - resourceusages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - resourceusages/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - stages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - stages/status
+  verbs:
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kwok-controller
+subjects:
+- kind: ServiceAccount
+  name: kwok-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+  namespace: kube-system
+spec:
+  ports:
+  - name: http
+    port: 10247
+    protocol: TCP
+    targetPort: 10247
+  selector:
+    app: kwok-controller
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kwok-controller
+  template:
+    metadata:
+      labels:
+        app: kwok-controller
+    spec:
+      containers:
+      - args:
+        - --manage-all-nodes=false
+        - --manage-nodes-with-annotation-selector=kwok.x-k8s.io/node=fake
+        - --manage-nodes-with-label-selector=
+        - --manage-single-node=
+        - --disregard-status-with-annotation-selector=kwok.x-k8s.io/status=custom
+        - --disregard-status-with-label-selector=
+        - --node-ip=$(POD_IP)
+        - --node-port=10247
+        - --cidr=10.0.0.1/24
+        - --node-lease-duration-seconds=40
+        - --enable-crds=Stage
+        - --enable-crds=Metric
+        - --enable-crds=Attach
+        - --enable-crds=ClusterAttach
+        - --enable-crds=Exec
+        - --enable-crds=ClusterExec
+        - --enable-crds=Logs
+        - --enable-crds=ClusterLogs
+        - --enable-crds=PortForward
+        - --enable-crds=ClusterPortForward
+        - --enable-crds=ResourceUsage
+        - --enable-crds=ClusterResourceUsage
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: registry.k8s.io/kwok/kwok:v0.5.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 10247
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 10
+        name: kwok-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: 10247
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 20
+          timeoutSeconds: 2
+        startupProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10247
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          timeoutSeconds: 2
+      restartPolicy: Always
+      serviceAccountName: kwok-controller

--- a/cluster-provision/k8s/1.29/manifests/kwok/stage-fast.yaml
+++ b/cluster-provision/k8s/1.29/manifests/kwok/stage-fast.yaml
@@ -1,0 +1,255 @@
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: node-heartbeat-with-lease
+spec:
+  delay:
+    durationMilliseconds: 600000
+    jitterDurationMilliseconds: 610000
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      {{ $lastTransitionTime := or .metadata.creationTimestamp $now }}
+      conditions:
+      {{ range NodeConditions }}
+      - lastHeartbeatTime: {{ $now | Quote }}
+        lastTransitionTime: {{ $lastTransitionTime | Quote }}
+        message: {{ .message | Quote }}
+        reason: {{ .reason | Quote }}
+        status: {{ .status | Quote }}
+        type: {{ .type | Quote }}
+      {{ end }}
+
+      addresses:
+      {{ with .status.addresses }}
+      {{ YAML . 1 }}
+      {{ else }}
+      {{ with NodeIP }}
+      - address: {{ . | Quote }}
+        type: InternalIP
+      {{ end }}
+      {{ with NodeName }}
+      - address: {{ . | Quote }}
+        type: Hostname
+      {{ end }}
+      {{ end }}
+
+      {{ with NodePort }}
+      daemonEndpoints:
+        kubeletEndpoint:
+          Port: {{ . }}
+      {{ end }}
+  resourceRef:
+    apiGroup: v1
+    kind: Node
+  selector:
+    matchExpressions:
+    - key: .status.phase
+      operator: In
+      values:
+      - Running
+    - key: .status.conditions.[] | select( .type == "Ready" ) | .status
+      operator: In
+      values:
+      - "True"
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: node-initialize
+spec:
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      {{ $lastTransitionTime := or .metadata.creationTimestamp $now }}
+      conditions:
+      {{ range NodeConditions }}
+      - lastHeartbeatTime: {{ $now | Quote }}
+        lastTransitionTime: {{ $lastTransitionTime | Quote }}
+        message: {{ .message | Quote }}
+        reason: {{ .reason | Quote }}
+        status: {{ .status | Quote }}
+        type: {{ .type  | Quote}}
+      {{ end }}
+
+      addresses:
+      {{ with .status.addresses }}
+      {{ YAML . 1 }}
+      {{ else }}
+      {{ with NodeIP }}
+      - address: {{ . | Quote }}
+        type: InternalIP
+      {{ end }}
+      {{ with NodeName }}
+      - address: {{ . | Quote }}
+        type: Hostname
+      {{ end }}
+      {{ end }}
+
+      {{ with NodePort }}
+      daemonEndpoints:
+        kubeletEndpoint:
+          Port: {{ . }}
+      {{ end }}
+
+      allocatable:
+      {{ with .status.allocatable }}
+      {{ YAML . 1 }}
+      {{ else }}
+        cpu: 1k
+        memory: 1Ti
+        pods: 1M
+      {{ end }}
+      capacity:
+      {{ with .status.capacity }}
+      {{ YAML . 1 }}
+      {{ else }}
+        cpu: 1k
+        memory: 1Ti
+        pods: 1M
+      {{ end }}
+      {{ with .status.nodeInfo }}
+      nodeInfo:
+        architecture: {{ with .architecture }} {{ . }} {{ else }} "amd64" {{ end }}
+        bootID: {{ with .bootID }} {{ . }} {{ else }} "" {{ end }}
+        containerRuntimeVersion: {{ with .containerRuntimeVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        kernelVersion: {{ with .kernelVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        kubeProxyVersion: {{ with .kubeProxyVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        kubeletVersion: {{ with .kubeletVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        machineID: {{ with .machineID }} {{ . }} {{ else }} "" {{ end }}
+        operatingSystem: {{ with .operatingSystem }} {{ . }} {{ else }} "linux" {{ end }}
+        osImage: {{ with .osImage }} {{ . }} {{ else }} "" {{ end }}
+        systemUUID: {{ with .systemUUID }} {{ . }} {{ else }} "" {{ end }}
+      {{ end }}
+      phase: Running
+  resourceRef:
+    apiGroup: v1
+    kind: Node
+  selector:
+    matchExpressions:
+    - key: .status.conditions.[] | select( .type == "Ready" ) | .status
+      operator: NotIn
+      values:
+      - "True"
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-complete
+spec:
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      {{ $root := . }}
+      containerStatuses:
+      {{ range $index, $item := .spec.containers }}
+      {{ $origin := index $root.status.containerStatuses $index }}
+      - image: {{ $item.image | Quote }}
+        name: {{ $item.name | Quote }}
+        ready: false
+        restartCount: 0
+        started: false
+        state:
+          terminated:
+            exitCode: 0
+            finishedAt: {{ $now | Quote }}
+            reason: Completed
+            startedAt: {{ $now | Quote }}
+      {{ end }}
+      phase: Succeeded
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: .metadata.deletionTimestamp
+      operator: DoesNotExist
+    - key: .status.phase
+      operator: In
+      values:
+      - Running
+    - key: .metadata.ownerReferences.[].kind
+      operator: In
+      values:
+      - Job
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-delete
+spec:
+  next:
+    delete: true
+    finalizers:
+      empty: true
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: .metadata.deletionTimestamp
+      operator: Exists
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-ready
+spec:
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+
+      conditions:
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: Initialized
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: Ready
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: ContainersReady
+      {{ range .spec.readinessGates }}
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: {{ .conditionType | Quote }}
+      {{ end }}
+
+      containerStatuses:
+      {{ range .spec.containers }}
+      - image: {{ .image | Quote }}
+        name: {{ .name | Quote }}
+        ready: true
+        restartCount: 0
+        state:
+          running:
+            startedAt: {{ $now | Quote }}
+      {{ end }}
+
+      initContainerStatuses:
+      {{ range .spec.initContainers }}
+      - image: {{ .image | Quote }}
+        name: {{ .name | Quote }}
+        ready: true
+        restartCount: 0
+        state:
+          terminated:
+            exitCode: 0
+            finishedAt: {{ $now | Quote }}
+            reason: Completed
+            startedAt: {{ $now | Quote }}
+      {{ end }}
+
+      hostIP: {{ NodeIPWith .spec.nodeName | Quote }}
+      podIP: {{ PodIPWith .spec.nodeName ( or .spec.hostNetwork false ) ( or .metadata.uid "" ) ( or .metadata.name "" ) ( or .metadata.namespace "" ) | Quote }}
+      phase: Running
+      startTime: {{ $now | Quote }}
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: .metadata.deletionTimestamp
+      operator: DoesNotExist
+    - key: .status.podIP
+      operator: DoesNotExist

--- a/cluster-provision/k8s/1.30/k8s_provision.sh
+++ b/cluster-provision/k8s/1.30/k8s_provision.sh
@@ -362,6 +362,9 @@ cp -rf /tmp/cdi*.yaml /opt/
 # copy aaq manifests
 cp -rf /tmp/aaq/ /opt/
 
+# copy kwok manifests
+cp -rf /tmp/kwok /opt/
+
 # Create a properly labelled tmp directory for testing
 mkdir -p /var/provision/kubevirt.io/tests
 chcon -t container_file_t /var/provision/kubevirt.io/tests

--- a/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/kustomization.yaml
+++ b/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - rbac
+  - stage

--- a/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/rbac/kustomization.yaml
+++ b/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - role.yaml
+  - role-binding.yaml

--- a/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/rbac/role-binding.yaml
+++ b/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/rbac/role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kwok-with-vmi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kwok-with-vmi
+subjects:
+  - kind: ServiceAccount
+    name: kwok-controller
+    namespace: kube-system

--- a/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/rbac/role.yaml
+++ b/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/rbac/role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kwok-with-vmi
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachineinstances
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachineinstances/finalizers
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - impersonate

--- a/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/stage/kustomization.yaml
+++ b/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/stage/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vmi-delete.yaml
+  - vmi-ready.yaml

--- a/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/stage/vmi-delete.yaml
+++ b/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/stage/vmi-delete.yaml
@@ -1,0 +1,16 @@
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: vmi-delete
+spec:
+  resourceRef:
+    apiGroup: kubevirt.io/v1
+    kind: VirtualMachineInstance
+  selector:
+    matchExpressions:
+      - key: '.metadata.deletionTimestamp'
+        operator: 'Exists'
+  next:
+    finalizers:
+      empty: true
+    delete: true

--- a/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/stage/vmi-ready.yaml
+++ b/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/stage/vmi-ready.yaml
@@ -1,0 +1,47 @@
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: vmi-ready
+spec:
+  resourceRef:
+    apiGroup: kubevirt.io/v1
+    kind: VirtualMachineInstance
+  selector:
+    matchExpressions:
+      - key: '.metadata.deletionTimestamp'
+        operator: 'DoesNotExist'
+      - key: '.status.phase'
+        operator: 'NotIn'
+        values:
+          - 'Running'
+      - key: '.spec.nodeSelector.type'
+        operator: 'In'
+        values:
+          - 'kwok'
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      activePods:
+      {{ YAML .status.activePods 1 }}
+      conditions:
+      - type: Ready
+        status: "True"
+        lastTransitionTime: {{ $now }}
+      guestOSInfo: {}
+      launcherContainerImageVersion: {{ .status.launcherContainerImageVersion }}
+      memory:
+      {{ YAML .status.memory 1 }}
+      migrationTransport: Unix
+      nodeName: {{ .status.nodeName }}
+      phase: Running
+      phaseTransitionTimestamps:
+      {{ YAML .status.phaseTransitionTimestamps 0 }}
+      - phase: Running
+        phaseTransitionTimestamp: {{ $now }}
+      qosClass: {{ .status.qosClass }}
+      runtimeUser: {{ .status.runtimeUser }}
+      volumeStatus:
+      {{ YAML .status.volumeStatus 1 }}
+    statusSubresource: ""
+    statusPatchAs:
+      username: system:serviceaccount:kubevirt:kubevirt-controller

--- a/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/stage/vmi-ready.yaml
+++ b/cluster-provision/k8s/1.30/manifests/kwok/kubevirt/stage/vmi-ready.yaml
@@ -11,9 +11,9 @@ spec:
       - key: '.metadata.deletionTimestamp'
         operator: 'DoesNotExist'
       - key: '.status.phase'
-        operator: 'NotIn'
+        operator: 'In'
         values:
-          - 'Running'
+          - 'Scheduled'
       - key: '.spec.nodeSelector.type'
         operator: 'In'
         values:

--- a/cluster-provision/k8s/1.30/manifests/kwok/kwok.yaml
+++ b/cluster-provision/k8s/1.30/manifests/kwok/kwok.yaml
@@ -1,0 +1,2408 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: attaches.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Attach
+    listKind: AttachList
+    plural: attaches
+    singular: attach
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Attach provides attach configuration for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for attach
+            properties:
+              attaches:
+                description: Attaches is a list of attaches to configure.
+                items:
+                  description: AttachConfig holds information how to attach.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    logsFile:
+                      description: LogsFile is the file from which the attach starts
+                      type: string
+                  type: object
+                type: array
+            required:
+            - attaches
+            type: object
+          status:
+            description: Status holds status for attach
+            properties:
+              conditions:
+                description: Conditions holds conditions for attach
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterattaches.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterAttach
+    listKind: ClusterAttachList
+    plural: clusterattaches
+    singular: clusterattach
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterAttach provides cluster-wide logging configuration
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster attach.
+            properties:
+              attaches:
+                description: Attaches is a list of attach configurations.
+                items:
+                  description: AttachConfig holds information how to attach.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    logsFile:
+                      description: LogsFile is the file from which the attach starts
+                      type: string
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - attaches
+            type: object
+          status:
+            description: Status holds status for cluster attach
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster attach.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterexecs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterExec
+    listKind: ClusterExecList
+    plural: clusterexecs
+    singular: clusterexec
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterExec provides cluster-wide exec configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster exec.
+            properties:
+              execs:
+                description: Execs is a list of exec to configure.
+                items:
+                  description: ExecTarget holds information how to exec.
+                  properties:
+                    containers:
+                      description: |-
+                        Containers is a list of containers to exec.
+                        if not set, all containers will be execed.
+                      items:
+                        type: string
+                      type: array
+                    local:
+                      description: Local holds information how to exec to a local
+                        target.
+                      properties:
+                        envs:
+                          description: Envs is a list of environment variables to
+                            exec with.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable.
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value of the environment variable.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        securityContext:
+                          description: SecurityContext is the user context to exec.
+                          properties:
+                            runAsGroup:
+                              description: RunAsGroup is the existing gid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                            runAsUser:
+                              description: RunAsUser is the existing uid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                          type: object
+                        workDir:
+                          description: WorkDir is the working directory to exec with.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - execs
+            type: object
+          status:
+            description: Status holds status for cluster exec
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster exec.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterlogs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterLogs
+    listKind: ClusterLogsList
+    plural: clusterlogs
+    singular: clusterlogs
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterLogs provides cluster-wide logging configuration
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster logs.
+            properties:
+              logs:
+                description: Forwards is a list of log configurations.
+                items:
+                  description: Log holds information how to forward logs.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    follow:
+                      description: Follow up if true
+                      type: boolean
+                    logsFile:
+                      description: LogsFile is the file from which the log forward
+                        starts
+                      type: string
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - logs
+            type: object
+          status:
+            description: Status holds status for cluster logs
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster logs.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterportforwards.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterPortForward
+    listKind: ClusterPortForwardList
+    plural: clusterportforwards
+    singular: clusterportforward
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPortForward provides cluster-wide port forward configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster port forward.
+            properties:
+              forwards:
+                description: Forwards is a list of forwards to configure.
+                items:
+                  description: Forward holds information how to forward based on ports.
+                  properties:
+                    command:
+                      description: |-
+                        Command is the command to run to forward with stdin/stdout.
+                        if set, Target will be ignored.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: |-
+                        Ports is a list of ports to forward.
+                        if not set, all ports will be forwarded.
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                    target:
+                      description: Target is the target to forward to.
+                      properties:
+                        address:
+                          description: Address is the address to forward to.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Port is the port to forward to.
+                          format: int32
+                          maximum: 65535
+                          minimum: 0
+                          type: integer
+                      required:
+                      - address
+                      - port
+                      type: object
+                  type: object
+                type: array
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - forwards
+            type: object
+          status:
+            description: Status holds status for cluster port forward
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster port forward.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: clusterresourceusages.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ClusterResourceUsage
+    listKind: ClusterResourceUsageList
+    plural: clusterresourceusages
+    singular: clusterresourceusage
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceUsage provides cluster-wide resource usage.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for cluster resource usage.
+            properties:
+              selector:
+                description: Selector is a selector to filter pods to configure.
+                properties:
+                  matchNames:
+                    description: |-
+                      MatchNames is a list of names to match.
+                      if not set, all names will be matched.
+                    items:
+                      type: string
+                    type: array
+                  matchNamespaces:
+                    description: |-
+                      MatchNamespaces is a list of namespaces to match.
+                      if not set, all namespaces will be matched.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              usages:
+                description: Usages is a list of resource usage for the pod.
+                items:
+                  description: ResourceUsageContainer holds spec for resource usage
+                    container.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    usage:
+                      additionalProperties:
+                        description: ResourceUsageValue holds value for resource usage.
+                        properties:
+                          expression:
+                            description: Expression is the expression for resource
+                              usage.
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Value is the value for resource usage.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      description: Usage is a list of resource usage for the container.
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: Status holds status for cluster resource usage
+            properties:
+              conditions:
+                description: Conditions holds conditions for cluster resource usage
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: execs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Exec
+    listKind: ExecList
+    plural: execs
+    singular: exec
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Exec provides exec configuration for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for exec
+            properties:
+              execs:
+                description: Execs is a list of execs to configure.
+                items:
+                  description: ExecTarget holds information how to exec.
+                  properties:
+                    containers:
+                      description: |-
+                        Containers is a list of containers to exec.
+                        if not set, all containers will be execed.
+                      items:
+                        type: string
+                      type: array
+                    local:
+                      description: Local holds information how to exec to a local
+                        target.
+                      properties:
+                        envs:
+                          description: Envs is a list of environment variables to
+                            exec with.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable.
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value of the environment variable.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        securityContext:
+                          description: SecurityContext is the user context to exec.
+                          properties:
+                            runAsGroup:
+                              description: RunAsGroup is the existing gid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                            runAsUser:
+                              description: RunAsUser is the existing uid to run exec
+                                command in container process.
+                              format: int64
+                              type: integer
+                          type: object
+                        workDir:
+                          description: WorkDir is the working directory to exec with.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            required:
+            - execs
+            type: object
+          status:
+            description: Status holds status for exec
+            properties:
+              conditions:
+                description: Conditions holds conditions for exec
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: logs.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Logs
+    listKind: LogsList
+    plural: logs
+    singular: logs
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Logs provides logging configuration for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for logs
+            properties:
+              logs:
+                description: Logs is a list of logs to configure.
+                items:
+                  description: Log holds information how to forward logs.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    follow:
+                      description: Follow up if true
+                      type: boolean
+                    logsFile:
+                      description: LogsFile is the file from which the log forward
+                        starts
+                      type: string
+                  type: object
+                type: array
+            required:
+            - logs
+            type: object
+          status:
+            description: Status holds status for logs
+            properties:
+              conditions:
+                description: Conditions holds conditions for logs
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: metrics.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Metric
+    listKind: MetricList
+    plural: metrics
+    singular: metric
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Metric provides metrics configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for metrics.
+            properties:
+              metrics:
+                description: Metrics is a list of metric configurations.
+                items:
+                  description: MetricConfig provides metric configuration to a single
+                    metric
+                  properties:
+                    buckets:
+                      description: Buckets is a list of buckets for a histogram metric.
+                      items:
+                        description: MetricBucket is a single bucket for a metric.
+                        properties:
+                          hidden:
+                            description: |-
+                              Hidden is means that this bucket not shown in the metric.
+                              but value will be calculated and cumulative into the next bucket.
+                            type: boolean
+                          le:
+                            description: Le is less-than or equal.
+                            minimum: 0
+                            type: number
+                          value:
+                            description: Value is a CEL expression.
+                            type: string
+                        required:
+                        - le
+                        - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - le
+                      x-kubernetes-list-type: map
+                    dimension:
+                      description: Dimension is a dimension of the metric.
+                      type: string
+                    help:
+                      description: Help provides information about this metric.
+                      type: string
+                    kind:
+                      description: Kind is kind of metric
+                      enum:
+                      - counter
+                      - gauge
+                      - histogram
+                      type: string
+                    labels:
+                      description: Labels are metric labels.
+                      items:
+                        description: MetricLabel holds label name and the value of
+                          the label.
+                        properties:
+                          name:
+                            description: Name is a label name.
+                            minLength: 1
+                            type: string
+                          value:
+                            description: Value is a CEL expression.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the fully-qualified name of the metric.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value is a CEL expression.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              path:
+                description: Path is a restful service path.
+                minLength: 1
+                type: string
+            required:
+            - metrics
+            - path
+            type: object
+          status:
+            description: Status holds status for metrics
+            properties:
+              conditions:
+                description: Conditions holds conditions for metrics.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: portforwards.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: PortForward
+    listKind: PortForwardList
+    plural: portforwards
+    singular: portforward
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PortForward provides port forward configuration for a single
+          pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for port forward.
+            properties:
+              forwards:
+                description: Forwards is a list of forwards to configure.
+                items:
+                  description: Forward holds information how to forward based on ports.
+                  properties:
+                    command:
+                      description: |-
+                        Command is the command to run to forward with stdin/stdout.
+                        if set, Target will be ignored.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: |-
+                        Ports is a list of ports to forward.
+                        if not set, all ports will be forwarded.
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                    target:
+                      description: Target is the target to forward to.
+                      properties:
+                        address:
+                          description: Address is the address to forward to.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Port is the port to forward to.
+                          format: int32
+                          maximum: 65535
+                          minimum: 0
+                          type: integer
+                      required:
+                      - address
+                      - port
+                      type: object
+                  type: object
+                type: array
+            required:
+            - forwards
+            type: object
+          status:
+            description: Status holds status for port forward
+            properties:
+              conditions:
+                description: Conditions holds conditions for port forward
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: resourceusages.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: ResourceUsage
+    listKind: ResourceUsageList
+    plural: resourceusages
+    singular: resourceusage
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceUsage provides resource usage for a single pod.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds spec for resource usage.
+            properties:
+              usages:
+                description: Usages is a list of resource usage for the pod.
+                items:
+                  description: ResourceUsageContainer holds spec for resource usage
+                    container.
+                  properties:
+                    containers:
+                      description: Containers is list of container names.
+                      items:
+                        type: string
+                      type: array
+                    usage:
+                      additionalProperties:
+                        description: ResourceUsageValue holds value for resource usage.
+                        properties:
+                          expression:
+                            description: Expression is the expression for resource
+                              usage.
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Value is the value for resource usage.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      description: Usage is a list of resource usage for the container.
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: Status holds status for resource usage
+            properties:
+              conditions:
+                description: Conditions holds conditions for resource usage
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app: kwok-controller
+  name: stages.kwok.x-k8s.io
+spec:
+  group: kwok.x-k8s.io
+  names:
+    kind: Stage
+    listKind: StageList
+    plural: stages
+    singular: stage
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Stage is an API that describes the staged change of a resource
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds information about the request being evaluated.
+            properties:
+              delay:
+                description: Delay means there is a delay in this stage.
+                properties:
+                  durationFrom:
+                    description: |-
+                      DurationFrom is the expression used to get the value.
+                      If it is a time.Time type, getting the value will be minus time.Now() to get DurationMilliseconds
+                      If it is a string type, the value get will be parsed by time.ParseDuration.
+                    properties:
+                      expressionFrom:
+                        description: ExpressionFrom is the expression used to get
+                          the value.
+                        type: string
+                    type: object
+                  durationMilliseconds:
+                    description: |-
+                      DurationMilliseconds indicates the stage delay time.
+                      If JitterDurationMilliseconds is less than DurationMilliseconds, then JitterDurationMilliseconds is used.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  jitterDurationFrom:
+                    description: |-
+                      JitterDurationFrom is the expression used to get the value.
+                      If it is a time.Time type, getting the value will be minus time.Now() to get JitterDurationMilliseconds
+                      If it is a string type, the value get will be parsed by time.ParseDuration.
+                    properties:
+                      expressionFrom:
+                        description: ExpressionFrom is the expression used to get
+                          the value.
+                        type: string
+                    type: object
+                  jitterDurationMilliseconds:
+                    description: |-
+                      JitterDurationMilliseconds is the duration plus an additional amount chosen uniformly
+                      at random from the interval between DurationMilliseconds and JitterDurationMilliseconds.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                type: object
+              immediateNextStage:
+                description: ImmediateNextStage means that the next stage of matching
+                  is performed immediately, without waiting for the Apiserver to push.
+                type: boolean
+              next:
+                description: Next indicates that this stage will be moved to.
+                properties:
+                  delete:
+                    description: Delete means that the resource will be deleted if
+                      true.
+                    type: boolean
+                  event:
+                    description: Event means that an event will be sent.
+                    properties:
+                      message:
+                        description: Message is a human-readable description of the
+                          status of this operation.
+                        type: string
+                      reason:
+                        description: Reason is why the action was taken. It is human-readable.
+                        type: string
+                      type:
+                        description: Type is the type of this event (Normal, Warning),
+                          It is machine-readable.
+                        type: string
+                    type: object
+                  finalizers:
+                    description: Finalizers means that finalizers will be modified.
+                    properties:
+                      add:
+                        description: Add means that the Finalizers will be added to
+                          the resource.
+                        items:
+                          description: FinalizerItem  describes the one of the finalizers.
+                          properties:
+                            value:
+                              description: Value is the value of the finalizer.
+                              type: string
+                          type: object
+                        type: array
+                      empty:
+                        description: Empty means that the Finalizers for that resource
+                          will be emptied.
+                        type: boolean
+                      remove:
+                        description: Remove means that the Finalizers will be removed
+                          from the resource.
+                        items:
+                          description: FinalizerItem  describes the one of the finalizers.
+                          properties:
+                            value:
+                              description: Value is the value of the finalizer.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  statusPatchAs:
+                    description: |-
+                      StatusPatchAs indicates the impersonating configuration for client when patching status.
+                      In most cases this will be empty, in which case the default client service account will be used.
+                      When this is not empty, a corresponding rbac change is required to grant `impersonate` privilege.
+                      The support for this field is not available in Pod and Node resources.
+                    properties:
+                      username:
+                        description: Username the target username for the client to
+                          impersonate
+                        type: string
+                    required:
+                    - username
+                    type: object
+                  statusSubresource:
+                    default: status
+                    description: |-
+                      StatusSubresource indicates the name of the subresource that will be patched. The support for
+                      this field is not available in Pod and Node resources.
+                    type: string
+                  statusTemplate:
+                    description: StatusTemplate indicates the template for modifying
+                      the status of the resource in the next.
+                    type: string
+                type: object
+              resourceRef:
+                description: ResourceRef specifies the Kind and version of the resource.
+                properties:
+                  apiGroup:
+                    default: v1
+                    description: APIGroup of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    type: string
+                required:
+                - kind
+                type: object
+              selector:
+                description: Selector specifies the stags will be applied to the selected
+                  resource.
+                properties:
+                  matchAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      MatchAnnotations is a map of {key,value} pairs. A single {key,value} in the matchAnnotations
+                      map is equivalent to an element of matchExpressions, whose key field is ".metadata.annotations[key]", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                  matchExpressions:
+                    description: MatchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        SelectorRequirement is a resource selector requirement is a selector that contains values, a key,
+                        and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: The name of the scope that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: Represents a scope's relationship to a set
+                            of values.
+                          type: string
+                        values:
+                          description: |-
+                            An array of string values.
+                            If the operator is In, NotIn, Intersection or NotIntersection, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values array must be empty.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is ".metadata.labels[key]", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              weight:
+                default: 0
+                description: |-
+                  Weight means when multiple stages share the same ResourceRef and Selector,
+                  a random stage will be matched as the next stage based on the weight.
+                minimum: 0
+                type: integer
+            required:
+            - next
+            - resourceRef
+            type: object
+          status:
+            description: Status holds status for the Stage
+            properties:
+              conditions:
+                description: Conditions holds conditions for the Stage.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - attaches
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - attaches/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterattaches
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterattaches/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterexecs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterexecs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterlogs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterlogs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterportforwards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterportforwards/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterresourceusages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - clusterresourceusages/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - execs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - execs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - logs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - logs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - metrics
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - metrics/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - portforwards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - portforwards/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - resourceusages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - resourceusages/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - stages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kwok.x-k8s.io
+  resources:
+  - stages/status
+  verbs:
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kwok-controller
+subjects:
+- kind: ServiceAccount
+  name: kwok-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+  namespace: kube-system
+spec:
+  ports:
+  - name: http
+    port: 10247
+    protocol: TCP
+    targetPort: 10247
+  selector:
+    app: kwok-controller
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kwok-controller
+  name: kwok-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kwok-controller
+  template:
+    metadata:
+      labels:
+        app: kwok-controller
+    spec:
+      containers:
+      - args:
+        - --manage-all-nodes=false
+        - --manage-nodes-with-annotation-selector=kwok.x-k8s.io/node=fake
+        - --manage-nodes-with-label-selector=
+        - --manage-single-node=
+        - --disregard-status-with-annotation-selector=kwok.x-k8s.io/status=custom
+        - --disregard-status-with-label-selector=
+        - --node-ip=$(POD_IP)
+        - --node-port=10247
+        - --cidr=10.0.0.1/24
+        - --node-lease-duration-seconds=40
+        - --enable-crds=Stage
+        - --enable-crds=Metric
+        - --enable-crds=Attach
+        - --enable-crds=ClusterAttach
+        - --enable-crds=Exec
+        - --enable-crds=ClusterExec
+        - --enable-crds=Logs
+        - --enable-crds=ClusterLogs
+        - --enable-crds=PortForward
+        - --enable-crds=ClusterPortForward
+        - --enable-crds=ResourceUsage
+        - --enable-crds=ClusterResourceUsage
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: registry.k8s.io/kwok/kwok:v0.5.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 10247
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 10
+        name: kwok-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: 10247
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 20
+          timeoutSeconds: 2
+        startupProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10247
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          timeoutSeconds: 2
+      restartPolicy: Always
+      serviceAccountName: kwok-controller

--- a/cluster-provision/k8s/1.30/manifests/kwok/stage-fast.yaml
+++ b/cluster-provision/k8s/1.30/manifests/kwok/stage-fast.yaml
@@ -1,0 +1,255 @@
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: node-heartbeat-with-lease
+spec:
+  delay:
+    durationMilliseconds: 600000
+    jitterDurationMilliseconds: 610000
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      {{ $lastTransitionTime := or .metadata.creationTimestamp $now }}
+      conditions:
+      {{ range NodeConditions }}
+      - lastHeartbeatTime: {{ $now | Quote }}
+        lastTransitionTime: {{ $lastTransitionTime | Quote }}
+        message: {{ .message | Quote }}
+        reason: {{ .reason | Quote }}
+        status: {{ .status | Quote }}
+        type: {{ .type | Quote }}
+      {{ end }}
+
+      addresses:
+      {{ with .status.addresses }}
+      {{ YAML . 1 }}
+      {{ else }}
+      {{ with NodeIP }}
+      - address: {{ . | Quote }}
+        type: InternalIP
+      {{ end }}
+      {{ with NodeName }}
+      - address: {{ . | Quote }}
+        type: Hostname
+      {{ end }}
+      {{ end }}
+
+      {{ with NodePort }}
+      daemonEndpoints:
+        kubeletEndpoint:
+          Port: {{ . }}
+      {{ end }}
+  resourceRef:
+    apiGroup: v1
+    kind: Node
+  selector:
+    matchExpressions:
+    - key: .status.phase
+      operator: In
+      values:
+      - Running
+    - key: .status.conditions.[] | select( .type == "Ready" ) | .status
+      operator: In
+      values:
+      - "True"
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: node-initialize
+spec:
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      {{ $lastTransitionTime := or .metadata.creationTimestamp $now }}
+      conditions:
+      {{ range NodeConditions }}
+      - lastHeartbeatTime: {{ $now | Quote }}
+        lastTransitionTime: {{ $lastTransitionTime | Quote }}
+        message: {{ .message | Quote }}
+        reason: {{ .reason | Quote }}
+        status: {{ .status | Quote }}
+        type: {{ .type  | Quote}}
+      {{ end }}
+
+      addresses:
+      {{ with .status.addresses }}
+      {{ YAML . 1 }}
+      {{ else }}
+      {{ with NodeIP }}
+      - address: {{ . | Quote }}
+        type: InternalIP
+      {{ end }}
+      {{ with NodeName }}
+      - address: {{ . | Quote }}
+        type: Hostname
+      {{ end }}
+      {{ end }}
+
+      {{ with NodePort }}
+      daemonEndpoints:
+        kubeletEndpoint:
+          Port: {{ . }}
+      {{ end }}
+
+      allocatable:
+      {{ with .status.allocatable }}
+      {{ YAML . 1 }}
+      {{ else }}
+        cpu: 1k
+        memory: 1Ti
+        pods: 1M
+      {{ end }}
+      capacity:
+      {{ with .status.capacity }}
+      {{ YAML . 1 }}
+      {{ else }}
+        cpu: 1k
+        memory: 1Ti
+        pods: 1M
+      {{ end }}
+      {{ with .status.nodeInfo }}
+      nodeInfo:
+        architecture: {{ with .architecture }} {{ . }} {{ else }} "amd64" {{ end }}
+        bootID: {{ with .bootID }} {{ . }} {{ else }} "" {{ end }}
+        containerRuntimeVersion: {{ with .containerRuntimeVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        kernelVersion: {{ with .kernelVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        kubeProxyVersion: {{ with .kubeProxyVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        kubeletVersion: {{ with .kubeletVersion }} {{ . }} {{ else }} "kwok-{{ Version }}" {{ end }}
+        machineID: {{ with .machineID }} {{ . }} {{ else }} "" {{ end }}
+        operatingSystem: {{ with .operatingSystem }} {{ . }} {{ else }} "linux" {{ end }}
+        osImage: {{ with .osImage }} {{ . }} {{ else }} "" {{ end }}
+        systemUUID: {{ with .systemUUID }} {{ . }} {{ else }} "" {{ end }}
+      {{ end }}
+      phase: Running
+  resourceRef:
+    apiGroup: v1
+    kind: Node
+  selector:
+    matchExpressions:
+    - key: .status.conditions.[] | select( .type == "Ready" ) | .status
+      operator: NotIn
+      values:
+      - "True"
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-complete
+spec:
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      {{ $root := . }}
+      containerStatuses:
+      {{ range $index, $item := .spec.containers }}
+      {{ $origin := index $root.status.containerStatuses $index }}
+      - image: {{ $item.image | Quote }}
+        name: {{ $item.name | Quote }}
+        ready: false
+        restartCount: 0
+        started: false
+        state:
+          terminated:
+            exitCode: 0
+            finishedAt: {{ $now | Quote }}
+            reason: Completed
+            startedAt: {{ $now | Quote }}
+      {{ end }}
+      phase: Succeeded
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: .metadata.deletionTimestamp
+      operator: DoesNotExist
+    - key: .status.phase
+      operator: In
+      values:
+      - Running
+    - key: .metadata.ownerReferences.[].kind
+      operator: In
+      values:
+      - Job
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-delete
+spec:
+  next:
+    delete: true
+    finalizers:
+      empty: true
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: .metadata.deletionTimestamp
+      operator: Exists
+---
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-ready
+spec:
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+
+      conditions:
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: Initialized
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: Ready
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: ContainersReady
+      {{ range .spec.readinessGates }}
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "True"
+        type: {{ .conditionType | Quote }}
+      {{ end }}
+
+      containerStatuses:
+      {{ range .spec.containers }}
+      - image: {{ .image | Quote }}
+        name: {{ .name | Quote }}
+        ready: true
+        restartCount: 0
+        state:
+          running:
+            startedAt: {{ $now | Quote }}
+      {{ end }}
+
+      initContainerStatuses:
+      {{ range .spec.initContainers }}
+      - image: {{ .image | Quote }}
+        name: {{ .name | Quote }}
+        ready: true
+        restartCount: 0
+        state:
+          terminated:
+            exitCode: 0
+            finishedAt: {{ $now | Quote }}
+            reason: Completed
+            startedAt: {{ $now | Quote }}
+      {{ end }}
+
+      hostIP: {{ NodeIPWith .spec.nodeName | Quote }}
+      podIP: {{ PodIPWith .spec.nodeName ( or .spec.hostNetwork false ) ( or .metadata.uid "" ) ( or .metadata.name "" ) ( or .metadata.namespace "" ) | Quote }}
+      phase: Running
+      startTime: {{ $now | Quote }}
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: .metadata.deletionTimestamp
+      operator: DoesNotExist
+    - key: .status.podIP
+      operator: DoesNotExist

--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -36,6 +36,7 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
     export KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER=true
     export KUBEVIRT_DEPLOY_GRAFANA=true
     export KUBEVIRT_DEPLOY_CDI=true
+    export KUBEVIRT_DEPLOY_KWOK=true
 
     trap cleanup EXIT ERR SIGINT SIGTERM SIGQUIT
     bash -x ./cluster-up/up.sh

--- a/cluster-provision/k8s/deploy-manifests.sh
+++ b/cluster-provision/k8s/deploy-manifests.sh
@@ -20,6 +20,7 @@ find "$DIR/${provision_dir}/manifests/" -type f -name '*.yaml' \
     -not -path '**/prometheus/**' \
     -not -path '**/ceph/**' \
     -not -path '**/nfs-csi/**' \
+    -not -path '**/kwok/**' \
     -not -name 'local-volume.yaml' \
     -not -name 'cni*.yaml' \
     -not -name 'cdi*-cr.yaml' \

--- a/hack/bump-kwok.sh
+++ b/hack/bump-kwok.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright The KubeVirt Authors.
+
+set -e
+
+KWOK_RELEASES="https://github.com/kubernetes-sigs/kwok/releases/download/"
+
+# syntax:
+# ./hack/bump-kwok.sh <PROVIDER> <KWOK_VERSION>
+
+# usage example
+# ./hack/bump-kwok.sh 1.28 v0.5.2
+
+function main() {
+    provider="${1:?provider not set or empty}"
+    kwok_version="${2:?kwok version not set or empty}"
+
+    declare -a manifests_url
+    manifests_url+=("${KWOK_RELEASES}/${kwok_version}/kwok.yaml")
+    manifests_url+=("${KWOK_RELEASES}/${kwok_version}/stage-fast.yaml")
+
+
+    declare -a manifests
+    for url in "${manifests_url[@]}"; do
+        file="${url##*/}"
+        if ! ls "./cluster-provision/k8s/${provider}/manifests/kwok/${file}" > /dev/null; then
+            echo "${file} not found at kubevirtci folder"
+            exit 1
+        fi
+
+        manifest=$(curl -Ls "${url}")
+        if [[ "${manifest}" == "Not Found" ]]; then
+            echo "${url} not found"
+            exit 1
+        fi
+
+        manifests+=("${manifest}")
+    done
+
+    for i in "${!manifests[@]}"; do
+        file="${manifests_url[i]##*/}"
+        echo "${manifests[$i]}" > "./cluster-provision/k8s/${provider}/manifests/kwok/${file}"
+    done
+
+    echo "kwok, provision, Bump k8s-${provider} kwok to ${kwok_version}"
+}
+
+main "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Running the following command will install kwok enabled with the ability to fake VMIs
```
KUBEVIRT_DEPLOY_KWOK=true make cluster-up
```

With this, e2e test could be written to leverage fake nodes and fake VMIs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/11128

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
