### PR TITLE
fix: Remove extra slash in file path and remove unneeded sed

### DIFF
--- a/hack/bump-cdi.sh
+++ b/hack/bump-cdi.sh
@@ -42,7 +42,7 @@ if [ $# -gt 0 ]; then
 fi
 
 
-cdi_dir="./cluster-provision/gocli/opts/cdi/"
+cdi_dir="./cluster-provision/gocli/opts/cdi"
 
 if [ -d "$cdi_dir" ]; then
     # Execute the fetch-latest-cdi.sh script on the directory
@@ -52,13 +52,6 @@ if [ -d "$cdi_dir" ]; then
     else
         echo "Updated cdi manifests for $cdi_dir"
     fi
-
-    # Bump versions in the two files within the directory
-    for file in "$cdi_dir"/*; do
-        # Replace version numbers in the file (example: bumping from 1.0.0 to 1.1.0)
-        sed -i 's/1\.0\.0/1.1.0/g' "$file"
-    done
-
 else
     echo "Directory $cdi_dir does not exist."
     exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fix for: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-cdi/1828968549343825920

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
