### PR TITLE
feat: enable variable for requiring nested virtualization

### DIFF
--- a/cluster-up/check.sh
+++ b/cluster-up/check.sh
@@ -53,6 +53,10 @@ if is_enabled "$KVM_NESTED"; then
 	echo "[ OK ] $KVM_ARCH nested virtualization enabled"
 else
 	echo "[ERR ] $KVM_ARCH nested virtualization not enabled"
+	if [ $KUBEVIRT_NESTED_VIRTUALIZATION_REQUIRED == "true" ]; then
+		echo "[ERR ] nested virtualization required, exiting..."
+		exit 1
+	fi
 fi
 
 if is_enabled "$KVM_HPAGE" && [ "$(uname -m)" = "s390x" ]; then

--- a/cluster-up/cluster/K8S.md
+++ b/cluster-up/cluster/K8S.md
@@ -60,6 +60,13 @@ export KUBEVIRT_SLIM=true
 make cluster-up
 ```
 
+## Start only if nested virtualization is enabled
+
+```bash
+export KUBEVIRT_NESTED_VIRTUALIZATION_REQUIRED=true
+make cluster-up
+```
+
 ## Enabling IPv6 connectivity
 
 In order to be able to reach from the cluster to the host's IPv6 network, IPv6


### PR DESCRIPTION
When this variable is enabled, the cluster-up process will fail early. This approach helps to avoid disrupting existing workflows that rely on emulation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
