### PR TITLE
crio: pin cri-o to previous minor version for each provider

### DIFF
--- a/cluster-provision/k8s/1.29/k8s_provision.sh
+++ b/cluster-provision/k8s/1.29/k8s_provision.sh
@@ -65,7 +65,8 @@ gpgcheck=0
 enabled=1
 EOF
 
-dnf install -y cri-o
+#FIXME: Pinned to cri-o v1.29.9 due to issue with conformance tests with v1.29.10
+dnf install -y cri-o-1.29.9
 
 systemctl enable --now crio
 

--- a/cluster-provision/k8s/1.30/k8s_provision.sh
+++ b/cluster-provision/k8s/1.30/k8s_provision.sh
@@ -72,7 +72,8 @@ gpgcheck=0
 enabled=1
 EOF
 
-dnf install -y cri-o
+#FIXME: Pinned to cri-o v1.30.6 due to issue with conformance tests with v1.30.7
+dnf install -y cri-o-1.30.6
 
 systemctl enable --now crio
 

--- a/cluster-provision/k8s/1.31/k8s_provision.sh
+++ b/cluster-provision/k8s/1.31/k8s_provision.sh
@@ -72,7 +72,8 @@ gpgcheck=0
 enabled=1
 EOF
 
-dnf install -y cri-o
+#FIXME: Pinned to cri-o v1.31.1 due to issue with conformance tests with v1.31.2
+dnf install -y cri-o-1.31.1
 
 systemctl enable --now crio
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The conformance tests have been failing consistently against the latest
minor version releases of cri-o[1].

Pin to the previous minor version to unblock kubevirtci PRs

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/1317/check-provision-k8s-1.30/1854522410141749248

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
