### PR TITLE
Fix: Bypass Provision Manager for s390x kubevirtci publish

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -8,6 +8,12 @@ ARCH=$(uname -m | grep -q s390x && echo s390x || echo amd64)
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)}
 PREV_KUBEVIRTCI_TAG=$(curl -sL https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest?ignoreCache=1)
 BYPASS_PMAN=${BYPASS_PMAN:-false}
+# As of now, we are updating kubevirt-prow/release/kubevirt/kubevirtci/latest after amd64 images are published, independent of s390x image publish failure.
+# Provision manager assumes s390x images are available with the tag in the latest file and tries to retag them when no diffs between the current code and the tag.
+# This workaround is required till we make tag in latest file be updated after s390x image is published as well.
+if [ $ARCH == "s390x" ]; then
+  BYPASS_PMAN=true
+fi
 PHASES=${PHASES:-k8s}
 
 function detect_cri() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Bypass Provision Manager for s390x kubevirtci publish

Currently we are updating kubevirt-prow/release/kubevirt/kubevirtci/latest file after amd64 images are published, independent of s390x image publish failure. Provision manager assumes s390x images are available with the tag in the latest file and tries to retag them when no diffs between the current code and the tag. But this fails, when no s390x image exists with tag in the latest file.

This fixes failures of prow build which publishes kubevirtci images of s390x arch, where build failed as source image tag provision manager tries to re-tag doesn't exist in container image repository:
[publish-kubevirtci-s390x/1887109512381337600](https://storage.googleapis.com/kubevirt-prow/logs/publish-kubevirtci-s390x/1887109512381337600/build-log.txt)
[publish-kubevirtci-s390x/1886536840723304448](https://storage.googleapis.com/kubevirt-prow/logs/publish-kubevirtci-s390x/1886536840723304448/build-log.txt)
[publish-kubevirtci-s390x/1884887500791484416](https://storage.googleapis.com/kubevirt-prow/logs/publish-kubevirtci-s390x/1884887500791484416/build-log.txt)

**Special notes for your reviewer**:
/cc @brianmcarey 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

```release-note
NONE
```
