### PR TITLE
added kubectl env variable to external provider.sh

### DIFF
--- a/cluster-up/cluster/external/provider.sh
+++ b/cluster-up/cluster/external/provider.sh
@@ -22,6 +22,15 @@ manifest_docker_prefix=\${DOCKER_PREFIX}
 image_pull_policy=\${IMAGE_PULL_POLICY:-Always}
 EOF
 
+    if [ -n "$KUBECTL" ]; then
+       echo "kubectl=${KUBECTL}" >> "$PROVIDER_CONFIG_FILE_PATH"
+    else
+       if which kubectl; then
+          echo "kubectl=$(which kubectl)" >> "$PROVIDER_CONFIG_FILE_PATH"
+       fi 
+    fi
+
+
     if which oc; then
         echo "oc=$(which oc)" >> "$PROVIDER_CONFIG_FILE_PATH"
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
For external cluster provider The --kubectl-path here https://github.com/kubevirt/kubevirt/blob/main/hack/functests.sh#L69 is getting set as empty. The reason for this behaviour is unlike k8s providers where the kubectl binary will be scp' ed from control node https://github.com/kubevirt/kubevirt/blob/main/cluster-up/cluster/k8s-provider-common.sh#L244, the external cluster don't have this capability. So, we have to manually export the env with KUBECTL variable. So, In order to set this env variable while running test, we have to source the KUBECTL env to provider config.

Why Iam doing this?
There are some of the tests which need kubectl binary to execute and display the result when run on external cluster.  As a result, this kind of behaviour is seen when the --kubectl-path is set as empty.
Before Result:
`

Ran 0 of 1569 Specs in 288.463 seconds
SUCCESS! -- 0 Passed | 0 Failed | 3 Pending | 1566 Skipped
PASS

Ginkgo ran 1 suite in 4m51.561813014s
Test Suite Passed
`
After the changes:

`

Ran 34 of 1569 Specs in 456.025 seconds
SUCCESS! -- 34 Passed | 0 Failed | 3 Pending | 1532 Skipped
PASS

Ginkgo ran 1 suite in 7m39.205318123s
Test Suite Passed
`
This is the test that was run.
https://github.com/kubevirt/kubevirt/blob/main/tests/access_test.go#L162

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
    NONE

```
