### PR TITLE
publish: disable the publish of alpine containerdisk due to failures

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -212,9 +212,10 @@ function main() {
   done
   
   # Currently the underlying build tool alpine-make-vm-image supports only x86_64 and aarch64
-  if [ $ARCH == "amd64" ]; then
-    publish_alpine_container_disk
-  fi
+  # Disable alpine container disk publish - see https://github.com/kubevirt/kubevirtci/issues/1336
+  #if [ $ARCH == "amd64" ]; then
+  #  publish_alpine_container_disk
+  #fi
 
   push_gocli
   if [ $ARCH == "s390x" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

The alpine container disk build is failing and causing the publish job to not complete successfully[1]

Disable this until issue with the build is resolved

[1] https://github.com/kubevirt/kubevirtci/issues/1336


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
