### PR TITLE
fix: segmentation fault when using podman

### DIFF
--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -47,14 +47,20 @@ function up() {
     fi
     eval ${_cli:?} run $params
 
-    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+    # Workaround https://github.com/containers/conmon/issues/315 by not dumping file content to stdout
+    scp_suffix="- >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER"
+    if [[ ${_cri_bin} = podman* ]]; then
+        scp_suffix="/kubevirtci_config"
+    fi
+
+    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf ${scp_suffix}/.kubeconfig
 
     # Set server and disable tls check
     export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
     kubectl config set-cluster kubernetes --server="https://$(_main_ip):$(_port k8s)"
     kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
 
-    ${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    ${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl ${scp_suffix}/.kubectl
     
     chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
 


### PR DESCRIPTION
The ephemeral-provider-common.sh script reveals several issues related to Podman, particularly when dumping file content to stdout. The CLI scp command is affected; however, by replacing the string "- >" with the destination folder itself, the command functions correctly.

Additionally, it's important to note that the destination folder differs between Podman and Docker due to changes made in ephemeral_provider_common.sh on line 57.

As an alternative, we could consider making this workaround more generic by eliminating the use of "- >" altogether.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
