### PR TITLE
In Provision Manager, call "git fetch --tags" command to avoid git diff fail

### DIFF
--- a/cluster-provision/gocli/cmd/provision_manager.go
+++ b/cluster-provision/gocli/cmd/provision_manager.go
@@ -324,7 +324,7 @@ func runCommand(command string, args []string) (string, error) {
 	}
 
 	var stderr2 bytes.Buffer
-	fetchCmd := exec.Command("git", "fetch", "upstream", "main", "--tags")
+	fetchCmd := exec.Command("git", "fetch", "upstream", "--tags")
 	fetchCmd.Stderr = &stderr2
 	if err := fetchCmd.Run(); err != nil {
 		logrus.Debugf("Failed to fetch tags from upstream: %v, stderr: %s", err, stderr2.String())
@@ -337,7 +337,7 @@ func runCommand(command string, args []string) (string, error) {
 	err := cmd.Run()
 	if err != nil {
 		if strings.Contains(stderr3.String(), "unknown revision or path not in the working tree") {
-			logrus.Error("Tag not found, please run 'git fetch upstream main --tags'")
+			logrus.Error("Tag not found, please run 'git fetch upstream --tags'")
 		}
 		return "", errors.Wrapf(err, "Failed to run command: %s %s\nStdout:\n%s\nStderr:\n%s",
 			command, strings.Join(args, " "), cmd.Stdout, cmd.Stderr)


### PR DESCRIPTION
**What this PR does / why we need it**:
Without change - In provision manager while doing git diff to a tag obtained from latest file in gcs, if that tag is not present on local clone, we are exiting with a message to run git fetch by the user. 

Now with this change- we are once 'trying' to run the git fetch tags command after add upstream remote, before asking the user to do that.

This is mainly required to avoid failures in publish-kubevirtci-s390x job builds below, as while a build of this job is running, x86 equivalent job publish-kubevirtci might have updated latest file in GCS with new tag and tagged a commit in main, but as the publish-kubevirtci-s390x build is already in progress, its tags are outdated and needs a fetch:

[publish-kubevirtci-s390x/1886496178602774528](https://storage.googleapis.com/kubevirt-prow/logs/publish-kubevirtci-s390x/1886496178602774528/build-log.txt)
[publish-kubevirtci-s390x/1886111630970851328](https://storage.googleapis.com/kubevirt-prow/logs/publish-kubevirtci-s390x/1886111630970851328/build-log.txt)
[publish-kubevirtci-s390x/1885392389216931840](https://storage.googleapis.com/kubevirt-prow/logs/publish-kubevirtci-s390x/1885392389216931840/build-log.txt)
[publish-kubevirtci-s390x/1884869941908213760](https://storage.googleapis.com/kubevirt-prow/logs/publish-kubevirtci-s390x/1884869941908213760/build-log.txt)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
