### PR TITLE
gocli: Add wait for cri-o service to be ready after proxy settings applied

### DIFF
--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -68,6 +68,11 @@ EOT
 
 systemctl daemon-reload
 systemctl restart crio.service
+
+while [[ systemctl status crio | grep active | wc -l -eq 0 ]]
+do
+    sleep 2
+done
 EOF
 `
 	etcdDataDir         = "/var/lib/etcd"

--- a/cluster-provision/gocli/opts/node01/node01.go
+++ b/cluster-provision/gocli/opts/node01/node01.go
@@ -48,6 +48,7 @@ func (n *node01Provisioner) Exec() error {
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
 		"swapoff -a",
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",
+		`timeout=60; interval=5; while ! systemctl status crio | grep active; do echo "Waiting for cri-o service to be ready"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
 		kubeadmInitCmd,
 		`kubectl --kubeconfig=/etc/kubernetes/admin.conf patch deployment coredns -n kube-system -p "$(cat /provision/kubeadm-patches/add-security-context-deployment-patch.yaml)"`,
 		`kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f ` + cniManifest,

--- a/cluster-provision/gocli/opts/node01/testconfig.go
+++ b/cluster-provision/gocli/opts/node01/testconfig.go
@@ -8,6 +8,7 @@ func AddExpectCalls(sshClient *kubevirtcimocks.MockSSHClient) {
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
 		"swapoff -a",
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",
+		`timeout=60; interval=5; while ! systemctl status crio | grep active; do echo "Waiting for cri-o service to be ready"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
 		`kubeadm init --config /etc/kubernetes/kubeadm.conf -v5`,
 		`kubectl --kubeconfig=/etc/kubernetes/admin.conf patch deployment coredns -n kube-system -p "$(cat /provision/kubeadm-patches/add-security-context-deployment-patch.yaml)"`,
 		`kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /provision/cni.yaml`,

--- a/cluster-provision/gocli/opts/nodes/nodes.go
+++ b/cluster-provision/gocli/opts/nodes/nodes.go
@@ -40,6 +40,7 @@ func (n *nodesProvisioner) Exec() error {
 		"systemctl daemon-reload &&  service kubelet restart",
 		"swapoff -a",
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",
+		`timeout=60; interval=5; while ! systemctl status crio | grep active; do echo "Waiting for cri-o service to be ready"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
 		"kubeadm join --token abcdef.1234567890123456 " + controlPlaneIP + ":6443 --ignore-preflight-errors=all --discovery-token-unsafe-skip-ca-verification=true",
 		"mkdir -p /var/lib/rook",
 		"chcon -t container_file_t /var/lib/rook",

--- a/cluster-provision/gocli/opts/nodes/testconfig.go
+++ b/cluster-provision/gocli/opts/nodes/testconfig.go
@@ -10,6 +10,7 @@ func AddExpectCalls(sshClient *kubevirtcimocks.MockSSHClient) {
 		"systemctl daemon-reload &&  service kubelet restart",
 		"swapoff -a",
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",
+		`timeout=60; interval=5; while ! systemctl status crio | grep active; do echo "Waiting for cri-o service to be ready"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
 		"kubeadm join --token abcdef.1234567890123456 192.168.66.101:6443 --ignore-preflight-errors=all --discovery-token-unsafe-skip-ca-verification=true",
 		"mkdir -p /var/lib/rook",
 		"chcon -t container_file_t /var/lib/rook",


### PR DESCRIPTION
**What this PR does / why we need it**:

There was previously a wait for the cri-o service to be ready[1] after applying the docker proxy settings but this was not included with the introduction of the opts package[2].

This can lead to kubeadm failing its preflight checks as cri-o is not ready[3]

[1] https://github.com/kubevirt/kubevirtci/blob/03aa94e9da974b0e37dc8f180a4f700d47020c08/cluster-provision/k8s/1.31/nodes.sh#L43
[2] https://github.com/kubevirt/kubevirtci/pull/1217
[3] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/13020/pull-kubevirt-e2e-k8s-1.31-sig-network/1843292337933914112#1:build-log.txt%3A343

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @aerosouund @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
