### PR TITLE
Include manifests that are part of gocli when checking for prepull images

### DIFF
--- a/cluster-provision/k8s/check-pod-images.sh
+++ b/cluster-provision/k8s/check-pod-images.sh
@@ -17,7 +17,8 @@ fi
 images_not_in_list=$(mktemp)
 images_from_manifests=$(mktemp)
 trap 'rm -f $images_not_in_list $images_from_manifests' EXIT SIGINT SIGTERM
-$DIR/${provision_dir}/fetch-images.sh "$DIR/${provision_dir}" >"${images_from_manifests}"
+$DIR/${provision_dir}/fetch-images.sh "$DIR/${provision_dir}" > "${images_from_manifests}"
+$DIR/${provision_dir}/fetch-images.sh "$DIR/../gocli/opts/" >> "${images_from_manifests}"
 for image in $(${ksh} get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | grep -v 'registry.k8s.io' | sort | uniq); do
     set +e
     if ! grep -q "$image" "${pre_pull_image_file}"; then


### PR DESCRIPTION
**What this PR does / why we need it**:

When the manifest were moved to gocli[1], the images within these manifests
where no longer counted in the prepull images check.

This includes these images again.

[1] https://github.com/kubevirt/kubevirtci/pull/1217

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc dhiller @xpivarc 

This is required to take the bump CDI PR - https://github.com/kubevirt/kubevirtci/pull/1249

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
