### PR TITLE
Libssh in provision

### DIFF
--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -379,14 +379,3 @@ func _cmd(cli *client.Client, container string, cmd string, description string) 
 	}
 	return nil
 }
-
-func performPhase(cli *client.Client, container string, script string, envVars string) error {
-	err := _cmd(cli, container, fmt.Sprintf("test -f %s", script), "checking provision scripts")
-	if err != nil {
-		return err
-	}
-
-	return _cmd(cli, container,
-		fmt.Sprintf("ssh.sh sudo %s /bin/bash < %s", envVars, script),
-		fmt.Sprintf("provisioning the node (%s)", script))
-}


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes occurrences of ssh.sh from the provision command in the gocli, this should have the benefit of ending the timeout during shutdown flake since ssh connection is made directly to the VM without an intermediary

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Use libssh in provision cmd
```
