### PR TITLE
Skip CNAO CR

### DIFF
--- a/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
@@ -32,6 +32,7 @@ type NodeK8sConfig struct {
 	Istio        bool
 	NfsCsi       bool
 	CNAO         bool
+	CNAOSkipCR   bool
 	Multus       bool
 	CDI          bool
 	CDIVersion   string

--- a/cluster-provision/gocli/cmd/nodesconfig/opts.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/opts.go
@@ -172,6 +172,12 @@ func WithCnao(cnao bool) K8sConfigFunc {
 	}
 }
 
+func WithCNAOSkipCR(skip bool) K8sConfigFunc {
+	return func(n *NodeK8sConfig) {
+		n.CNAOSkipCR = skip
+	}
+}
+
 func WithMultus(multus bool) K8sConfigFunc {
 	return func(n *NodeK8sConfig) {
 		n.Multus = multus

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -120,6 +120,7 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().Bool("enable-istio", false, "deploys Istio service mesh")
 	run.Flags().Bool("reverse", false, "reverse node setup order")
 	run.Flags().Bool("enable-cnao", false, "enable network extensions with istio")
+	run.Flags().Bool("skip-cnao-cr", false, "skip deploying cnao custom resource. if true, only cnao CRDS will be deployed")
 	run.Flags().Bool("deploy-multus", false, "deploy multus")
 	run.Flags().Bool("deploy-cdi", false, "deploy cdi")
 	run.Flags().String("cdi-version", "", "cdi version")
@@ -338,6 +339,10 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 	cnaoEnabled, err := cmd.Flags().GetBool("enable-cnao")
+	if err != nil {
+		return err
+	}
+	cnaoSkipCR, err := cmd.Flags().GetBool("skip-cnao-cr")
 	if err != nil {
 		return err
 	}
@@ -773,6 +778,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		nodesconfig.WithIstio(istioEnabled),
 		nodesconfig.WithNfsCsi(nfsCsiEnabled),
 		nodesconfig.WithCnao(cnaoEnabled),
+		nodesconfig.WithCNAOSkipCR(cnaoSkipCR),
 		nodesconfig.WithMultus(deployMultus),
 		nodesconfig.WithCdi(deployCdi),
 		nodesconfig.WithCdiVersion(cdiVersion),
@@ -833,7 +839,7 @@ func provisionK8sOptions(sshClient libssh.Client, k8sClient k8s.K8sDynamicClient
 	}
 
 	if n.CNAO {
-		cnaoOpt := cnao.NewCnaoOpt(k8sClient, sshClient, n.Multus)
+		cnaoOpt := cnao.NewCnaoOpt(k8sClient, sshClient, n.Multus, n.CNAOSkipCR)
 		opts = append(opts, cnaoOpt)
 	}
 

--- a/cluster-provision/gocli/opts/cnao/cnao_test.go
+++ b/cluster-provision/gocli/opts/cnao/cnao_test.go
@@ -35,7 +35,7 @@ var _ = Describe("CnaoOpt", func() {
 	})
 
 	It("should execute create CNAO with Multus", func() {
-		opt = NewCnaoOpt(client, sshClient, false)
+		opt = NewCnaoOpt(client, sshClient, false, false)
 		sshClient.EXPECT().Command("kubectl --kubeconfig=/etc/kubernetes/admin.conf wait deployment -n cluster-network-addons cluster-network-addons-operator --for condition=Available --timeout=200s")
 		opt.Exec()
 
@@ -51,7 +51,7 @@ var _ = Describe("CnaoOpt", func() {
 	})
 
 	It("should execute create CNAO without Multus", func() {
-		opt = NewCnaoOpt(client, sshClient, true)
+		opt = NewCnaoOpt(client, sshClient, true, false)
 		sshClient.EXPECT().Command("kubectl --kubeconfig=/etc/kubernetes/admin.conf wait deployment -n cluster-network-addons cluster-network-addons-operator --for condition=Available --timeout=200s")
 		opt.Exec()
 

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -146,6 +146,10 @@ function _add_common_params() {
         params=" --enable-audit $params"
     fi
 
+    if [ $KUBVIRT_WITH_CNAO_SKIP_CONFIG == "true" ]; then
+        params=" --skip-cnao-cr $params"
+    fi
+
     if [ $KUBEVIRT_DEPLOY_NFS_CSI == "true" ]; then
         params=" --enable-nfs-csi $params"
     fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the bash flag `KUBVIRT_WITH_CNAO_SKIP_CONFIG` which will skip deploying the CNAO custom resource and adds support for it in the gocli

**Special notes for your reviewer**:

cc: @oshoval @EdDev 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

