### PR TITLE
fix: gocli startup in s390x architecture

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -114,7 +114,8 @@ function _add_common_params() {
             params=" --container-suffix=:$KUBEVIRTCI_CONTAINER_SUFFIX $params"
         fi
 
-        if [[ ${KUBEVIRT_SLIM} == "true" ]]; then
+        # Currently, the s390x architecture supports only KUBEVIRT_SLIM.
+        if [[ ${KUBEVIRT_SLIM} == "true" || $(uname -m) == "s390x" ]]; then
             params=" --slim $params"
         fi
     fi


### PR DESCRIPTION
The gocli container image is multi-architecture compatible; however, it attempts to download the k8s-1.30 image, which is not available for the s390x architecture. The k8s-1.30-slim image, on the other hand, is compatible. To enable support for s390x, we can enforce the use of the --slim parameter for this architecture.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
