### PR TITLE
kind,sriov: Fix container tag in conformance tests

### DIFF
--- a/cluster-up/cluster/kind/check-cluster-up.sh
+++ b/cluster-up/cluster/kind/check-cluster-up.sh
@@ -74,7 +74,7 @@ export CRI_BIN=${CRI_BIN:-$(detect_cri)}
     SONOBUOY_EXTRA_ARGS="${SONOBUOY_EXTRA_ARGS} ${kubevirt_plugin}"
 
     commit=$(curl -sL "${nightly_build_base_url}/${latest}/commit")
-    commit="${commit:0:9}"
+    commit="${commit:0:10}"
     container_tag="--plugin-env kubevirt-conformance.CONTAINER_TAG=${latest}_${commit}"
     SONOBUOY_EXTRA_ARGS="${SONOBUOY_EXTRA_ARGS} ${container_tag}"
     


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The check-kind-sriov lane has been failing for the past couple of weeks.

There is an issue pulling the fedora-with-test-tooling container disk:
```
           "status": {
                "conditions": [
                    {
                        "type": "Ready",
                        "status": "False",
                        "lastProbeTime": "2024-10-16T13:53:49Z",
                        "lastTransitionTime": "2024-10-16T13:53:49Z",
                        "reason": "GuestNotRunning",
                        "message": "Guest VM is not reported as running"
                    },
                    {
                        "type": "Synchronized",
                        "status": "False",
                        "lastProbeTime": null,
                        "lastTransitionTime": "2024-10-16T13:57:13Z",
                        "reason": "ImagePullBackOff",
                        "message": "Back-off pulling image \"quay.io/kubevirt/fedora-with-test-tooling-container-disk:20241016_438042b6a\""
                    }
                ],
```

Fixing the container tag that is passed to the conformance tests fixes
this issue


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
