### PR TITLE
kind-ovn: Introduce new kind-ovn provider

### DIFF
--- a/cluster-up/cluster/kind-ovn/README.md
+++ b/cluster-up/cluster/kind-ovn/README.md
@@ -1,0 +1,29 @@
+# OVN K8S in a Kind cluster
+
+Provides a k8s cluster that runs using [KinD](https://github.com/kubernetes-sigs/kind)
+The cluster is completely ephemeral and is recreated on every cluster restart. The KubeVirt containers are built on the
+local machine and are then pushed to a registry which is exposed at
+`localhost:5000`.
+
+## Bringing the cluster up
+
+```bash
+export KUBEVIRT_PROVIDER=kind-ovn
+make cluster-up
+```
+
+## Bringing the cluster down
+
+```bash
+export KUBEVIRT_PROVIDER=kind-ovn
+make cluster-down
+```
+
+## FAQ
+
+In case the cluster deployment fails, you need to make sure you have enough watches
+add those to /etc/sysctl.conf, and apply it `sysctl -p /etc/sysctl.conf`.
+```
+sysctl fs.inotify.max_user_watches=1048576
+sysctl fs.inotify.max_user_instances=512
+```

--- a/cluster-up/cluster/kind-ovn/install-ovn.sh
+++ b/cluster-up/cluster/kind-ovn/install-ovn.sh
@@ -1,0 +1,47 @@
+#!/bin/bash -e
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2024 Red Hat, Inc.
+#
+
+export OVNK_COMMIT=c77ee8c38c6a6d9e55131a1272db5fad5b606e44
+
+OVNK_REPO='https://github.com/ovn-org/ovn-kubernetes.git'
+CLUSTER_PATH=${CLUSTER_PATH:-"${KUBEVIRTCI_CONFIG_PATH}/${KUBEVIRT_PROVIDER}/_ovnk"}
+
+function cluster::_get_repo() {
+    git --git-dir ${CLUSTER_PATH}/.git config --get remote.origin.url
+}
+
+function cluster::_get_sha() {
+    git --git-dir ${CLUSTER_PATH}/.git rev-parse HEAD
+}
+
+function cluster::install() {
+    if [ -d ${CLUSTER_PATH} ]; then
+        if [ $(cluster::_get_repo) != ${OVNK_REPO} -o $(cluster::_get_sha) != ${OVNK_COMMIT} ]; then
+            rm -rf ${CLUSTER_PATH}
+        fi
+    fi
+
+    if [ ! -d ${CLUSTER_PATH} ]; then
+        git clone ${OVNK_REPO} ${CLUSTER_PATH}
+        (
+            cd ${CLUSTER_PATH}
+            git checkout ${OVNK_COMMIT}
+        )
+    fi
+}

--- a/cluster-up/cluster/kind-ovn/provider.sh
+++ b/cluster-up/cluster/kind-ovn/provider.sh
@@ -1,0 +1,88 @@
+#!/bin/bash -ex
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2024 Red Hat, Inc.
+#
+
+KIND_VERSION=0.19.0
+export KIND_IMAGE=kindest/node
+export K8S_VERSION=v1.28.0@sha256:dad5a6238c5e41d7cac405fae3b5eda2ad1de6f1190fa8bfc64ff5bb86173213
+
+KIND_PATH=${KIND_PATH:-"${KUBEVIRTCI_CONFIG_PATH}/${KUBEVIRT_PROVIDER}/_kind"}
+CLUSTER_PATH=${CLUSTER_PATH:-"${KUBEVIRTCI_CONFIG_PATH}/${KUBEVIRT_PROVIDER}/_ovnk"}
+CLUSTER_NAME=${KUBEVIRT_PROVIDER}
+
+function calculate_mtu() {
+    overlay_overhead=58
+    current_mtu=$(cat /sys/class/net/$(ip route | grep "default via" | head -1 | awk '{print $5}')/mtu)
+    expr $current_mtu - $overlay_overhead
+}
+
+MTU=${MTU:-$(calculate_mtu)}
+
+PLATFORM=$(uname -m)
+case ${PLATFORM} in
+x86_64* | i?86_64* | amd64*)
+    ARCH="amd64"
+    ;;
+aarch64* | arm64*)
+    ARCH="arm64"
+    ;;
+*)
+    echo "invalid Arch, only support x86_64, aarch64"
+    exit 1
+    ;;
+esac
+
+function fetch_kind() {
+    mkdir -p $KIND_PATH
+    current_kind_version=$($KIND_PATH/kind --version |& awk '{print $3}')
+    if [[ $current_kind_version != $KIND_VERSION ]]; then
+        echo "Downloading kind v$KIND_VERSION"
+        curl -LSs https://github.com/kubernetes-sigs/kind/releases/download/v$KIND_VERSION/kind-linux-${ARCH} -o "$KIND_PATH/kind"
+        chmod +x "$KIND_PATH/kind"
+    fi
+    export PATH=$KIND_PATH:$PATH
+}
+
+function prepare_config() {
+    echo "STEP: Prepare provider config"
+    cat >$KUBEVIRTCI_CONFIG_PATH/$KUBEVIRT_PROVIDER/config-provider-$KUBEVIRT_PROVIDER.sh <<EOF
+master_ip=127.0.0.1
+kubeconfig=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+kubectl=kubectl
+docker_prefix=127.0.0.1:5000/kubevirt
+manifest_docker_prefix=localhost:5000/kubevirt
+EOF
+}
+
+function up() {
+    cluster::install
+    fetch_kind
+    pushd $CLUSTER_PATH/contrib ; ./kind.sh --cluster-name $CLUSTER_NAME --multi-network-enable -mtu $MTU --local-kind-registry --enable-interconnect; popd
+    cp ~/$CLUSTER_NAME.conf "${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig"
+    prepare_config
+}
+
+function down() {
+    kind delete cluster --name $CLUSTER_NAME
+}
+
+function _kubectl() {
+    export KUBECONFIG=$(./cluster-up/kubeconfig.sh)
+    kubectl "$@"
+}
+
+source ${KUBEVIRTCI_PATH}cluster/kind-ovn/install-ovn.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Provider allows running kubevirt with ovn-k8s tests on CI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
