### PR TITLE
cluster-up, cnao: Do not deploy OVS-CNI

### DIFF
--- a/cluster-provision/k8s/1.28/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.28/manifests/cnao/network-addons-config-example.cr.yaml
@@ -11,4 +11,3 @@ spec:
   macvtap: {}
   multus: {}
   multusDynamicNetworks: {}
-  ovs: {}

--- a/cluster-provision/k8s/1.29/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.29/manifests/cnao/network-addons-config-example.cr.yaml
@@ -11,4 +11,3 @@ spec:
   macvtap: {}
   multus: {}
   multusDynamicNetworks: {}
-  ovs: {}

--- a/cluster-provision/k8s/1.30/manifests/cnao/network-addons-config-example.cr.yaml
+++ b/cluster-provision/k8s/1.30/manifests/cnao/network-addons-config-example.cr.yaml
@@ -11,4 +11,3 @@ spec:
   macvtap: {}
   multus: {}
   multusDynamicNetworks: {}
-  ovs: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There is no actual need to deploy OVS-CNI dy default at the moment, we dont test OVS CNI e2e in kubevirt/kubevirt.

Also the ephemeral cluster nodes does not have OVS back-end installed causing OVS-CNI pods to get into crush-loop all over CI.

In case OVS-CNI is required in certain environments, it can be deployed by patching the existing cluster-network-addons instance.

Set CNAO to not deploy OVS-CNI pods and reduce some memory consumption.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Other kubevirt org repositories that use kubevirt/kubevirtci for test/dev environment could patch CNAO NetworkAddonsConfig CR (NAC) and add the necessary components.
Alternatively, set the environment variable `KUBVIRT_WITH_CNAO_SKIP_CONFIG=true` and deploy new NAC with all components that are necessary

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cluster-up: CNAO does not deploy OVS-CNI by default
```
