### PR TITLE
kind-sriov: Bump SR-IOV CNI and device-plugin

### DIFF
--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/kustomization.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/kustomization.yaml
@@ -11,7 +11,7 @@ patchesJson6902:
     group: apps
     version: v1
     kind: DaemonSet
-    name: kube-sriov-cni-ds-amd64
+    name: kube-sriov-cni-ds
   path: patch-node-selector.yaml
 - target:
     group: apps

--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/kustomization.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - sriov-cni-daemonset.yaml
 - sriovdp-daemonset.yaml
 - sriovdp-config.yaml
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/kustomization.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/kustomization.yaml
@@ -17,11 +17,11 @@ patchesJson6902:
     group: apps
     version: v1
     kind: DaemonSet
-    name: kube-sriov-device-plugin-amd64
+    name: kube-sriov-device-plugin
   path: patch-node-selector.yaml
 - target:
     group: apps
     version: v1
     kind: DaemonSet
-    name: kube-sriov-device-plugin-amd64
+    name: kube-sriov-device-plugin
   path: patch-sriovdp-resource-prefix.yaml

--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/patch-node-selector.yaml.in
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/patch-node-selector.yaml.in
@@ -1,3 +1,9 @@
 - op: add
+  path: /spec/template/spec/nodeSelector
+  value: {}
+- op: add
+  path: /spec/template/spec/nodeSelector/$LABEL_KEY
+  value: "$LABEL_VALUE"
+- op: test
   path: /spec/template/spec/nodeSelector/$LABEL_KEY
   value: "$LABEL_VALUE"

--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/sriov-cni-daemonset.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/sriov-cni-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-sriov-cni
-        image: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.7.0
+        image: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.9.0
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/sriov-cni-daemonset.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/sriov-cni-daemonset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kube-sriov-cni-ds-amd64
+  name: kube-sriov-cni-ds
   namespace: kube-system
   labels:
     tier: node
@@ -18,9 +18,10 @@ spec:
         tier: node
         app: sriov-cni
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
       - key: node-role.kubernetes.io/control-plane
         operator: Exists
         effect: NoSchedule

--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/sriovdp-daemonset.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/sriovdp-daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kube-sriov-device-plugin-amd64
+  name: kube-sriov-device-plugin
   namespace: kube-system
   labels:
     tier: node
@@ -26,12 +26,6 @@ spec:
         app: sriovdp
     spec:
       hostNetwork: true
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
-      tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
@@ -51,7 +45,10 @@ spec:
             memory: "200Mi"
         volumeMounts:
         - name: devicesock
-          mountPath: /var/lib/kubelet/
+          mountPath: /var/lib/kubelet/device-plugins
+          readOnly: false
+        - name: plugins-registry
+          mountPath: /var/lib/kubelet/plugins_registry
           readOnly: false
         - name: log
           mountPath: /var/log
@@ -62,150 +59,10 @@ spec:
       volumes:
         - name: devicesock
           hostPath:
-            path: /var/lib/kubelet/
-        - name: log
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
           hostPath:
-            path: /var/log
-        - name: device-info
-          hostPath:
-            path: /var/run/k8s.cni.cncf.io/devinfo/dp
-            type: DirectoryOrCreate
-        - name: config-volume
-          configMap:
-            name: sriovdp-config
-            items:
-            - key: config.json
-              path: config.json
-
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: kube-sriov-device-plugin-ppc64le
-  namespace: kube-system
-  labels:
-    tier: node
-    app: sriovdp
-spec:
-  selector:
-    matchLabels:
-      name: sriov-device-plugin
-  template:
-    metadata:
-      labels:
-        name: sriov-device-plugin
-        tier: node
-        app: sriovdp
-    spec:
-      hostNetwork: true
-      nodeSelector:
-        beta.kubernetes.io/arch: ppc64le
-      tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      serviceAccountName: sriov-device-plugin
-      containers:
-      - name: kube-sriovdp
-        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest-ppc64le
-        imagePullPolicy: IfNotPresent
-        args:
-        - --log-dir=sriovdp
-        - --log-level=10
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "250m"
-            memory: "40Mi"
-          limits:
-            cpu: 1
-            memory: "200Mi"
-        volumeMounts:
-        - name: devicesock
-          mountPath: /var/lib/kubelet/
-          readOnly: false
-        - name: log
-          mountPath: /var/log
-        - name: config-volume
-          mountPath: /etc/pcidp
-        - name: device-info
-          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
-      volumes:
-        - name: devicesock
-          hostPath:
-            path: /var/lib/kubelet/
-        - name: log
-          hostPath:
-            path: /var/log
-        - name: device-info
-          hostPath:
-            path: /var/run/k8s.cni.cncf.io/devinfo/dp
-            type: DirectoryOrCreate
-        - name: config-volume
-          configMap:
-            name: sriovdp-config
-            items:
-            - key: config.json
-              path: config.json
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: kube-sriov-device-plugin-arm64
-  namespace: kube-system
-  labels:
-    tier: node
-    app: sriovdp
-spec:
-  selector:
-    matchLabels:
-      name: sriov-device-plugin
-  template:
-    metadata:
-      labels:
-        name: sriov-device-plugin
-        tier: node
-        app: sriovdp
-    spec:
-      hostNetwork: true
-      nodeSelector:
-        beta.kubernetes.io/arch: arm64
-      tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      serviceAccountName: sriov-device-plugin
-      containers:
-      - name: kube-sriovdp
-        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:latest-arm64
-        imagePullPolicy: IfNotPresent
-        args:
-        - --log-dir=sriovdp
-        - --log-level=10
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "250m"
-            memory: "40Mi"
-          limits:
-            cpu: 1
-            memory: "200Mi"
-        volumeMounts:
-        - name: devicesock
-          mountPath: /var/lib/kubelet/
-          readOnly: false
-        - name: log
-          mountPath: /var/log
-        - name: config-volume
-          mountPath: /etc/pcidp
-        - name: device-info
-          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
-      volumes:
-        - name: devicesock
-          hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet/plugins_registry
         - name: log
           hostPath:
             path: /var/log

--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/sriovdp-daemonset.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/sriovdp-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp
-        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.4.0
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.9.0
         imagePullPolicy: IfNotPresent
         args:
         - --log-dir=sriovdp


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The kind-sriov providier use pretty old versions of the sriov-cni and sriov-dp (device-plugin).

Bump SR-IOV CNI to [v2.9.0](https://github.com/k8snetworkplumbingwg/sriov-cni/releases/tag/v2.9.0)
Bump SR-IOV device-plugin [v3.9.0](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/releases/tag/v3.9.0)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
