### PR TITLE
ceph: Increase timeout for ceph to be ready to 10 minutes

### DIFF
--- a/cluster-provision/gocli/opts/rookceph/ceph.go
+++ b/cluster-provision/gocli/opts/rookceph/ceph.go
@@ -95,7 +95,7 @@ func (o *cephOpt) Exec() error {
 
 	backoffStrategy := backoff.NewExponentialBackOff()
 	backoffStrategy.InitialInterval = 30 * time.Second
-	backoffStrategy.MaxElapsedTime = 6 * time.Minute
+	backoffStrategy.MaxElapsedTime = 10 * time.Minute
 
 	err = backoff.Retry(operation, backoffStrategy)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This timeout has been hit on a number of occasions[1] when the cluster is loaded and there is high competition for IO.

As the storage setup in the CI workloads cluster needs to be improved, increase the timeout for now to avoid failing e2e lanes on cluster-up.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/13862/pull-kubevirt-e2e-k8s-1.31-sig-compute-migrations/1887411164745306112#1:build-log.txt%3A2275

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @akalenyu 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
