### PR TITLE
feat: Bumped local-volume-provisioner container image from 2.3.2 to 2.5.0

### DIFF
--- a/cluster-provision/k8s/1.29/manifests/local-volume.yaml
+++ b/cluster-provision/k8s/1.29/manifests/local-volume.yaml
@@ -99,7 +99,7 @@ spec:
     spec:
       serviceAccountName: local-storage-admin
       containers:
-        - image: "quay.io/external_storage/local-volume-provisioner:v2.3.2"
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.5.0"
           name: provisioner
           securityContext:
             privileged: true
@@ -113,7 +113,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: "quay.io/external_storage/local-volume-provisioner:v2.3.2"
+            value: "quay.io/external_storage/local-volume-provisioner:v2.5.0"
           volumeMounts:
             - mountPath: /etc/provisioner/config
               name: provisioner-config

--- a/cluster-provision/k8s/1.30/manifests/local-volume.yaml
+++ b/cluster-provision/k8s/1.30/manifests/local-volume.yaml
@@ -99,7 +99,7 @@ spec:
     spec:
       serviceAccountName: local-storage-admin
       containers:
-        - image: "quay.io/external_storage/local-volume-provisioner:v2.3.2"
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.5.0"
           name: provisioner
           securityContext:
             privileged: true
@@ -113,7 +113,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: "quay.io/external_storage/local-volume-provisioner:v2.3.2"
+            value: "quay.io/external_storage/local-volume-provisioner:v2.5.0"
           volumeMounts:
             - mountPath: /etc/provisioner/config
               name: provisioner-config

--- a/cluster-provision/k8s/1.31/manifests/local-volume.yaml
+++ b/cluster-provision/k8s/1.31/manifests/local-volume.yaml
@@ -99,7 +99,7 @@ spec:
     spec:
       serviceAccountName: local-storage-admin
       containers:
-        - image: "quay.io/external_storage/local-volume-provisioner:v2.3.2"
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.5.0"
           name: provisioner
           securityContext:
             privileged: true
@@ -113,7 +113,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: "quay.io/external_storage/local-volume-provisioner:v2.3.2"
+            value: "quay.io/external_storage/local-volume-provisioner:v2.5.0"
           volumeMounts:
             - mountPath: /etc/provisioner/config
               name: provisioner-config


### PR DESCRIPTION
**What this PR does / why we need it**:
As current version 2.3.2 of local-volume-provisioner used by k8s provider isn't supported for s390x, updated to the latest version available in quay which has s390x support i.e., 2.5.0. This is pre-requisite for enabling k8s providers for s390x. Ref: PR [1252](https://github.com/kubevirt/kubevirtci/pull/1252/commits/f09fb7c8822cff893c8d83f093072a82ae1b3269#r1776849558)

**Special notes for your reviewer**:


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
