### PR TITLE
fedora: Add tcpdump to tooling image

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -43,7 +43,7 @@ write_files:
         bind 'set enable-bracketed-paste off'
 runcmd:
   - sudo systemctl daemon-reload
-  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng virt-what vm-dump-metrics tpm2-tools nc sg3_utils iperf3 wget
+  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng virt-what vm-dump-metrics tpm2-tools nc sg3_utils iperf3 wget tcpdump
   # Download the busybox netcat and relpace it with the OpenBSD netcat
   # To align with the netcat tool used in the Alpine image for network e2e testing
   - if [ $(uname -m) == "aarch64" ]; then export CPUARCH="armv8l"; elif [ $(uname -m) == "s390x" ]; then export CPUARCH="s390x"; else export CPUARCH="x86_64"; fi


### PR DESCRIPTION
At some scenarios the egress link is broken during development and we have to inspect packages, on those scenarios we cannot install tcpdump and having it out of the box is a great help.