### PR TITLE
Revert "fix: segmentation fault when using podman (#1368)"

### DIFF
--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -47,20 +47,14 @@ function up() {
     fi
     eval ${_cli:?} run $params
 
-    # Workaround https://github.com/containers/conmon/issues/315 by not dumping file content to stdout
-    scp_suffix="- >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER"
-    if [[ ${_cri_bin} = podman* ]]; then
-        scp_suffix="/kubevirtci_config"
-    fi
-
-    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf ${scp_suffix}/.kubeconfig
+    ${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 
     # Set server and disable tls check
     export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
     kubectl config set-cluster kubernetes --server="https://$(_main_ip):$(_port k8s)"
     kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
 
-    ${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl ${scp_suffix}/.kubectl
+    ${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
     
     chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts commit f58328a78330dff7e7c62d10c867b6ca27ee6baa.

A number of users have reported issues running dev clusters locally with docker since this change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
