### PR TITLE
cluster-up, kind, common: Enable TopologyManager for kind-sriov

### DIFF
--- a/cluster-up/cluster/kind-sriov/provider.sh
+++ b/cluster-up/cluster/kind-sriov/provider.sh
@@ -62,6 +62,7 @@ function deploy_sriov() {
 function up() {
     cp $KIND_MANIFESTS_DIR/kind.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
     export CONFIG_WORKER_CPU_MANAGER=true
+    export CONFIG_TOPOLOGY_MANAGER_POLICY="single-numa-node"
     kind_up
 
     configure_registry_proxy

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -311,11 +311,17 @@ EOF
     done
 }
 
-function _add_kubeadm_config_patches() {
-    if [ $KUBEVIRT_WITH_KIND_ETCD_IN_MEMORY == "true" ]; then
-        cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+function _add_kubeadm_config_patches_header() {
+   cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
 kubeadmConfigPatches:
 - |
+EOF
+}
+
+function _add_kubeadm_config_patches() {
+  _add_kubeadm_config_patches_header
+  if [ $KUBEVIRT_WITH_KIND_ETCD_IN_MEMORY == "true" ]; then
+    cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
   kind: ClusterConfiguration
   metadata:
     name: config
@@ -323,8 +329,16 @@ kubeadmConfigPatches:
     local:
       dataDir: $ETCD_IN_MEMORY_DATA_DIR
 EOF
-        echo "KIND cluster etcd data will be mounted to RAM on kind nodes: $ETCD_IN_MEMORY_DATA_DIR"
-    fi
+    echo "KIND cluster etcd data will be mounted to RAM on kind nodes: $ETCD_IN_MEMORY_DATA_DIR"
+  fi
+  if [[ -n "$CONFIG_TOPOLOGY_MANAGER_POLICY" ]]; then
+     cat <<EOF >> ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
+  ---
+  kind: KubeletConfiguration
+  topologyManagerPolicy: ${CONFIG_TOPOLOGY_MANAGER_POLICY}
+  ---
+EOF
+  fi
 }
 
 function _setup_ipfamily() {
@@ -339,7 +353,9 @@ EOF
 
 function _prepare_kind_config() {
     _add_workers
-    _add_kubeadm_config_patches
+    if [[ "$KUBEVIRT_WITH_KIND_ETCD_IN_MEMORY" == "true" ||  -n "$CONFIG_TOPOLOGY_MANAGER_POLICY" ]]; then
+      _add_kubeadm_config_patches
+    fi
     _setup_ipfamily
     echo "Final KIND config:"
     cat ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
SR-IOV tests check topology alignment. Currently in kind/sriov kueblet does not attempt to align resources.
In SR-IOV alignment test, we call the function `hardware.LookupDeviceVCPUAffinity()`. This function returns a slice of
aligned CPUs, i.e. (complex sentence ahead warning) CPU numbers,
that are assigned to the guest, which share a NUMA with SRIOV VFs, that are also passed to the guest.
In other words: If an app is running in the guest, and using a network interface, that NIC is physically close to its CPU, and it doesn't have to cross the system bus to get to it.
Back to `LookupDeviceVCPUAffinity()`: if it finds that there is no aligment, it doesn't err, it just returns an empty slice.
As the test is currently written, an empty list is fine i.e. no alignment: it simply validates that the guest knows that there's no alignment, by validating it in the cloud-init metadata file in the guest.
This change adding a topology manager policy of single-numa-node, forces alignment. If alignment is not achieved, scheduling will fail.
We will also assert in the test that the alignment slice is not empty.

Add topology manager[1] to kubelet config and set its policy to single-numa-node.
Together with cpu-manager policy=static, which we already set,
kubelet will reject a pod that it is unable to align.
[1] https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
