### PR TITLE
fix the busybox netcat not found issue in fedora-test-tooling for s390x.

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -43,7 +43,7 @@ write_files:
         bind 'set enable-bracketed-paste off'
 runcmd:
   - sudo systemctl daemon-reload
-  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng dmidecode virt-what vm-dump-metrics tpm2-tools nc sg3_utils iperf3 wget
+  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng virt-what vm-dump-metrics tpm2-tools nc sg3_utils iperf3 wget
   # Download the busybox netcat and relpace it with the OpenBSD netcat
   # To align with the netcat tool used in the Alpine image for network e2e testing
   - if [ $(uname -m) == "aarch64" ]; then export CPUARCH="armv8l"; elif [ $(uname -m) == "s390x" ]; then export CPUARCH="s390x"; else export CPUARCH="x86_64"; fi


### PR DESCRIPTION
Hi @brianmcarey ,
The package dmidecode is not available for s390x. Due to this the wget gets skipped and the busy box binary is not getting downloaded. Here are the logs.

```
localhost login: [  754.365587] cloud-init[1043]: Last metadata expiration check: 0:00:06 ago on Tue 10 Sep 2024 04:47:32 AM UTC.
[  814.868520] cloud-init[1043]: Package qemu-guest-agent-2:8.1.0-1.fc39.s390x is already installed.
[  815.206750] cloud-init[1043]: No match for argument: dmidecode
[  815.433653] cloud-init[1043]: Package tpm2-tools-5.5-4.fc39.s390x is already installed.
[  815.615077] cloud-init[1043]: Package sg3_utils-1.46-6.fc39.s390x is already installed.
[  816.146109] cloud-init[1043]: Error: Unable to find a match: dmidecode
[  817.678591] cloud-init[1043]: sudo: wget: command not found
[  OK  ] Started session-c3.scope - Session c3 of User root.
[  818.830901] cloud-init[1043]: chmod: cannot access 'busybox-s390x': No such file or directory
[  OK  ] Started session-c4.scope - Session c4 of User root.
[  819.988355] cloud-init[1043]: mv: cannot stat '/usr/bin/nc': No such file or directory
[  OK  ] Started session-c5.scope - Session c5 of User root.
[  821.083049] cloud-init[1043]: mv: cannot stat 'busybox-s390x': No such file or directory
```
By removing this it won't cause any issues in x86 . because the dmidecode is downloaded as a dependency.
Here are the logs.

```
[   58.203185] cloud-init[820]: ================================================================================
[   58.203487] cloud-init[820]:  Package               Architecture Version                 Repository     Size
[   58.204547] cloud-init[820]: ================================================================================
[   58.205716] cloud-init[820]: Installing:
[   58.206490] cloud-init[820]:  iperf3                x86_64       3.10.1-2.fc35           fedora        110 k
[   58.207016] cloud-init[820]:  kernel-modules        x86_64       5.14.10-300.fc35        fedora         32 M
[   58.208266] cloud-init[820]:  netcat                x86_64       1.219-1.fc35            updates        34 k
[   58.209571] cloud-init[820]:  sg3_utils             x86_64       1.46-2.fc35             fedora        925 k
[   58.210209] cloud-init[820]:  stress-ng             x86_64       0.13.00-1.fc35          fedora        1.8 M
[   58.210899] cloud-init[820]:  tpm2-tools            x86_64       5.2-1.fc35              updates       728 k
[   58.211555] cloud-init[820]:  virt-what             x86_64       1.25-1.fc35             updates        33 k
[   58.212202] cloud-init[820]:  vm-dump-metrics       x86_64       1.1-10.fc35             fedora         30 k
[   58.217196] cloud-init[820]:  wget                  x86_64       1.21.3-1.fc35           updates       809 k
[   58.217892] cloud-init[820]: Installing dependencies:
[   58.218577] cloud-init[820]:  Judy                  x86_64       1.0.5-27.fc35           fedora        132 k
[   58.219222] cloud-init[820]:  dmidecode             x86_64       1:3.3-2.fc35            fedora         87 k
[   58.223068] cloud-init[820]:  libbsd                x86_64       0.10.0-8.fc35           fedora        104 k
[   58.231065] cloud-init[820]:  libmetalink           x86_64       0.1.3-24.fc35           updates        33 k
[   58.238921] cloud-init[820]:  libretls              x86_64       3.5.2-1.fc35            updates        41 k
[   58.246647] cloud-init[820]:  lksctp-tools          x86_64       1.0.18-11.fc35          fedora         91 k
[   58.254562] cloud-init[820]:  sg3_utils-libs        x86_64       1.46-2.fc35             fedora        102 k
[   58.258753] cloud-init[820]: Transaction Summary
[   58.260132] cloud-init[820]: ================================================================================
[   58.268549] cloud-init[820]: Install  16 Packages
[   58.279946] cloud-init[820]: Total download size: 37 M
[   58.288405] cloud-init[820]: Installed size: 45 M
[   58.295142] cloud-init[820]: Downloading Packages:
[   59.223677] cloud-init[820]: (1/16): dmidecode-3.3-2.fc35.x86_64.rpm         828 kB/s |  87 kB     00:00
```