### PR TITLE
publish: Use podman push instead of skopeo copy to push images

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -67,20 +67,18 @@ function build_clusters() {
 function push_node_base_image() {
   TARGET_IMAGE="${TARGET_REPO}/centos9:${KUBEVIRTCI_TAG}"
   echo "INFO: push $TARGET_IMAGE"
-  skopeo copy "docker-daemon:${TARGET_REPO}/centos9-base:latest" "docker://${TARGET_IMAGE}"
+  podman push "$TARGET_IMAGE"
   echo ${TARGET_IMAGE} > cluster-provision/k8s/base-image
 }
 
 function push_cluster_images() {
-  # until "unknown blob" issue is fixed use skopeo to push image
-  # see https://github.com/moby/moby/issues/43234
   for i in ${IMAGES_TO_BUILD[@]}; do
     echo "INFO: push $i"
     TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
-    skopeo copy "docker-daemon:${TARGET_IMAGE}" "docker://${TARGET_IMAGE}"
+    podman push "$TARGET_IMAGE"
 
     TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
-    skopeo copy "docker-daemon:${TARGET_IMAGE}" "docker://${TARGET_IMAGE}"
+    podman push "$TARGET_IMAGE"
   done
 
   # images that the change doesn't affect can be retagged from previous tag
@@ -94,7 +92,7 @@ function push_cluster_images() {
 function push_gocli() {
   echo "INFO: push gocli"
   TARGET_IMAGE="${TARGET_REPO}/gocli:${KUBEVIRTCI_TAG}"
-  skopeo copy "docker-daemon:${TARGET_IMAGE}" "docker://${TARGET_IMAGE}"
+  podman push "$TARGET_IMAGE"
 }
 
 function publish_node_base_image() {
@@ -117,9 +115,9 @@ function build_alpine_container_disk() {
 function push_alpine_container_disk() {
   echo "INFO: push alpine container disk"
   TARGET_IMAGE="${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}"
-  skopeo copy "docker-daemon:${TARGET_IMAGE}" "docker://${TARGET_IMAGE}"
+  podman push $TARGET_IMAGE
   TARGET_KUBEVIRT_IMAGE="${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel"
-  skopeo copy "docker-daemon:${TARGET_KUBEVIRT_IMAGE}" "docker://${TARGET_KUBEVIRT_IMAGE}"
+  podman push $TARGET_KUBEVIRT_IMAGE
 }
 
 function publish_alpine_container_disk() {


### PR DESCRIPTION

**What this PR does / why we need it**:

The publish postsubmit is no longer using docker to build and publish the kubevirtci images[1] so therefore the skopeo workaround is no longer required.

podman push is the simpler option to go for.

[1] https://github.com/kubevirt/project-infra/commit/1229020479c3317f8c8e68aa92fde2cb5cc0aec9

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
