### PR TITLE
K8s 1.31 provider slim support for s390x arch

### DIFF
--- a/cluster-provision/k8s/1.31/k8s_provision.sh
+++ b/cluster-provision/k8s/1.31/k8s_provision.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+arch=$(uname -m)
+
 source /var/lib/kubevirtci/shared_vars.sh
 
 function getKubernetesClosestStableVersion() {
@@ -203,10 +205,13 @@ sysctl --system
 
 systemctl restart NetworkManager
 
-nmcli connection modify "System eth0" \
-   ipv6.method auto \
-   ipv6.addr-gen-mode eui64
-nmcli connection up "System eth0"
+# No need to modify the ethernet connection incase of s390x Architecture.
+if [ "$arch" != "s390x" ]; then
+  nmcli connection modify "System eth0" \
+    ipv6.method auto \
+    ipv6.addr-gen-mode eui64
+  nmcli connection up "System eth0"
+fi
 
 kubeadmn_patches_path="/provision/kubeadm-patches"
 mkdir -p $kubeadmn_patches_path

--- a/cluster-provision/k8s/1.31/provision.sh
+++ b/cluster-provision/k8s/1.31/provision.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+ARCH=$(uname -m)
+
 KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
 mkdir -p $KUBEVIRTCI_SHARED_DIR
 export ISTIO_VERSION=1.15.0
@@ -58,8 +60,16 @@ dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
 
-dnf install -y centos-release-nfv-openvswitch
-dnf install -y openvswitch2.16
+#openvswitch for s390x is not available from the centos default repos.
+if [ "$ARCH" == "s390x" ]; then
+  dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
+  systemctl enable openvswitch
+else
+  dnf install -y centos-release-nfv-openvswitch
+  dnf install -y openvswitch2.16
+fi 
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 
+# envsubst pkg is not available by default in s390x Architecture, so explicitly installing it as part of gettext
+dnf install -y gettext


### PR DESCRIPTION
**What this PR does / why we need it**:
As with #1252 now k8s 1.30 provider slim supports s390x arch, now with this PR k8s provider **1.31 slim** support for s390x arch is added.
This PR needs to be merged once #1252 gets merged. Commit(s) https://github.com/kubevirt/kubevirtci/pull/1316/commits/493549619f6703f8ad2c294c30dc32c74becc5bd and later, would be mainly to be reviewed here, as all earlier commits in this PR are already reviewd and picked from #1252 (base for this PR)

**Special notes for your reviewer**:
@brianmcarey : The comments you've given on the PR #1252 for publish.sh are addressed in this PR.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
