### PR TITLE
etcd: Add tuning to etcd disk priority to improve performance

### DIFF
--- a/cluster-provision/k8s/1.28/node01.sh
+++ b/cluster-provision/k8s/1.28/node01.sh
@@ -83,6 +83,10 @@ while [[ $retry_counter -lt 20 && $kubectl_rc -ne 0 ]]; do
     retry_counter=$((retry_counter + 1))
 done
 
+# Increase etcd's disk priority as suggested in the tuning guide
+# https://etcd.io/docs/v3.2/tuning/#disk
+sudo ionice -c2 -n0 -p `pgrep etcd`
+
 echo "Printing kuberenetes version"
 kubectl --kubeconfig=/etc/kubernetes/admin.conf version
 

--- a/cluster-provision/k8s/1.29/node01.sh
+++ b/cluster-provision/k8s/1.29/node01.sh
@@ -83,6 +83,10 @@ while [[ $retry_counter -lt 20 && $kubectl_rc -ne 0 ]]; do
     retry_counter=$((retry_counter + 1))
 done
 
+# Increase etcd's disk priority as suggested in the tuning guide
+# https://etcd.io/docs/v3.2/tuning/#disk
+sudo ionice -c2 -n0 -p `pgrep etcd`
+
 echo "Printing kuberenetes version"
 kubectl --kubeconfig=/etc/kubernetes/admin.conf version
 

--- a/cluster-provision/k8s/1.30/node01.sh
+++ b/cluster-provision/k8s/1.30/node01.sh
@@ -83,6 +83,10 @@ while [[ $retry_counter -lt 20 && $kubectl_rc -ne 0 ]]; do
     retry_counter=$((retry_counter + 1))
 done
 
+# Increase etcd's disk priority as suggested in the tuning guide
+# https://etcd.io/docs/v3.2/tuning/#disk
+sudo ionice -c2 -n0 -p `pgrep etcd`
+
 echo "Printing kuberenetes version"
 kubectl --kubeconfig=/etc/kubernetes/admin.conf version
 

--- a/cluster-provision/k8s/1.31/node01.sh
+++ b/cluster-provision/k8s/1.31/node01.sh
@@ -83,6 +83,10 @@ while [[ $retry_counter -lt 20 && $kubectl_rc -ne 0 ]]; do
     retry_counter=$((retry_counter + 1))
 done
 
+# Increase etcd's disk priority as suggested in the tuning guide
+# https://etcd.io/docs/v3.2/tuning/#disk
+sudo ionice -c2 -n0 -p `pgrep etcd`
+
 echo "Printing kuberenetes version"
 kubectl --kubeconfig=/etc/kubernetes/admin.conf version
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It is suggested in the etcd tuning guide[1] that the disk priority for etcd be raised to ensure a certain level of performance. The guide suggests that this can help with avoiding etcd timeouts which are seen in a few of the e2e lanes[2].

[1] https://etcd.io/docs/v3.2/tuning/#disk
[2] https://search.ci.kubevirt.io/?search=etcdserver%3A+request+timed+out&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @akalenyu @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
