### PR TITLE
publish,centos: Fix the image tag ahead of pushing the centos base image

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -66,8 +66,9 @@ function build_clusters() {
 
 function push_node_base_image() {
   TARGET_IMAGE="${TARGET_REPO}/centos9:${KUBEVIRTCI_TAG}"
+  podman tag ${TARGET_REPO}/centos9-base:latest ${TARGET_IMAGE}
   echo "INFO: push $TARGET_IMAGE"
-  podman push "$TARGET_IMAGE"
+  podman push ${TARGET_IMAGE}
   echo ${TARGET_IMAGE} > cluster-provision/k8s/base-image
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The publish of the centos base has been broken[1] since the move from `skopeo copy` to `podman push` [2]. 

The image needs to have the correct tag before it can be pushed.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-centos-base/1802914304081530880
[2] https://github.com/kubevirt/kubevirtci/pull/1200

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @xpivarc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
