### PR TITLE
[k8s providers]: use systemd as the cgroup driver for CRI-O and kubelet

### DIFF
--- a/cluster-provision/gocli/opts/node01/conf/00-cgroupv2.conf
+++ b/cluster-provision/gocli/opts/node01/conf/00-cgroupv2.conf
@@ -1,3 +1,3 @@
 [crio.runtime]
 conmon_cgroup = "pod"
-cgroup_manager = "cgroupfs"
+cgroup_manager = "systemd"

--- a/cluster-provision/gocli/opts/node01/node01.go
+++ b/cluster-provision/gocli/opts/node01/node01.go
@@ -46,9 +46,6 @@ func (n *node01Provisioner) Exec() error {
 	cmds := []string{
 		`if [ -f /home/vagrant/enable_audit ]; then echo '` + string(advAudit) + `' | tee /etc/kubernetes/audit/adv-audit.yaml > /dev/null; fi`,
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
-		`mkdir -p /etc/crio/crio.conf.d`,
-		`[ -f /sys/fs/cgroup/cgroup.controllers ] && mkdir -p /etc/crio/crio.conf.d && echo '` + string(cgroupv2) + `' |  tee /etc/crio/crio.conf.d/00-cgroupv2.conf > /dev/null &&  sed -i 's/--cgroup-driver=systemd/--cgroup-driver=cgroupfs/' /etc/sysconfig/kubelet && systemctl stop kubelet && systemctl restart crio && systemctl start kubelet`,
-		"while [[ $(systemctl status crio | grep -c active) -eq 0 ]]; do sleep 2; done",
 		"swapoff -a",
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",
 		kubeadmInitCmd,

--- a/cluster-provision/gocli/opts/node01/testconfig.go
+++ b/cluster-provision/gocli/opts/node01/testconfig.go
@@ -6,9 +6,6 @@ func AddExpectCalls(sshClient *kubevirtcimocks.MockSSHClient) {
 	cmds := []string{
 		`if [ -f /home/vagrant/enable_audit ]; then echo '` + string(advAudit) + `' | tee /etc/kubernetes/audit/adv-audit.yaml > /dev/null; fi`,
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
-		`mkdir -p /etc/crio/crio.conf.d`,
-		`[ -f /sys/fs/cgroup/cgroup.controllers ] && mkdir -p /etc/crio/crio.conf.d && echo '` + string(cgroupv2) + `' |  tee /etc/crio/crio.conf.d/00-cgroupv2.conf > /dev/null &&  sed -i 's/--cgroup-driver=systemd/--cgroup-driver=cgroupfs/' /etc/sysconfig/kubelet && systemctl stop kubelet && systemctl restart crio && systemctl start kubelet`,
-		"while [[ $(systemctl status crio | grep -c active) -eq 0 ]]; do sleep 2; done",
 		"swapoff -a",
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",
 		`kubeadm init --config /etc/kubernetes/kubeadm.conf -v5`,

--- a/cluster-provision/gocli/opts/nodes/conf/00-cgroupv2.conf
+++ b/cluster-provision/gocli/opts/nodes/conf/00-cgroupv2.conf
@@ -1,3 +1,3 @@
 [crio.runtime]
 conmon_cgroup = "pod"
-cgroup_manager = "cgroupfs"
+cgroup_manager = "systemd"

--- a/cluster-provision/gocli/opts/nodes/nodes.go
+++ b/cluster-provision/gocli/opts/nodes/nodes.go
@@ -37,8 +37,6 @@ func (n *nodesProvisioner) Exec() error {
 		"source /var/lib/kubevirtci/shared_vars.sh",
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
 		`echo "KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --fail-swap-on=false ` + nodeIP + ` --feature-gates=CPUManager=true,NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m" | tee /etc/sysconfig/kubelet > /dev/null`,
-		`[ -f /sys/fs/cgroup/cgroup.controllers ] && mkdir -p /etc/crio/crio.conf.d && echo '` + string(cgroupv2) + `' |  tee /etc/crio/crio.conf.d/00-cgroupv2.conf > /dev/null &&  sed -i 's/--cgroup-driver=systemd/--cgroup-driver=cgroupfs/' /etc/sysconfig/kubelet && systemctl stop kubelet && systemctl restart crio`,
-		"while [[ $(systemctl status crio | grep -c active) -eq 0 ]]; do sleep 2; done",
 		"systemctl daemon-reload &&  service kubelet restart",
 		"swapoff -a",
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",

--- a/cluster-provision/gocli/opts/nodes/testconfig.go
+++ b/cluster-provision/gocli/opts/nodes/testconfig.go
@@ -7,8 +7,6 @@ func AddExpectCalls(sshClient *kubevirtcimocks.MockSSHClient) {
 		"source /var/lib/kubevirtci/shared_vars.sh",
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
 		`echo "KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --fail-swap-on=false ${nodeip} --feature-gates=CPUManager=true,NodeSwap=true --cpu-manager-policy=static --kube-reserved=cpu=250m --system-reserved=cpu=250m" | tee /etc/sysconfig/kubelet > /dev/null`,
-		`[ -f /sys/fs/cgroup/cgroup.controllers ] && mkdir -p /etc/crio/crio.conf.d && echo '` + string(cgroupv2) + `' |  tee /etc/crio/crio.conf.d/00-cgroupv2.conf > /dev/null &&  sed -i 's/--cgroup-driver=systemd/--cgroup-driver=cgroupfs/' /etc/sysconfig/kubelet && systemctl stop kubelet && systemctl restart crio`,
-		"while [[ $(systemctl status crio | grep -c active) -eq 0 ]]; do sleep 2; done",
 		"systemctl daemon-reload &&  service kubelet restart",
 		"swapoff -a",
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",

--- a/cluster-provision/k8s/1.31/node01.sh
+++ b/cluster-provision/k8s/1.31/node01.sh
@@ -40,10 +40,8 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
     cat << EOF > ${CRIO_CONF_DIR}/00-cgroupv2.conf
 [crio.runtime]
 conmon_cgroup = "pod"
-cgroup_manager = "cgroupfs"
+cgroup_manager = "systemd"
 EOF
-
-    sed -i 's/--cgroup-driver=systemd/--cgroup-driver=cgroupfs/' /etc/sysconfig/kubelet
 
     systemctl stop kubelet
     systemctl restart crio

--- a/cluster-provision/k8s/1.31/nodes.sh
+++ b/cluster-provision/k8s/1.31/nodes.sh
@@ -31,11 +31,8 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
     cat << EOF > ${CRIO_CONF_DIR}/00-cgroupv2.conf
 [crio.runtime]
 conmon_cgroup = "pod"
-cgroup_manager = "cgroupfs"
+cgroup_manager = "systemd"
 EOF
-
-    sed -i 's/--cgroup-driver=systemd/--cgroup-driver=cgroupfs/' /var/lib/kubevirtci/shared_vars.sh
-    source /var/lib/kubevirtci/shared_vars.sh
 
     # kubelet will be started later on
     systemctl stop kubelet


### PR DESCRIPTION
**What this PR does / why we need it**:
Since Centos is a systemd based OS there is no need to work directly with cgroupfs. Also its requried to be consistent with the cgroup driver both in kubelet and in the CRI.

In addition there was a mismatch between cAdivor CRI-O communication, since cAdvisor works with systemd while CRI-O was configured to work with cgroupfs.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
use systemd as the cgroup driver for CRI-O and kubelet
```
