### PR TITLE
Label rook storage class

### DIFF
--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -797,7 +797,7 @@ func provisionK8sOptions(sshClient libssh.Client, k8sClient k8s.K8sDynamicClient
 	opts := []opts.Opt{}
 
 	if n.Ceph {
-		cephOpt := rookceph.NewCephOpt(k8sClient)
+		cephOpt := rookceph.NewCephOpt(k8sClient, sshClient)
 		opts = append(opts, cephOpt)
 	}
 

--- a/cluster-provision/gocli/cmd/run_test.go
+++ b/cluster-provision/gocli/cmd/run_test.go
@@ -77,6 +77,7 @@ var _ = Describe("Node Provisioning", func() {
 			}
 			n := nodesconfig.NewNodeK8sConfig(k8sConfs)
 
+			rookceph.AddExpectCalls(sshClient)
 			istio.AddExpectCalls(sshClient)
 			aaq.AddExpectCalls(sshClient)
 

--- a/cluster-provision/gocli/opts/rookceph/ceph_test.go
+++ b/cluster-provision/gocli/opts/rookceph/ceph_test.go
@@ -5,7 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	k8s "kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/k8s"
+	kubevirtcimocks "kubevirt.io/kubevirtci/cluster-provision/gocli/utils/mock"
 )
 
 func TestNfsCsiOpt(t *testing.T) {
@@ -17,15 +19,18 @@ var _ = Describe("CephOpt", func() {
 	var (
 		k8sClient k8s.K8sDynamicClient
 		opt       *cephOpt
+		sshClient *kubevirtcimocks.MockSSHClient
 	)
 
 	BeforeEach(func() {
+		sshClient = kubevirtcimocks.NewMockSSHClient(gomock.NewController(GinkgoT()))
+		AddExpectCalls(sshClient)
 		r := k8s.NewReactorConfig("create", "cephblockpools", CephReactor)
 		k8sClient = k8s.NewTestClient(r)
-		opt = NewCephOpt(k8sClient)
+		opt = NewCephOpt(k8sClient, sshClient)
 	})
 
-	It("should execute NfsCsiOpt successfully", func() {
+	It("should execute Ceph successfully", func() {
 		err := opt.Exec()
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/cluster-provision/gocli/opts/rookceph/testconfig.go
+++ b/cluster-provision/gocli/opts/rookceph/testconfig.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stesting "k8s.io/client-go/testing"
+	kubevirtcimocks "kubevirt.io/kubevirtci/cluster-provision/gocli/utils/mock"
 )
 
 var CephReactor = func(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -16,4 +17,9 @@ var CephReactor = func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, err
 	}
 	return false, obj, nil
+}
+
+func AddExpectCalls(sshClient *kubevirtcimocks.MockSSHClient) {
+	sshClient.EXPECT().Command(`kubectl --kubeconfig /etc/kubernetes/admin.conf patch storageclass local -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'`)
+	sshClient.EXPECT().Command(`kubectl --kubeconfig /etc/kubernetes/admin.conf patch storageclass rook-ceph-block -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'`)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the problem mentioned with ceph storage class labeling in: https://github.com/kubevirt/kubevirt/pull/12677#issuecomment-2336737660

By executing the patch commands through the `sshClient` and adds the expected calls to the test suites of ceph and run


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The fix uses kubectl and bash to avoid modifying the k8s client interface before deploying the fix, another PR that will introduce a `Patch` method in the k8s client will follow shortly

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
