### PR TITLE
fix: To update base-image file during x86 publish

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -193,6 +193,7 @@ function main() {
     publish_node_base_image
     if [ $ARCH == "s390x" ]; then
       publish_manifest "centos9" $KUBEVIRTCI_TAG
+    elif [ $ARCH == "amd64" ]; then
       echo "${TARGET_REPO}/centos9:${KUBEVIRTCI_TAG}" > cluster-provision/k8s/base-image
     fi
     exit 0


### PR DESCRIPTION
**What this PR does / why we need it**:
As currently during s390x publish of centos9 image, cluster-provision/k8s/base-image file is getting updated, this bug got introduced in #1252 is fixed now by updating the same file during x86 publish. Also this fix unblocks [PR 3566](https://github.com/kubevirt/project-infra/pull/3566/files#diff-a21ad5b79a285876dc3de98ee13976593770d5142dc3fc2d215e0bc17f386e75 )

**Special notes for your reviewer**:
/cc @brianmcarey 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
