### PR TITLE
kind-1.30-vgpu: Add retry to the creation of the kind cluster

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -184,7 +184,10 @@ function _fix_node_labels() {
 }
 
 function setup_kind() {
-    $KIND --loglevel debug create cluster --retain --name=${CLUSTER_NAME} --config=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml --image=$KIND_NODE_IMAGE
+    $KIND --loglevel debug create cluster --retain --name=${CLUSTER_NAME} --config=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml --image=$KIND_NODE_IMAGE \
+        || ( $KIND --loglevel debug delete cluster --name=${CLUSTER_NAME} \
+        && $KIND --loglevel debug create cluster --retain --name=${CLUSTER_NAME} --config=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml --image=$KIND_NODE_IMAGE )
+
     $KIND get kubeconfig --name=${CLUSTER_NAME} > ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
     if ${CRI_BIN} exec ${CLUSTER_NAME}-control-plane ls /usr/bin/kubectl > /dev/null; then


### PR DESCRIPTION
**What this PR does / why we need it**:

The kind-1.30-vgpu provider fails to create the kind cluster every so often due to missing cgroups in the kind node container.  This was discovered when trying to introduce the new lane to kubevirt - https://github.com/kubevirt/project-infra/pull/3499

```
Welcome to Debian GNU/Linux 12 (bookworm)!

Failed to attach 1 to compat systemd cgroup /init.scope: No such file or directory
Couldn't move remaining userspace processes, ignoring: Input/output error
Queued start job for default target graphical.target.
-.slice: Failed to migrate controller cgroups from /, ignoring: Input/output error
[  OK  ] Created slice kubelet.slic… used to run Kubernetes / Kubelet.
[  OK  ] Created slice system-modpr…lice - Slice /system/modprobe.
[  OK  ] Started systemd-ask-passwo…quests to Console Directory Watch.
[  OK  ] Set up automount proc-sys-…rmats File System Automount Point.
[  OK  ] Reached target cryptsetup.…get - Local Encrypted Volumes.
[  OK  ] Reached target integrityse…Local Integrity Protected Volumes.
[  OK  ] Reached target paths.target - Path Units.
[  OK  ] Reached target slices.target - Slice Units.
[  OK  ] Reached target swap.target - Swaps.
[  OK  ] Reached target veritysetup… - Local Verity Protected Volumes.
[  OK  ] Listening on systemd-journ…socket - Journal Audit Socket.
[  OK  ] Listening on systemd-journ…t - Journal Socket (/dev/log).
[  OK  ] Listening on systemd-journald.socket - Journal Socket.
[  OK  ] Reached target sockets.target - Socket Units.
Failed to attach 146 to compat systemd cgroup /dev-hugepages.mount: No such file or directory
         Mounting dev-hugepages.mount - Huge Pages File System...
Failed to attach 146 to compat systemd cgroup /dev-hugepages.mount: No such file or directory
Failed to attach 147 to compat systemd cgroup /sys-kernel-debug.mount: No such file or directory
         Mounting sys-kernel-debug.… - Kernel Debug File System...
Failed to attach 147 to compat systemd cgroup /sys-kernel-debug.mount: No such file or directory
Failed to attach 149 to compat systemd cgroup /sys-kernel-tracing.mount: No such file or directory
         Mounting sys-kernel-tracin… - Kernel Trace File System...
Failed to attach 149 to compat systemd cgroup /sys-kernel-tracing.mount: No such file or directory
```

I added a retry to the kind cluster create in the provider and this results in the provider coming up successfully every time. I haven't been able to identify why these cgroups are present sometimes and not present others - there maybe some issue with the mount that kind does on /sys

For now it is probably good enough to just add the retry in the provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
