### PR TITLE
kind, vgpu: Remove modprobe of vfio_mdev as no longer present

### DIFF
--- a/cluster-up/cluster/kind-1.27-vgpu/provider.sh
+++ b/cluster-up/cluster/kind-1.27-vgpu/provider.sh
@@ -34,9 +34,6 @@ function configure_registry_proxy() {
 }
 
 function up() {
-    # load the vfio_mdev module
-    /usr/sbin/modprobe vfio_mdev
-    
     # print hardware info for easier debugging based on logs
     echo 'Available cards'
     ${CRI_BIN} run --rm --cap-add=SYS_RAWIO quay.io/phoracek/lspci@sha256:0f3cacf7098202ef284308c64e3fc0ba441871a846022bb87d65ff130c79adb1 sh -c "lspci -k | grep -EA2 'VGA|3D'"


### PR DESCRIPTION
**What this PR does / why we need it**:

These vgpu e2e lanes are failing due to missing a kernel module vfio_mdev[1] after the workloads cluster upgrade. 

The loading of this kernel module is not required as the nvidia operator is installed on the workloads cluster.

Tested here on kubevirt - https://github.com/kubevirt/kubevirt/pull/11816

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-kind-1.27-vgpu/1784918657499926528#1:build-log.txt%3A310

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
