### PR TITLE
virtctl.sh: add deprecation warning and parent dir fallback

### DIFF
--- a/cluster-up/virtctl.sh
+++ b/cluster-up/virtctl.sh
@@ -19,6 +19,9 @@
 
 set -e
 
+>&2 echo "WARNING: usage of '${BASH_SOURCE[0]}' is deprecated!"
+>&2 echo "         see: https://github.com/kubevirt/kubevirtci/issues/1277"
+
 if [ -z "$KUBEVIRTCI_PATH" ]; then
     KUBEVIRTCI_PATH="$(
         cd "$(dirname "$BASH_SOURCE[0]")/"

--- a/cluster-up/virtctl.sh
+++ b/cluster-up/virtctl.sh
@@ -41,5 +41,12 @@ elif [ -n "$KUBECONFIG" ]; then
     CONFIG_ARGS="--kubeconfig=${KUBECONFIG}"
 fi
 
-${KUBEVIRTCI_PATH}/../_out/cmd/virtctl/virtctl $CONFIG_ARGS "$@"
+KUBEVIRT_OUT_PATH=${KUBEVIRTCI_PATH}/../_out
+if [ ! -d ${KUBEVIRT_OUT_PATH} ]; then
+    # see https://github.com/kubevirt/kubevirt/pull/12872
+    >&2 echo "WARNING: $KUBEVIRT_OUT_PATH not found, falling back to parent"
+    KUBEVIRT_OUT_PATH=${KUBEVIRTCI_PATH}/../../_out
+    >&2 echo "         $KUBEVIRT_OUT_PATH"
+fi
+${KUBEVIRT_OUT_PATH}/cmd/virtctl/virtctl $CONFIG_ARGS "$@"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We want to remove virtctl.sh in the long run [1], for now we are issuing a deprecation warning.

Also, since there might be usages outside kubevirt that source kubevirtci
cluster-up folder from kubevirt main repo, we add a fallback that uses
the parent directory.

See https://github.com/kubevirt/kubevirtci/issues/1277

[1]: https://github.com/kubevirt/kubevirtci/issues/1277

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
