### PR TITLE
fix: exit early when nested virtualization is not enabled in s390x

### DIFF
--- a/cluster-up/check.sh
+++ b/cluster-up/check.sh
@@ -53,8 +53,13 @@ if is_enabled "$KVM_NESTED"; then
 	echo "[ OK ] $KVM_ARCH nested virtualization enabled"
 else
 	echo "[ERR ] $KVM_ARCH nested virtualization not enabled"
+	# Exits early only in s390x. There may be some use cases with emulation for another architectures.
+	if [ "$KVM_ARCH" == "s390x" ]; then
+		exit 1
+	fi
 fi
 
 if is_enabled "$KVM_HPAGE" && [ "$(uname -m)" = "s390x" ]; then
 	echo "[ERR ] $KVM_HPAGE KVM hugepage enabled. It needs to be disabled while nested virtualization is enabled for s390x"
+	exit 1
 fi


### PR DESCRIPTION
This change saves developers and maintainers time checking logs.

Context: In our s390x CI cluster, sometimes nested virtualization was disabled. This approach will help us identify such occurrences more quickly in the future.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
