### PR TITLE
k8s-1.30: Enable feature-gate of DRA alpha feature

### DIFF
--- a/cluster-provision/k8s/1.30/manifests/kubeadm.conf
+++ b/cluster-provision/k8s/1.30/manifests/kubeadm.conf
@@ -19,6 +19,8 @@ apiServer:
     audit-policy-file: /etc/kubernetes/audit/adv-audit.yaml
     enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
     admission-control-config-file: /etc/kubernetes/psa.yaml
+    feature-gates: DynamicResourceAllocation=true
+    runtime-config: resource.k8s.io/v1alpha2=true
   extraVolumes:
   - hostPath: /etc/kubernetes/psa.yaml
     mountPath: /etc/kubernetes/psa.yaml
@@ -37,6 +39,10 @@ clusterName: kubernetes
 controllerManager:
   extraArgs:
     node-cidr-mask-size-ipv6: "116"
+    feature-gates: DynamicResourceAllocation=true
+scheduler:
+  extraArgs:
+    feature-gates: DynamicResourceAllocation=true
 etcd:
   local:
     dataDir: /var/lib/etcd
@@ -52,3 +58,8 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clusterCIDR: 10.244.0.0/16,fd10:244::/112
 mode: iptables
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+featureGates:
+  DynamicResourceAllocation: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This is related to ongoing projects to test Dynamic Resource Allocation (DRA) in KubeVirt:

https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/

I'm enabling it in k8s-1.30 as per ongoing PCI passthrough driver developed by Sibasish Behera as part of his GSoC 2024 project, see:

https://github.com/kubevirt/dra-pci-driver

**Special notes for your reviewer**:

This patch mimics what was being done by hand in the dra-pci-driver, described [here](https://github.com/TheRealSibasishBehera/dra-pci-driver/blob/main/doc/KV_SETUP.md#step-2-enable-dynamic-resource-allocation)

I validated that it worked by [checking](https://github.com/TheRealSibasishBehera/dra-pci-driver/blob/main/doc/KV_SETUP.md#step-3-verification-for-resource-api) `resourceclasses` exist within this image.

When the Node is up:

```
toso@tapioca ~/s/k/kubevirt (main)> cluster-up/kubectl.sh get resourceclasses
selecting docker as container runtime
No resources found
```

After installing `dra-pci-driver`

```
toso@tapioca ~/s/k/kubevirt (main)> cluster-up/kubectl.sh get resourceclasses
selecting docker as container runtime
NAME              DRIVERNAME                 AGE
pci.kubevirt.io   pci.resource.kubevirt.io   4m23s
```


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable  Dynamic Resource Allocation (DRA) Alpha feature in k8s-1.30
```
