### PR TITLE
kind, check-cluster-up: Enable Kubevirt CPUManager FG when SR-IOV provider is tested

### DIFF
--- a/cluster-up/cluster/kind/check-cluster-up.sh
+++ b/cluster-up/cluster/kind/check-cluster-up.sh
@@ -69,6 +69,11 @@ export CRI_BIN=${CRI_BIN:-$(detect_cri)}
     fi
     ${kubectl} wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m
 
+    if [[ "$KUBEVIRT_PROVIDER" =~ "sriov" ]]; then
+      # Some SR-IOV tests require Kubevirt CPUManager feature
+      ${kubectl} patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "replace", "path": "/spec/configuration/developerConfiguration/featureGates","value": ["CPUManager"]}]'
+    fi
+
     echo "Run latest nighly build Kubevirt conformance tests"
     kubevirt_plugin="--plugin ${nightly_build_base_url}/${latest}/conformance.yaml"
     SONOBUOY_EXTRA_ARGS="${SONOBUOY_EXTRA_ARGS} ${kubevirt_plugin}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The "check-up-kind-sriov" is turned optional and **not gating** because it constantly failing, due to following tests failures:
```
SRIOV VMI connected to single SRIOV network should have cloud-init meta_data with tagged interface and aligned cpus to sriov interface numa node for VMIs with dedicatedCPUs
SRIOV VMI connected to single SRIOV network [test_id:3959]should create a virtual machine with sriov interface and dedicatedCPUs
```

The mentioned tests causing the lane to fail following removal of programmatic skips in kubevirt/kubevirt tests https://github.com/kubevirt/kubevirt/pull/13144, affecting the mentioned tests.
Previously the mentioned tests were skipped silently (bad) and now, following the programmatic skip removal, fail loudly.
The root cause for the failures (or previous skips) is tests depends on Kubevirt's CPUManager feature but its not enabled at all, see below notes section for more details *.

This PR fixes the lane by enabling Kubevirt's CPUManager features when SR-IOV provider is tested.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
* When Kubevirt's CPUManager feature is on, it will label supporting nodes with cpumanager=ture label (done by the  heartbeat controller).
The failing tests, creates VMs with dedicated-CPUs option, Kubevirt will label such VM's virt-launcher pod with node-selector signifying `cpumanager=true` label.
The end result is the tested VMs fail to become ready on time due to impossible scheduling; VMs has `cpumanager=ture` node selector, but no node has `cpumanager=true` label.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kind/check-cluster-up.sh enable Kubevirt's CPUManager feature when the SR-IOV provider is tested.
```
