### PR TITLE
Change vagrant box source of centos9 to generic cloud image

### DIFF
--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -19,6 +19,7 @@ RUN curl -LO https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_V
   && chmod u+x dockerize \
   && mv dockerize /usr/local/bin/
 
+#TODO: Replace vagrant box image with generic cloud image which is already in qcow2 image than converting. ie., same way as it is (or will be) done for s390x
 COPY scripts/download_box.sh /
 
 RUN echo "Centos9 version $centos_version"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently centos9, which is the base disk image used for creating nodes in k8s providers, is vagrant box type. So to be usable with qemu-system, this is converted to qcow2 and later used. As generic cloud image (in qcow2 format) already exists in centos9 mirror, where we download centos9 images from, we can directly use that, as we are doing that in PR where we are adding s390x support in providers. This requires removing the conversion from box to qcow2 format and replacing vagrant user with cloud-user whereever required.
**Note: This PR is just a placeholder for now, so the draft PR**

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
For KubeVirt developers: The provider nodes now use a new user called cloud-user than earlier user vagrant.
-->
```release-note

```
