### PR TITLE
K8s 1.30 provider slim s390x

### DIFF
--- a/K8S.md
+++ b/K8S.md
@@ -48,13 +48,14 @@ make cluster-up
 # Attach to node01 console                           
 docker exec -it ${KUBEVIRT_PROVIDER}-node01 screen /dev/pts/0
 ```                                                 
-Use `vagrant:vagrant` to login.  
+Use `vagrant:vagrant` for x86 and root:root for s390x to login.
 Note: it is sometimes `/dev/pts/1` or `/dev/pts/2`, try them in case you don't get a prompt.
 
 Make sure you don't leave open screens, else the next screen will be messed up.  
 `screen -ls` shows the open screens.  
-`screen -XS <ID> quit` closes an open session.  
+`screen -XS <session-id> quit` closes an open session.
 Close all zombies and shutdown screen gracefully if you plan to open a new one instead.
+Ctrl+A and Ctrl+D will detach your screen session and `screen -r <session-id>` reattach to a detached screen session.
 
 ## Container image cache
 In order to have a local cache of container images:

--- a/KUBEVIRTCI_LOCAL_TESTING.md
+++ b/KUBEVIRTCI_LOCAL_TESTING.md
@@ -21,7 +21,7 @@ cd $KUBEVIRTCI_DIR
 
 ```bash
 # Build a provider. This includes starting it with cluster-up for verification and shutting it down for cleanup.
-(cd cluster-provision/k8s/1.27; ../provision.sh)
+(cd cluster-provision/k8s/1.30; ../provision.sh)
 ```
 
 Note: 
@@ -34,7 +34,7 @@ please use `export BYPASS_PMAN_CHANGE_CHECK=true` to bypass provision-manager ch
 # set local provision test flag (mandatory)
 export KUBEVIRTCI_PROVISION_CHECK=1
 ```
-
+This ensures to set container-registry to quay.io and container-suffix to :latest
 If `KUBEVIRTCI_PROVISION_CHECK` is not used,
 you can set `KUBEVIRTCI_CONTAINER_REGISTRY` (default: `quay.io`), `KUBEVIRTCI_CONTAINER_ORG` (default: `kubevirtci`) and `KUBEVIRTCI_CONTAINER_SUFFIX` (default: according gocli tag),
 in order to use a custom image.
@@ -134,12 +134,16 @@ For that we have phased mode.
 Usage: export the required mode, i.e `export PHASES=linux` or `export PHASES=k8s`
 and then run the provision. the full flow will be:
 
-`export PHASES=linux; (cd cluster-provision/k8s/1.21; ../provision.sh)`  
-`export PHASES=k8s; (cd cluster-provision/k8s/1.21; ../provision.sh)`  
+`export PHASES=linux; (cd cluster-provision/k8s/1.30; ../provision.sh)`  
+`export PHASES=k8s; (cd cluster-provision/k8s/1.30; ../provision.sh)`  
 Run the `k8s` step as much as needed. It reuses the intermediate image that was created
-by the `linux` phase.  
+by the `linux` phase.
+Note :
+1. By default when you run `k8s` phase alone, it uses centos9 image specified in cluster-provision/k8s/base-image, not the one built locally in the `linux` phase. So, to make `k8s` phase use the locally built centos9 image, update cluster-provision/k8s/base-image with the locally built image name and tag (default: quay.io/kubevirtci/centos9:latest)
+2. Also note if you run both `linux,k8s` phases, then it doesn't save the intermediate container image generated post linux image. So, for the centos9 image required for k8s stage, you've to run the linux phase alone.
+
 Once you are done, either check the cluster manually, or use:  
-`export PHASES=k8s; export CHECK_CLUSTER=true; (cd cluster-provision/k8s/1.21; ../provision.sh)`
+`export PHASES=k8s; export CHECK_CLUSTER=true; (cd cluster-provision/k8s/1.30; ../provision.sh)`
 
 ### provision without pre-pulling images
 

--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -1,33 +1,56 @@
+FROM quay.io/fedora/fedora:39 AS base
 
-FROM quay.io/kubevirtci/fedora@sha256:e3a6087f62f288571db14defb7e0e10ad7fe6f973f567b0488d3aac5e927035a
+RUN dnf -y install jq iptables iproute dnsmasq qemu socat openssh-clients screen bind-utils tcpdump iputils libguestfs-tools-c && dnf clean all
+
+
+FROM base AS imageartifactdownload
+
+ARG BUILDARCH
 
 ARG centos_version
 
-RUN dnf -y install jq iptables iproute dnsmasq qemu openssh-clients screen bind-utils tcpdump iputils && dnf clean all
+WORKDIR /
 
+RUN echo "Centos9 version $centos_version"
+
+COPY scripts/download_box.sh /
+
+RUN if test "$BUILDARCH" != "s390x"; then \
+      /download_box.sh https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-$centos_version.x86_64.vagrant-libvirt.box && \
+      curl -L -o /initramfs-amd64.img http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/images/pxeboot/initrd.img && \
+      curl -L -o /vmlinuz-amd64 http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz; \
+    else \
+      /download_box.sh https://cloud.centos.org/centos/9-stream/s390x/images/CentOS-Stream-GenericCloud-9-$centos_version.s390x.qcow2 && \
+      # Access virtual machine disk images directly by using LIBGUESTFS_BACKEND=direct, instead of libvirt
+      export LIBGUESTFS_BACKEND=direct && \
+      guestfish --ro --add box.qcow2 --mount /dev/sda1:/ ls /boot/ | grep -E '^vmlinuz-|^initramfs-' | xargs -I {} guestfish --ro --add box.qcow2 -i copy-out /boot/{} / ; \
+    fi
+
+
+FROM base AS nodecontainer
+
+ARG BUILDARCH
+       
 WORKDIR /
 
 COPY vagrant.key /vagrant.key
 
 RUN chmod 700 vagrant.key
 
-ENV DOCKERIZE_VERSION v0.6.1
+ENV DOCKERIZE_VERSION=v0.8.0
 
-RUN curl -LO https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-  && tar -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-  && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-  && chmod u+x dockerize \
-  && mv dockerize /usr/local/bin/
+RUN if test "$BUILDARCH" != "s390x"; then \
+      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
+    else \
+      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-s390x-$DOCKERIZE_VERSION.tar.gz; \
+    fi && \
+    tar -xzvf dockerize-linux-$BUILDARCH.tar.gz && \
+    rm dockerize-linux-$BUILDARCH.tar.gz && \
+    chmod u+x dockerize && \
+    mv dockerize /usr/local/bin/
 
-COPY scripts/download_box.sh /
-
-RUN echo "Centos9 version $centos_version"
-
-ENV CENTOS_URL https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-$centos_version.x86_64.vagrant-libvirt.box
-
-RUN /download_box.sh ${CENTOS_URL}
-
-RUN curl -L -o /initrd.img http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/images/pxeboot/initrd.img
-RUN curl -L -o /vmlinuz http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz
+COPY --from=imageartifactdownload /box.qcow2 box.qcow2
+COPY --from=imageartifactdownload /vmlinuz-* /vmlinuz
+COPY --from=imageartifactdownload /initramfs-* /initrd.img
 
 COPY scripts/* /

--- a/cluster-provision/centos9/build.sh
+++ b/cluster-provision/centos9/build.sh
@@ -4,4 +4,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 centos_version="$(cat $DIR/version | tr -d '\n')"
 
-docker build --build-arg centos_version=$centos_version . -t quay.io/kubevirtci/centos9
+docker build --build-arg BUILDARCH=$(uname -m) --build-arg centos_version=$centos_version . -t quay.io/kubevirtci/centos9

--- a/cluster-provision/centos9/scripts/download_box.sh
+++ b/cluster-provision/centos9/scripts/download_box.sh
@@ -3,6 +3,13 @@
 set -e
 set -o pipefail
 
-curl -L $1 | tar -zxvf - box.img
-qemu-img convert -O qcow2 box.img box.qcow2
-rm box.img
+ARCH=$(uname -m)
+
+#For the s390x architecture, instead of vagrant box image, generic cloud (qcow2) image is used directly.
+if [ "$ARCH" == "s390x" ]; then
+    curl -L $1 -o box.qcow2
+else
+    curl -L $1 | tar -zxvf - box.img
+    qemu-img convert -O qcow2 box.img box.qcow2
+    rm box.img
+fi

--- a/cluster-provision/centos9/scripts/kernel.s390x.args
+++ b/cluster-provision/centos9/scripts/kernel.s390x.args
@@ -1,0 +1,1 @@
+root=/dev/vda1 ro no_timer_check console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M

--- a/cluster-provision/gocli/Makefile
+++ b/cluster-provision/gocli/Makefile
@@ -2,6 +2,7 @@ SHELL := /bin/bash
 
 IMAGES_FILE ?= images.json
 KUBEVIRTCI_IMAGE_REPO ?= quay.io/kubevirtci
+GOARCH ?= $$(uname -m | grep -q s390x && echo s390x || echo amd64)
 
 export GO111MODULE=on
 export GOPROXY=direct
@@ -23,7 +24,7 @@ test-gocli:
 
 .PHONY: gocli
 cli:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -ldflags "-X 'kubevirt.io/kubevirtci/cluster-provision/gocli/images.SUFFIX=:$(KUBEVIRTCI_TAG)'" -o $(BIN_DIR)/cli ./cmd/cli
+	CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} $(GO) build -ldflags "-X 'kubevirt.io/kubevirtci/cluster-provision/gocli/images.SUFFIX=:$(KUBEVIRTCI_TAG)'" -o $(BIN_DIR)/cli ./cmd/cli
 .PHONY: fmt
 fmt:
 	$(GO) fmt ./cmd/...

--- a/cluster-provision/gocli/cmd/scp.go
+++ b/cluster-provision/gocli/cmd/scp.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"context"
 	"os"
+	"runtime"
 
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/utils"
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/docker"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/libssh"
 
 	"bytes"
 	"fmt"
@@ -56,8 +58,9 @@ func NewSCPCommand() *cobra.Command {
 		Args:  cobra.MinimumNArgs(2),
 	}
 
+	sshUser := libssh.GetUserByArchitecture(runtime.GOARCH)
 	ssh.Flags().String("container-name", "dnsmasq", "the container name to SSH copy from")
-	ssh.Flags().String("ssh-user", "vagrant", "the user that used to connect via SSH to the node")
+	ssh.Flags().String("ssh-user", sshUser, "the user that used to connect via SSH to the node")
 
 	return ssh
 }

--- a/cluster-provision/gocli/cmd/utils/images.go
+++ b/cluster-provision/gocli/cmd/utils/images.go
@@ -4,5 +4,5 @@ const (
 	// NFSGaneshaImage contains the reference to NFS docker image
 	NFSGaneshaImage = "docker.io/janeczku/nfs-ganesha@sha256:17fe1813fd20d9fdfa497a26c8a2e39dd49748cd39dbb0559df7627d9bcf4c53"
 	// DockerRegistryImage contains the reference to docker registry docker image
-	DockerRegistryImage = "quay.io/libpod/registry:2.7"
+	DockerRegistryImage = "quay.io/libpod/registry:2.8.2"
 )

--- a/cluster-provision/gocli/opts/node01/node01.go
+++ b/cluster-provision/gocli/opts/node01/node01.go
@@ -3,6 +3,7 @@ package node01
 import (
 	_ "embed"
 	"fmt"
+	"runtime"
 
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/libssh"
 )
@@ -44,7 +45,7 @@ func (n *node01Provisioner) Exec() error {
 	}
 
 	cmds := []string{
-		`if [ -f /home/vagrant/enable_audit ]; then echo '` + string(advAudit) + `' | tee /etc/kubernetes/audit/adv-audit.yaml > /dev/null; fi`,
+		`if [ -f /home/` + libssh.GetUserByArchitecture(runtime.GOARCH) + `/enable_audit ]; then echo '` + string(advAudit) + `' | tee /etc/kubernetes/audit/adv-audit.yaml > /dev/null; fi`,
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
 		"swapoff -a",
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",

--- a/cluster-provision/gocli/opts/nodes/testconfig.go
+++ b/cluster-provision/gocli/opts/nodes/testconfig.go
@@ -6,7 +6,7 @@ func AddExpectCalls(sshClient *kubevirtcimocks.MockSSHClient) {
 	cmds := []string{
 		"source /var/lib/kubevirtci/shared_vars.sh",
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
-		`echo "KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --fail-swap-on=false  --feature-gates=CPUManager=true,NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m" | tee /etc/sysconfig/kubelet > /dev/null`,
+		`echo "KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --fail-swap-on=false  --feature-gates=NodeSwap=true,CPUManager=true --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m" | tee /etc/sysconfig/kubelet > /dev/null`,
 		"systemctl daemon-reload &&  service kubelet restart",
 		"swapoff -a",
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",

--- a/cluster-provision/gocli/pkg/libssh/ssh.go
+++ b/cluster-provision/gocli/pkg/libssh/ssh.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"runtime"
 
 	"github.com/bramvdbogaerde/go-scp"
 	"github.com/sirupsen/logrus"
@@ -44,7 +45,7 @@ func NewSSHClient(port uint16, idx int, root bool) (*SSHClientImpl, error) {
 	if err != nil {
 		return nil, err
 	}
-	u := "vagrant"
+	u := GetUserByArchitecture(runtime.GOARCH)
 	if root {
 		u = "root"
 	}
@@ -62,6 +63,13 @@ func NewSSHClient(port uint16, idx int, root bool) (*SSHClientImpl, error) {
 		initMutex: sync.Mutex{},
 		nodeIdx:   idx,
 	}, nil
+}
+
+func GetUserByArchitecture(arch string) string {
+	if arch == "s390x" {
+		return "cloud-user"
+	}
+	return "vagrant"
 }
 
 func (s *SSHClientImpl) Command(cmd string) error {

--- a/cluster-provision/k8s/1.30/k8s_provision.sh
+++ b/cluster-provision/k8s/1.30/k8s_provision.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+arch=$(uname -m)
+
 source /var/lib/kubevirtci/shared_vars.sh
 
 function getKubernetesClosestStableVersion() {
@@ -202,10 +204,13 @@ sysctl --system
 
 systemctl restart NetworkManager
 
-nmcli connection modify "System eth0" \
-   ipv6.method auto \
-   ipv6.addr-gen-mode eui64
-nmcli connection up "System eth0"
+# No need to modify the ethernet connection incase of s390x Architecture.
+if [ "$arch" != "s390x" ]; then
+  nmcli connection modify "System eth0" \
+    ipv6.method auto \
+    ipv6.addr-gen-mode eui64
+  nmcli connection up "System eth0"
+fi
 
 kubeadmn_patches_path="/provision/kubeadm-patches"
 mkdir -p $kubeadmn_patches_path

--- a/cluster-provision/k8s/1.30/provision.sh
+++ b/cluster-provision/k8s/1.30/provision.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+ARCH=$(uname -m)
+
 KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
 mkdir -p $KUBEVIRTCI_SHARED_DIR
 export ISTIO_VERSION=1.15.0
@@ -58,8 +60,16 @@ dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
 
-dnf install -y centos-release-nfv-openvswitch
-dnf install -y openvswitch2.16
+#openvswitch for s390x is not available from the centos default repos.
+if [ "$ARCH" == "s390x" ]; then
+  dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
+  systemctl enable openvswitch
+else
+  dnf install -y centos-release-nfv-openvswitch
+  dnf install -y openvswitch2.16
+fi 
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 
+# envsubst pkg is not available by default in s390x Architecture, so explicitly installing it as part of gettext
+dnf install -y gettext

--- a/cluster-provision/k8s/base-image
+++ b/cluster-provision/k8s/base-image
@@ -1,1 +1,1 @@
-quay.io/kubevirtci/centos9:2410290401-44a9432b
+quay.io/kubevirtci/centos9:2410291205-1fdde4bf

--- a/cluster-up/check.sh
+++ b/cluster-up/check.sh
@@ -26,12 +26,17 @@ fi
 
 KVM_ARCH=""
 KVM_NESTED="unknown"
+KVM_HPAGE="unknown"
 if [ -f "/sys/module/kvm_intel/parameters/nested" ]; then
 	KVM_NESTED=$( cat /sys/module/kvm_intel/parameters/nested )
 	KVM_ARCH="intel"
 elif [ -f "/sys/module/kvm_amd/parameters/nested" ]; then
 	KVM_NESTED=$( cat /sys/module/kvm_amd/parameters/nested )
 	KVM_ARCH="amd"
+elif [ -f "/sys/module/kvm/parameters/nested" ]; then
+	KVM_NESTED=$( cat /sys/module/kvm/parameters/nested )
+	KVM_ARCH="s390x"
+	KVM_HPAGE=$( cat /sys/module/kvm/parameters/hpage )
 fi
 
 function is_enabled() {
@@ -48,4 +53,8 @@ if is_enabled "$KVM_NESTED"; then
 	echo "[ OK ] $KVM_ARCH nested virtualization enabled"
 else
 	echo "[ERR ] $KVM_ARCH nested virtualization not enabled"
+fi
+
+if is_enabled "$KVM_HPAGE" && [ "$(uname -m)" = "s390x" ]; then
+	echo "[ERR ] $KVM_HPAGE KVM hugepage enabled. It needs to be disabled while nested virtualization is enabled for s390x"
 fi

--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -71,14 +71,8 @@ function up() {
     kubectl config set-cluster kubernetes --server="https://$(_main_ip):$(_port k8s)"
     kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
 
-    # Workaround https://github.com/containers/conmon/issues/315 by not dumping the file to stdout for the time being
-    if [[ ${_cri_bin} = podman* ]]; then
-        k8s_version=$(kubectl get node node01 --no-headers -o=custom-columns=VERSION:.status.nodeInfo.kubeletVersion)
-        curl -Ls "https://dl.k8s.io/release/${k8s_version}/bin/linux/amd64/kubectl" -o ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
-    else
-        ${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
-    fi
-
+    ${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    
     chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
 
     # Make sure that local config is correct

--- a/hack/conformance.sh
+++ b/hack/conformance.sh
@@ -2,6 +2,8 @@
 
 set -xeuo pipefail
 
+ARCH=$(uname -m | grep -q s390x && echo s390x || echo amd64)
+
 SCRIPT_PATH=$(dirname "$(realpath "$0")")
 
 ARTIFACTS=${ARTIFACTS:-${PWD}}
@@ -61,7 +63,7 @@ teardown() {
     fi
 }
 
-curl -L "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_version}/sonobuoy_${sonobuoy_version}_linux_amd64.tar.gz" | tar -xz
+curl -L "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_version}/sonobuoy_${sonobuoy_version}_linux_${ARCH}.tar.gz" | tar -xz
 
 trap teardown EXIT
 

--- a/hack/conformance.sh
+++ b/hack/conformance.sh
@@ -6,7 +6,8 @@ ARCH=$(uname -m | grep -q s390x && echo s390x || echo amd64)
 
 SCRIPT_PATH=$(dirname "$(realpath "$0")")
 
-ARTIFACTS=${ARTIFACTS:-${PWD}}
+ARTIFACTS=${ARTIFACTS:-${PWD}/artifacts}
+mkdir -p "$ARTIFACTS"
 
 config_file=${1:-}
 sonobuoy_version=0.56.9


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables s390x support in kubernetes provider 1.30.
This is required for running s390x based tests spinning a k8s cluster using k8s provider.

**Special notes for your reviewer**:
Earlier PR (created for 1.28 provider) whose comments are addressed in this PR: #1201 
Changes required in respective prow jobs to publish provider are in PR: [#3566](https://github.com/kubevirt/project-infra/pull/3566) 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:

```release-note
NONE
```
