### PR TITLE
gocli: Add retry to creating and starting dnsmasq container

### DIFF
--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -447,21 +447,36 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		}
 	}
 
-	dnsmasq, err := containers2.DNSMasq(cli, ctx, &containers2.DNSMasqOptions{
-		ClusterImage:       clusterImage,
-		SecondaryNicsCount: secondaryNics,
-		RandomPorts:        randomPorts,
-		PortMap:            portMap,
-		Prefix:             prefix,
-		NodeCount:          nodes,
-	})
-	if err != nil {
-		return err
-	}
+	var dnsmasq *container.CreateResponse
+	for i := 0; i <= 3; i++ {
+		if i == 3 {
+			fmt.Printf("dnsmasq container failed to start 3 times")
+			return err
+		}
+		dnsmasq, err = containers2.DNSMasq(cli, ctx, &containers2.DNSMasqOptions{
+			ClusterImage:       clusterImage,
+			SecondaryNicsCount: secondaryNics,
+			RandomPorts:        randomPorts,
+			PortMap:            portMap,
+			Prefix:             prefix,
+			NodeCount:          nodes,
+		})
+		if err != nil {
+			return err
+		}
 
-	containers <- dnsmasq.ID
-	if err := cli.ContainerStart(ctx, dnsmasq.ID, container.StartOptions{}); err != nil {
-		return err
+		if err := cli.ContainerStart(ctx, dnsmasq.ID, container.StartOptions{}); err != nil {
+			fmt.Printf("Failed to start dnsmasq container: %s\n", err)
+			fmt.Printf("Retry creating and starting dnsmasq container\n")
+			if err := cli.ContainerRemove(ctx, dnsmasq.ID, container.RemoveOptions{}); err != nil {
+				return err
+			}
+			time.Sleep(2 * time.Second)
+
+		} else {
+			containers <- dnsmasq.ID
+			break
+		}
 	}
 
 	dm, err := cli.ContainerInspect(context.Background(), dnsmasq.ID)


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a flake that causes `make cluster-up` to fail early when trying to create the dnsmasq container due to a port collision[1]. This looks to be a race condition and is very difficult to reproduce.

As this happens on every lane that uses the kubevirtci virtual cluster providers, the cumulative impact is quite high.

Adding 3 retries should help to avoid `make cluster-up` failing due to this.

[1] https://search.ci.kubevirt.io/?search=bind%3A+address+already+in+use&maxAge=336h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
