### PR TITLE
whereabouts: bump to latest release v0.8.0

### DIFF
--- a/cluster-provision/gocli/opts/cnao/manifests/whereabouts.yaml
+++ b/cluster-provision/gocli/opts/cnao/manifests/whereabouts.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: ippools.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io
@@ -20,14 +19,19 @@ spec:
         description: IPPool is the Schema for the ippools API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -41,14 +45,17 @@ spec:
                   properties:
                     id:
                       type: string
+                    ifname:
+                      type: string
                     podref:
                       type: string
                   required:
                   - id
+                  - podref
                   type: object
-                description: Allocations is the set of allocated IPs for the given
-                  range. Its` indices are a direct mapping to the IP with the same
-                  index/offset for the pool's range.
+                description: |-
+                  Allocations is the set of allocated IPs for the given range. Its` indices are a direct mapping to the
+                  IP with the same index/offset for the pool's range.
                 type: object
               range:
                 description: Range is a RFC 4632/4291-style string that represents
@@ -61,19 +68,12 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: overlappingrangeipreservations.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io
@@ -91,14 +91,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -108,22 +113,18 @@ spec:
             properties:
               containerid:
                 type: string
+              ifname:
+                type: string
               podref:
                 type: string
             required:
-            - containerid
+            - podref
             type: object
         required:
         - spec
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -163,6 +164,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
   - k8s.cni.cncf.io
   resources:
   - network-attachment-definitions
@@ -179,6 +186,7 @@ rules:
   - create
   - patch
   - update
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -191,6 +199,17 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: whereabouts
+  namespace: kube-system
+---
+apiVersion: v1
+data:
+  cron-expression: 30 4 * * *
+kind: ConfigMap
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      Configmap containing user customizable cronjob schedule
+  name: whereabouts-config
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -220,11 +239,16 @@ spec:
         command:
         - /bin/sh
         env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         - name: WHEREABOUTS_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.6.1-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.8.0-amd64
         name: whereabouts
         resources:
           limits:
@@ -240,9 +264,9 @@ spec:
           name: cnibin
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
+        - mountPath: /cron-schedule
+          name: cron-scheduler-configmap
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/arch: amd64
       serviceAccountName: whereabouts
       tolerations:
       - effect: NoSchedule
@@ -254,5 +278,12 @@ spec:
       - hostPath:
           path: /etc/cni/net.d
         name: cni-net-dir
+      - configMap:
+          defaultMode: 484
+          items:
+          - key: cron-expression
+            path: config
+          name: whereabouts-config
+        name: cron-scheduler-configmap
   updateStrategy:
     type: RollingUpdate

--- a/cluster-provision/gocli/opts/cnao/manifests/whereabouts.yaml
+++ b/cluster-provision/gocli/opts/cnao/manifests/whereabouts.yaml
@@ -248,7 +248,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.8.0-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.8.0
         name: whereabouts
         resources:
           limits:

--- a/hack/bump-whereabouts.sh
+++ b/hack/bump-whereabouts.sh
@@ -22,14 +22,13 @@ WHEREABOUTS_BASE="https://github.com/k8snetworkplumbingwg/whereabouts/archive"
 WHEREABOUTS_RELEASES="${WHEREABOUTS_BASE}/refs/tags/"
 
 # syntax:
-# ./hack/bump-whereabouts.sh <PROVIDER> <WHEREABOUTS_VERSION>
+# ./hack/bump-whereabouts.sh <WHEREABOUTS_VERSION>
 
 # usage example
-# ./hack/bump-whereabouts.sh 1.19 v0.4.2
-# ./hack/bump-whereabouts.sh 1.19 master
+# ./hack/bump-whereabouts.sh v0.4.2
+# ./hack/bump-whereabouts.sh master
 
-provider="${1:?provider not set or empty}"
-whereabouts_version="${2:?whereabouts version not set or empty}"
+whereabouts_version="${1:?whereabouts version not set or empty}"
 
 url=
 if [[ $whereabouts_version = v* ]]; then
@@ -51,11 +50,11 @@ manifests_dir=doc
 cp hack/kustomization/whereabouts/*.yaml ${tmp_dir}/whereabouts/${manifests_dir}/
 sed -i "s/##VERSION##/${whereabouts_version}/" ${tmp_dir}/whereabouts/${manifests_dir}/kustomization.yaml
 
-target_dir="cluster-provision/k8s/${provider}/manifests/whereabouts"
+target_dir="cluster-provision/gocli/opts/cnao/manifests/"
 mkdir -p ${target_dir}
-rm -rf ${target_dir:?}/*
-kubectl kustomize ${tmp_dir}/whereabouts/${manifests_dir}/ >${target_dir}/whereabouts-${whereabouts_version}.yaml
+rm -rf ${target_dir:?}/whereabouts.yaml
+kubectl kustomize ${tmp_dir}/whereabouts/${manifests_dir}/ >${target_dir}/whereabouts.yaml
 
 rm -rf $tmp_dir
 
-echo "whereabouts, provision, Bump k8s-${provider} whereabouts to ${whereabouts_version}"
+echo "whereabouts, provision, Bump whereabouts to ${whereabouts_version}"

--- a/hack/kustomization/whereabouts/kustomization.yaml
+++ b/hack/kustomization/whereabouts/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
 
 images:
   - name: ghcr.io/k8snetworkplumbingwg/whereabouts
-    newTag: ##VERSION##-amd64
+    newTag: ##VERSION##


### PR DESCRIPTION
**What this PR does / why we need it**:

Following a couple of the go rewrite PRs the whereabouts manifests now
live under gocli.

Update the bump script to handle this change.

whereabouts has not been updated in sometime - bumping to latest
release v0.8.0[1]

[1] https://github.com/k8snetworkplumbingwg/whereabouts/releases/tag/v0.8.0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @jean-edouard 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
