### PR TITLE
fix: segmentation fault in podman

### DIFF
--- a/cluster-up/cluster/k8s-provider-common.sh
+++ b/cluster-up/cluster/k8s-provider-common.sh
@@ -48,15 +48,13 @@ function up() {
     eval ${_cli:?} run $params
 
     cli_scp_command "${_cli} scp --prefix $provider_prefix /etc/kubernetes/admin.conf" ".kubeconfig"
+    cli_scp_command "${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl" ".kubectl"
+    change_permissions
 
     # Set server and disable tls check
     export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
-    kubectl config set-cluster kubernetes --server="https://$(_main_ip):$(_port k8s)"
-    kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
-
-    cli_scp_command "${_cli} scp --prefix ${provider_prefix:?} /usr/bin/kubectl" ".kubectl"
-    
-    chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    _kubectl config set-cluster kubernetes --server="https://$(_main_ip):$(_port k8s)"
+    _kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct
     prepare_config
@@ -96,5 +94,17 @@ function cli_scp_command() {
         $prefix_cli /kubevirtci_config/$destination_file
     else
         $prefix_cli - >${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/$destination_file
+    fi
+}
+
+function change_permissions() {
+    if [[ ${_cri_bin} = podman* ]]; then
+        args="-v ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER:/kubevirtci_config"
+        ${_cri_bin} run --privileged --rm $args \
+            --entrypoint /bin/sh ${_cli_container} \
+            -c "chmod 755 /kubevirtci_config/.kubectl"
+        ${_cri_bin} run --privileged --rm $args \
+            --entrypoint /bin/sh ${_cli_container} \
+            -c "chmod 766 /kubevirtci_config/.kubeconfig"
     fi
 }


### PR DESCRIPTION
For more information, please refer to:
https://github.com/containers/conmon/issues/315

The decision to create an additional function instead of using a variable is based on the behavior of shell parameter expansion. Specifically, defining a variable with a character such as '>' will result in the Bash shell adding quotes before executing the command.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
