### PR TITLE
enable vm-image-builder for s390x.

### DIFF
--- a/cluster-provision/images/vm-image-builder/README.md
+++ b/cluster-provision/images/vm-image-builder/README.md
@@ -26,6 +26,9 @@ The following RPM packages need to be present on your machine:
 To cross build for the Arm64 image on AMD64 machines, the following RPM needs to be installed:
 - qemu-system-aarch64
 
+To cross build for the s390x image on AMD64 machines, the following RPM needs to be installed:
+- qemu-system-s390x
+
 ## Quickstart: Build and publish an existing containerdisk
 
 Choose one of the configuration directories in this folder which you want to
@@ -49,6 +52,12 @@ variable.
 export ARCHITECTURE=arm64
 ```
 
+To build for s390x, you need to set the following environment
+variable.
+```
+export ARCHITECTURE=s390x
+``` 
+
 To build the Virtual Machine without console output, only need to set the
 environment variable `CONSOLE`. This is useful when the build script is
 run in a CICD pipeline.
@@ -66,6 +75,7 @@ $ ls -l example/
 cloud-config    # cloud-init configuration for virt-customize
 image-url       # download URL of the base image
 image-url-arm64 # download URL of the base image for Arm64
+image-url-s390x # download URL of the base image for s390x
 os-variant      # operating system variant (for example fedora32)
 ```
 
@@ -92,8 +102,8 @@ $ virtctl console testvm1
 ```
 
 ### Build and publish multi-arch images
-The multi-arch publish does not support building alpine-cloud-init because the [alpine-make-vm-image](https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image) project does not support building Arm64 images.
-The `publish-multiarch-containerdisk.sh` script now supports building Arm64 and AMD64 images.
+The multi-arch publish does not support building alpine-cloud-init because the [alpine-make-vm-image](https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image) project does not support building Arm64 and s390x images.
+The `publish-multiarch-containerdisk.sh` script now supports building Arm64, AMD64 and s390x images.
 The script primarily performs the following tasks:
 1. Use `create-containerdisk.sh` to build images.
 2. Upload the resulting images to a specific registry.
@@ -115,9 +125,9 @@ The script primarily performs the following tasks:
 ./ publish-multiarch-containerdisk.sh example myregistry registry_org
 
 # The script will do following things:
-# 1. Build both Arm64 and AMD64 example image.
+# 1. Build the Arm64,AMD64 and s390x example image.
 # 2. Generate a tag based on the current time.
-# 3. Push the registry_org/myregistry/example:tag-arm64 and registry_org/myregistry/example:tag-amd64.
+# 3. Push the registry_org/myregistry/example:tag-arm64,registry_org/myregistry/example:tag-amd64 and registry_org/myregistry/example:tag-s390x
 # 4. Generate a multi-arch manifest for the image, registry_org/myregistry/example:tag.
 ```
 

--- a/cluster-provision/images/vm-image-builder/common.sh
+++ b/cluster-provision/images/vm-image-builder/common.sh
@@ -10,6 +10,9 @@ go_style_arch_name() {
     aarch64|arm64)
         echo "arm64"
         ;;
+    s390x)
+        echo "s390x"
+        ;;
     *)
         echo "ERROR: invalid Arch, ${arch}"
         exit 1
@@ -26,6 +29,9 @@ linux_style_arch_name() {
         ;;
     aarch64|arm64)
         echo "aarch64"
+        ;;
+    s390x)
+        echo "s390x"
         ;;
     *)
         echo "ERROR: invalid Arch, ${arch}"

--- a/cluster-provision/images/vm-image-builder/example/image-url-s390x
+++ b/cluster-provision/images/vm-image-builder/example/image-url-s390x
@@ -1,0 +1,1 @@
+https://archives.fedoraproject.org/pub/fedora-secondary/releases/39/Cloud/s390x/images/Fedora-Cloud-Base-39-1.5.s390x.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url-s390x
+++ b/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url-s390x
@@ -1,0 +1,1 @@
+https://archives.fedoraproject.org/pub/fedora-secondary/releases/39/Cloud/s390x/images/Fedora-Cloud-Base-39-1.5.s390x.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-realtime/image-url-s390x
+++ b/cluster-provision/images/vm-image-builder/fedora-realtime/image-url-s390x
@@ -1,0 +1,1 @@
+https://archives.fedoraproject.org/pub/fedora-secondary/releases/39/Cloud/s390x/images/Fedora-Cloud-Base-39-1.5.s390x.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -46,7 +46,7 @@ runcmd:
   - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng dmidecode virt-what vm-dump-metrics tpm2-tools nc sg3_utils iperf3 wget
   # Download the busybox netcat and relpace it with the OpenBSD netcat
   # To align with the netcat tool used in the Alpine image for network e2e testing
-  - if [ $(uname -m) == "aarch64" ]; then export CPUARCH="armv8l"; else export CPUARCH="x86_64"; fi
+  - if [ $(uname -m) == "aarch64" ]; then export CPUARCH="armv8l"; elif [ $(uname -m) == "s390x" ]; then export CPUARCH="s390x"; else export CPUARCH="x86_64"; fi
   - sudo wget https://busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-${CPUARCH}
   - sudo chmod +x busybox-${CPUARCH}
   - sudo mv /usr/bin/nc /usr/bin/netcat-openbsd

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-s390x
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-s390x
@@ -1,0 +1,1 @@
+https://archives.fedoraproject.org/pub/fedora-secondary/releases/39/Cloud/s390x/images/Fedora-Cloud-Base-39-1.5.s390x.qcow2

--- a/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
@@ -3,7 +3,7 @@ set -exuo pipefail
 
 SCRIPT_PATH=$(dirname "$(realpath "$0")")
 source ${SCRIPT_PATH}/common.sh
-archs=(amd64 arm64)
+archs=(amd64 arm64 s390x)
 
 main() {
     local build_only=""


### PR DESCRIPTION
Currently the fedora-test-tooling and fedora-Realtime images are used in e2e testing.
 I want to add the s390x support for these images. So that we can enable kubevirt e2e testing for s390x.  
The alpine cloud-init is not supported for s390x as this https://[raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image](https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image) is not supported on s390x. 
I have also raised the issue https://github.com/alpinelinux/alpine-make-vm-image/issues/43 but there is no response on this yet