### PR TITLE
bind-vfio: Remove "Error" from echo statement to reduce noise in prow job logs

### DIFF
--- a/cluster-provision/gocli/opts/bind-vfio/bind-vfio.go
+++ b/cluster-provision/gocli/opts/bind-vfio/bind-vfio.go
@@ -42,8 +42,8 @@ func (o *bindVfioOpt) Exec() error {
 	}
 
 	cmds := []string{
-		"if [[ ! -d /sys/bus/pci/devices/" + pciDevId + " ]]; then echo 'Error: PCI address does not exist!' && exit 1; fi",
-		"if [[ ! -d /sys/bus/pci/devices/" + pciDevId + "/iommu/ ]]; then echo 'Error: No vIOMMU found in the VM' && exit 1; fi",
+		"if [[ ! -d /sys/bus/pci/devices/" + pciDevId + " ]]; then echo 'PCI address does not exist!' && exit 1; fi",
+		"if [[ ! -d /sys/bus/pci/devices/" + pciDevId + "/iommu/ ]]; then echo 'No vIOMMU found in the VM' && exit 1; fi",
 		"[[ '" + driver + "' != 'vfio-pci' ]] && echo " + pciDevId + " > " + driverPath + "/unbind && echo 'vfio-pci' > " + driverOverride + " && echo " + pciDevId + " > /sys/bus/pci/drivers/vfio-pci/bind",
 	}
 

--- a/cluster-provision/gocli/opts/bind-vfio/testconfig.go
+++ b/cluster-provision/gocli/opts/bind-vfio/testconfig.go
@@ -16,8 +16,8 @@ func AddExpectCalls(sshClient *kubevirtcimocks.MockSSHClient, pciID string) {
 	sshClient.EXPECT().Command("modprobe -i vfio-pci")
 
 	cmds := []string{
-		"if [[ ! -d /sys/bus/pci/devices/testpciaddr ]]; then echo 'Error: PCI address does not exist!' && exit 1; fi",
-		"if [[ ! -d /sys/bus/pci/devices/testpciaddr/iommu/ ]]; then echo 'Error: No vIOMMU found in the VM' && exit 1; fi",
+		"if [[ ! -d /sys/bus/pci/devices/testpciaddr ]]; then echo 'PCI address does not exist!' && exit 1; fi",
+		"if [[ ! -d /sys/bus/pci/devices/testpciaddr/iommu/ ]]; then echo 'No vIOMMU found in the VM' && exit 1; fi",
 		"[[ 'not-vfio' != 'vfio-pci' ]] && echo testpciaddr > " + driverPath + "/unbind && echo 'vfio-pci' > " + driverOverride + " && echo testpciaddr > /sys/bus/pci/drivers/vfio-pci/bind",
 	}
 	for _, cmd := range cmds {


### PR DESCRIPTION
**What this PR does / why we need it**:

Error messages are highlighted in the prow job logs - these echo statements cause noise in these logs that can confuse people on what the real issue is with a failed job[1].

I think the messages and the exit 1 are clear enough on what the issue is if these are hit

Remove the "Error" string from these echos.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/13091/pull-kubevirt-e2e-k8s-1.29-sig-compute/1849079058487316480#1:build-log.txt%3A302

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
