### PR TITLE
Init CNAO_SKIP_CONFIG envvar

### DIFF
--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -41,6 +41,7 @@ KUBEVIRT_SWAP_ON=${KUBEVIRT_SWAP_ON:-false}
 KUBEVIRT_KSM_ON=${KUBEVIRT_KSM_ON:-false}
 KUBEVIRT_UNLIMITEDSWAP=${KUBEVIRT_UNLIMITEDSWAP:-false}
 KUBEVIRT_CPU_MANAGER_POLICY=${KUBEVIRT_CPU_MANAGER_POLICY:-none}
+KUBVIRT_WITH_CNAO_SKIP_CONFIG=${KUBVIRT_WITH_CNAO_SKIP_CONFIG:-false}
 
 # If on a developer setup, expose ocp on 8443, so that the openshift web console can be used (the port is important because of auth redirects)
 # http and https ports are accessed by testing framework and should not be randomized


### PR DESCRIPTION
Otherwise, on `make cluster-up` we get

   ../ephemeral-provider-common.sh: line 149: [: ==: unary operator expected