### PR TITLE
fix: IMAGES_TO_BUILD format in publish script

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -23,8 +23,8 @@ IMAGES_TO_BUILD=()
 IMAGES_TO_RETAG=()
 
 function run_provision_manager() {
-  if [ $BYPASS_PMAN == true ]; then
-      IMAGES_TO_BUILD="$(find cluster-provision/k8s/* -maxdepth 0 -type d -printf '%f\n')"
+  if [ "$BYPASS_PMAN" == "true" ]; then
+      IMAGES_TO_BUILD=($(find cluster-provision/k8s/* -maxdepth 0 -type d -printf '%f\n'))
       echo "INFO: Provision manager bypassed, rebuilding all vm based providers"
       echo "IMAGES_TO_BUILD: $(echo ${IMAGES_TO_BUILD[@]})"
       return
@@ -106,12 +106,13 @@ function push_cluster_images() {
 
   # images that the change doesn't affect can be retagged from previous tag
   for i in ${IMAGES_TO_RETAG[@]}; do
-    echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG)"
     if [ $ARCH == "amd64" ]; then 
+      echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
+      echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
     elif [[ "$ARCH" == "s390x" && ( "$i" == "1.30" || "$i" == "1.31" ) ]]; then
-      skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-${ARCH}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-${ARCH}"
+      echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim-$ARCH)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim-${ARCH}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
     fi
   done


### PR DESCRIPTION
**What this PR does / why we need it**:
IMAGES_TO_BUILD is formatted as ('1.29 1.30 1.31') instead of ('1.29','1.30','1.31'). This is fixed now. This was causing publish.sh script to fail where it check for images to be build for publish from IMAGES_TO_BUILD.

**Special notes for your reviewer**:
@brianmcarey This fixes the issue we were seeing when provision manager is bypassed:
- https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirtci-s390x/1859711662324453376
- https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirtci/1859709973081100288
Could you please re-trigger those jobs with change from this PR?

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
