### PR TITLE
cluster-up, kind: all to exec command via ssh.sh and add port mapping for kind cluster

### DIFF
--- a/cluster-up/cluster/kind-1.28/provider.sh
+++ b/cluster-up/cluster/kind-1.28/provider.sh
@@ -37,6 +37,7 @@ function up() {
     cp $KIND_MANIFESTS_DIR/kind.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
     _add_kubeadm_cpu_manager_config_patch
     _add_extra_mounts
+    _add_extra_portmapping
     export CONFIG_WORKER_CPU_MANAGER=true
     kind_up
 

--- a/cluster-up/cluster/kind-1.31/provider.sh
+++ b/cluster-up/cluster/kind-1.31/provider.sh
@@ -37,6 +37,7 @@ function up() {
     cp $KIND_MANIFESTS_DIR/kind.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
     _add_kubeadm_cpu_manager_config_patch
     _add_extra_mounts
+    _add_extra_portmapping
     export CONFIG_WORKER_CPU_MANAGER=true
     kind_up
 

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -12,6 +12,11 @@ CONFIG_WORKER_CPU_MANAGER=${CONFIG_WORKER_CPU_MANAGER:-false}
 # avaliable value: ipv4, ipv6, dual
 IPFAMILY=${IPFAMILY}
 
+# setup the port mapping for kind cluster, this is needed for some e2e tests
+# KIND_PORT_MAPPING=cluster_port:host_port e.g. KIND_PORT_MAPPING=30001:30002
+# only one port mapping allowed
+KIND_PORT_MAPPING=${KIND_PORT_MAPPING}
+
 # check CPU arch
 PLATFORM=$(uname -m)
 case ${PLATFORM} in
@@ -259,6 +264,22 @@ EOF
         cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
   - containerPath: /dev/vfio/
     hostPath: /dev/vfio/
+EOF
+  fi
+}
+
+function _add_extra_portmapping() {
+  if [[ "$KIND_PORT_MAPPING" != "" ]]; then
+    container_port=$(echo "$KIND_PORT_MAPPING" | awk -F: '{print $1}')
+    host_port=$(echo "$KIND_PORT_MAPPING" | awk -F: '{print $2}')
+    if [[ -z "$container_port" || -z "$host_port" ]]; then
+      echo "Invalid KIND_PORT_MAPPING format. Expected 'container_port:host_port'."
+      exit 1
+    fi
+    cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+  extraPortMappings:
+  - containerPort: $container_port
+    hostPort: $host_port
 EOF
   fi
 }

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -93,7 +93,11 @@ function _insecure-registry-config-cmd() {
 
 # this works since the nodes use the same names as containers
 function _ssh_into_node() {
-    ${CRI_BIN} exec -it "$1" bash
+    if [[ $2 != "" ]]; then
+        ${CRI_BIN} exec "$@"
+    else
+        ${CRI_BIN} exec -it "$1" bash
+    fi    
 }
 
 function _run_registry() {


### PR DESCRIPTION
**What this PR does / why we need it**:
1. ssh.sh now should support both ssh into cluster and exec command in the cluster directly.
2. port mapping is needed for some e2e tests. e.g. cdi upload image related tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
https://github.com/kubevirt/containerized-data-importer/issues/3466

**Release note**:
```release-note
NONE
```
