### PR TITLE
kind: provider scripts should consider KUBEVIRTCI_PATH

### DIFF
--- a/cluster-up/cluster/kind-1.28/provider.sh
+++ b/cluster-up/cluster/kind-1.28/provider.sh
@@ -14,10 +14,10 @@ else
 fi
 
 function set_kind_params() {
-    version=$(cat cluster-up/cluster/$KUBEVIRT_PROVIDER/version)
+    version=$(cat "${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/version")
     export KIND_VERSION="${KIND_VERSION:-$version}"
 
-    image=$(cat cluster-up/cluster/$KUBEVIRT_PROVIDER/image)
+    image=$(cat "${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/image")
     export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-$image}"
 }
 

--- a/cluster-up/cluster/kind-1.30-vgpu/provider.sh
+++ b/cluster-up/cluster/kind-1.30-vgpu/provider.sh
@@ -14,10 +14,10 @@ else
 fi
 
 function set_kind_params() {
-    version=$(cat cluster-up/cluster/$KUBEVIRT_PROVIDER/version)
+    version=$(cat "${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/version")
     export KIND_VERSION="${KIND_VERSION:-$version}"
 
-    image=$(cat cluster-up/cluster/$KUBEVIRT_PROVIDER/image)
+    image=$(cat "${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/image")
     export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-$image}"
 }
 

--- a/cluster-up/cluster/kind-ovn/provider.sh
+++ b/cluster-up/cluster/kind-ovn/provider.sh
@@ -81,7 +81,7 @@ function down() {
 }
 
 function _kubectl() {
-    export KUBECONFIG=$(./cluster-up/kubeconfig.sh)
+    export KUBECONFIG=$(${KUBEVIRTCI_PATH}/kubeconfig.sh)
     kubectl "$@"
 }
 

--- a/cluster-up/cluster/kind-sriov/provider.sh
+++ b/cluster-up/cluster/kind-sriov/provider.sh
@@ -21,10 +21,10 @@ function print_available_nics() {
 }
 
 function set_kind_params() {
-    version=$(cat cluster-up/cluster/$KUBEVIRT_PROVIDER/version)
+    version=$(cat "${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/version")
     export KIND_VERSION="${KIND_VERSION:-$version}"
 
-    image=$(cat cluster-up/cluster/$KUBEVIRT_PROVIDER/image)
+    image=$(cat "${KUBEVIRTCI_PATH}/cluster/$KUBEVIRT_PROVIDER/image")
     export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-$image}"
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The env variable is considered by the standard k8s providers, but not by
the kind providers. This change lets them consider the env var.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Required change for https://github.com/kubevirt/kubevirt/pull/12872 to work with KIND providers.
