### PR TITLE
CPUManager configuration cleanup

### DIFF
--- a/cluster-provision/k8s/1.28/nodes.sh
+++ b/cluster-provision/k8s/1.28/nodes.sh
@@ -51,11 +51,11 @@ done
 if [ -f /etc/sysconfig/kubelet ]; then
     # TODO use config file! this is deprecated
     cat <<EOT >>/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --fail-swap-on=false ${nodeip} --feature-gates=CPUManager=true,NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m
+KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --fail-swap-on=false ${nodeip} --feature-gates=NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m
 EOT
 else
     cat <<EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf
-Environment="KUBELET_CPUMANAGER_ARGS=--fail-swap-on=false --feature-gates=CPUManager=true,NodeSwap=true ${nodeip} --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m"
+Environment="KUBELET_CPUMANAGER_ARGS=--fail-swap-on=false --feature-gates=NodeSwap=true ${nodeip} --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m"
 EOT
 sed -i 's/$KUBELET_EXTRA_ARGS/$KUBELET_EXTRA_ARGS $KUBELET_CPUMANAGER_ARGS/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 fi

--- a/cluster-provision/k8s/1.28/nodes.sh
+++ b/cluster-provision/k8s/1.28/nodes.sh
@@ -48,7 +48,7 @@ do
     sleep 2
 done
 
-if [ -f /etc/sysconfig/kubelet ]; then
+if [ -f /etc/sysconfig/kubelet && ${KUBEVIRT_CPU_MANAGER_POLICY} == "static"]; then
     # TODO use config file! this is deprecated
     cat <<EOT >>/etc/sysconfig/kubelet
 KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --fail-swap-on=false ${nodeip} --feature-gates=NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m

--- a/cluster-provision/k8s/1.29/nodes.sh
+++ b/cluster-provision/k8s/1.29/nodes.sh
@@ -51,11 +51,11 @@ done
 if [ -f /etc/sysconfig/kubelet ]; then
     # TODO use config file! this is deprecated
     cat <<EOT >>/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --fail-swap-on=false ${nodeip} --feature-gates=CPUManager=true,NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m
+KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --fail-swap-on=false ${nodeip} --feature-gates=NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m
 EOT
 else
     cat <<EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf
-Environment="KUBELET_CPUMANAGER_ARGS=--fail-swap-on=false --feature-gates=CPUManager=true,NodeSwap=true ${nodeip} --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m"
+Environment="KUBELET_CPUMANAGER_ARGS=--fail-swap-on=false --feature-gates=NodeSwap=true ${nodeip} --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m"
 EOT
 sed -i 's/$KUBELET_EXTRA_ARGS/$KUBELET_EXTRA_ARGS $KUBELET_CPUMANAGER_ARGS/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 fi

--- a/cluster-provision/k8s/1.29/nodes.sh
+++ b/cluster-provision/k8s/1.29/nodes.sh
@@ -48,7 +48,7 @@ do
     sleep 2
 done
 
-if [ -f /etc/sysconfig/kubelet ]; then
+if [ -f /etc/sysconfig/kubelet && ${KUBEVIRT_CPU_MANAGER_POLICY} == "static" ]; then
     # TODO use config file! this is deprecated
     cat <<EOT >>/etc/sysconfig/kubelet
 KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --fail-swap-on=false ${nodeip} --feature-gates=NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m

--- a/cluster-provision/k8s/1.30/nodes.sh
+++ b/cluster-provision/k8s/1.30/nodes.sh
@@ -48,7 +48,7 @@ do
     sleep 2
 done
 
-if [ -f /etc/sysconfig/kubelet ]; then
+if [ -f /etc/sysconfig/kubelet && ${KUBEVIRT_CPU_MANAGER_POLICY} == "static" ]; then
     # TODO use config file! this is deprecated
     cat <<EOT >>/etc/sysconfig/kubelet
 KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --fail-swap-on=false ${nodeip} --feature-gates=NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m

--- a/cluster-provision/k8s/1.30/nodes.sh
+++ b/cluster-provision/k8s/1.30/nodes.sh
@@ -51,11 +51,11 @@ done
 if [ -f /etc/sysconfig/kubelet ]; then
     # TODO use config file! this is deprecated
     cat <<EOT >>/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --fail-swap-on=false ${nodeip} --feature-gates=CPUManager=true,NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
+KUBELET_EXTRA_ARGS=${KUBELET_CGROUP_ARGS} --fail-swap-on=false ${nodeip} --feature-gates=NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m
 EOT
 else
     cat <<EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf
-Environment="KUBELET_CPUMANAGER_ARGS=--fail-swap-on=false --feature-gates=CPUManager=true,NodeSwap=true ${nodeip} --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m"
+Environment="KUBELET_CPUMANAGER_ARGS=--fail-swap-on=false --feature-gates=NodeSwap=true ${nodeip} --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m"
 EOT
 sed -i 's/$KUBELET_EXTRA_ARGS/$KUBELET_EXTRA_ARGS $KUBELET_CPUMANAGER_ARGS/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 fi

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -204,23 +204,6 @@ function wait_for_kwok_ready() {
     fi
 }
 
-function configure_cpu_manager() {
-    if [ ${KUBEVIRT_CPU_MANAGER_POLICY} == "static" ]; then
-        for node in $($kubectl get nodes -l "node-role.kubernetes.io/worker" --no-headers -o custom-columns=":metadata.name" | tr -d '\r'); do
-            # FIXME Replace with kubelet config drop ins once all providers are using k8s >= 1.28
-            # https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/#kubelet-conf-d
-            $kubectl drain ${node}
-            $ssh ${node} -- sudo systemctl stop kubelet
-            # FIXME ${ssh} is broken when using HereDocs, fix and replace this mess if possible.
-            # https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#configuration
-            $ssh ${node} -- "sudo rm -f /var/lib/kubelet/cpu_manager_state && sudo echo -e 'cpuManagerPolicy: static\nkubeReserved:\n  cpu: \"1\"\n memory: \"1Gi\"\ncpuManagerPolicyOptions:\n  full-pcpus-only: \"true\"' | sudo tee -a /var/lib/kubelet/config.yaml && sudo sed -i 's/cpuManagerReconcilePeriod\:\ 0s/cpuManagerReconcilePeriod\:\ 5s/g' /var/lib/kubelet/config.yaml"
-            $ssh ${node} -- sudo systemctl start kubelet
-            $kubectl label --overwrite node/${node} cpumanager=true
-            $kubectl uncordon ${node}
-        done
-    fi
-}
-
 function up() {
     params=$(_add_common_params)
     if echo "$params" | grep -q ERROR; then
@@ -262,7 +245,6 @@ function up() {
 
     configure_prometheus
     configure_memory_overcommitment_behavior
-    configure_cpu_manager
 
     deploy_cnao
     deploy_multus

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -263,7 +263,6 @@ function _add_kubeadm_cpu_manager_config_patch() {
     kind: JoinConfiguration
     nodeRegistration:
       kubeletExtraArgs:
-        "feature-gates": "CPUManager=true"
         "cpu-manager-policy": "static"
         "kube-reserved": "cpu=500m"
         "system-reserved": "cpu=500m"


### PR DESCRIPTION
/hold

**What this PR does / why we need it**:

075a40f0ea4ce9f3b12a7e2ded8220707f73a9a5 mistakenly duplicated existing node configuration for `CPUManager` that is carried out before a worker joins the cluster. This PR removes the duplication while retaining the `KUBEVIRT_CPU_MANAGER_POLICY` env to control deployment of `CPUManager`.

Other TODOs and cleanups of the code are also included.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
