### PR TITLE
Kubelet drop in

### DIFF
--- a/cluster-provision/k8s/1.30/k8s_provision.sh
+++ b/cluster-provision/k8s/1.30/k8s_provision.sh
@@ -156,9 +156,19 @@ cp /tmp/local-volume.yaml /provision/local-volume.yaml
 kubelet_conf_d="/etc/kubernetes/kubelet.conf.d"
 mkdir -m 644 $kubelet_conf_d
 
-# TODO use config file! this is deprecated
+# Set our custom initializations to kubelet
+kubevirt_kubelet_conf="$kubelet_conf_d/50-kubevirt.conf"
+cat <<EOF >$kubevirt_kubelet_conf
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: systemd
+failSwapOn: false
+kubeletCgroups: /systemd/system.slice
+EOF
+
+# Set only command line options not supported by config
 cat <<EOT >/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice  --fail-swap-on=false --kubelet-cgroups=/systemd/system.slice --config-dir=$kubelet_conf_d
+KUBELET_EXTRA_ARGS=--runtime-cgroups=/systemd/system.slice --config-dir=$kubelet_conf_d
 EOT
 
 # Enable userfaultfd for centos9 to support post-copy live migration.

--- a/cluster-provision/k8s/1.30/k8s_provision.sh
+++ b/cluster-provision/k8s/1.30/k8s_provision.sh
@@ -151,9 +151,14 @@ patch $cni_manifest_ipv6 $cni_ipv6_diff
 
 cp /tmp/local-volume.yaml /provision/local-volume.yaml
 
+# Create drop-in config files for kubelet
+# https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/#kubelet-conf-d
+kubelet_conf_d="/etc/kubernetes/kubelet.conf.d"
+mkdir -m 644 $kubelet_conf_d
+
 # TODO use config file! this is deprecated
 cat <<EOT >/etc/sysconfig/kubelet
-KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice  --fail-swap-on=false --kubelet-cgroups=/systemd/system.slice
+KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice  --fail-swap-on=false --kubelet-cgroups=/systemd/system.slice --config-dir=$kubelet_conf_d
 EOT
 
 # Enable userfaultfd for centos9 to support post-copy live migration.


### PR DESCRIPTION
**What this PR does / why we need it**:

We are using deprecated kubelet's command line options which have config alternative options. Seems to be known since b89e9a64dc269b23d1f4e2d1318f46ebe11b5b21. This, combined with the goal of enabling k8s feature gates such as DRA in https://github.com/kubevirt/kubevirtci/pull/1251, the goal of this PR is to improve kubelet's config options and use [drop-in](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/#kubelet-conf-d) feature.

Commit logs clarify further the changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This PR only focused on k8s-1.30 to validate the change. I can do here or in a new PR for k8s-1.31 too.
/cc @lyarwood 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
