### PR TITLE
feat: Add a new flag to configure the dynamic-networks-controller being deploy through CNAO

### DIFF
--- a/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
@@ -38,6 +38,7 @@ type NodeK8sConfig struct {
 	CDIVersion   string
 	AAQ          bool
 	AAQVersion   string
+	DNC          bool
 }
 
 func NewNodeK8sConfig(confs []K8sConfigFunc) *NodeK8sConfig {

--- a/cluster-provision/gocli/cmd/nodesconfig/opts.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/opts.go
@@ -172,12 +172,22 @@ func WithCnao(cnao bool) K8sConfigFunc {
 	}
 }
 
+// Skips creation of the CNAO custom resource. Just installs the CRD and the operator
 func WithCNAOSkipCR(skip bool) K8sConfigFunc {
 	return func(n *NodeK8sConfig) {
 		n.CNAOSkipCR = skip
 	}
 }
 
+// Whether or no to deploy the dynamic networks controller through CNAO
+func WithDNC(dnc bool) K8sConfigFunc {
+	return func(n *NodeK8sConfig) {
+		n.DNC = dnc
+	}
+}
+
+// If enabled. Multus V3 will be deployed standalone separate from CNAO.
+// Multus V4 that gets deployed with CNAO will be skipped in case CNAO is enabled
 func WithMultus(multus bool) K8sConfigFunc {
 	return func(n *NodeK8sConfig) {
 		n.Multus = multus
@@ -205,11 +215,5 @@ func WithAAQ(aaq bool) K8sConfigFunc {
 func WithAAQVersion(aaqVersion string) K8sConfigFunc {
 	return func(n *NodeK8sConfig) {
 		n.AAQVersion = aaqVersion
-	}
-}
-
-func WithDNC(dnc bool) K8sConfigFunc {
-	return func(n *NodeK8sConfig) {
-		n.DNC = dnc
 	}
 }

--- a/cluster-provision/gocli/cmd/nodesconfig/opts.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/opts.go
@@ -207,3 +207,9 @@ func WithAAQVersion(aaqVersion string) K8sConfigFunc {
 		n.AAQVersion = aaqVersion
 	}
 }
+
+func WithDNC(dnc bool) K8sConfigFunc {
+	return func(n *NodeK8sConfig) {
+		n.DNC = dnc
+	}
+}

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -131,6 +131,7 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().Bool("reverse", false, "reverse node setup order")
 	run.Flags().Bool("enable-cnao", false, "enable network extensions with istio")
 	run.Flags().Bool("skip-cnao-cr", false, "skip deploying cnao custom resource. if true, only cnao CRDS will be deployed")
+	run.Flags().Bool("deploy-dnc", true, "deploy the dynamic networks controller with CNAO")
 	run.Flags().Bool("deploy-multus", false, "deploy multus")
 	run.Flags().Bool("deploy-cdi", false, "deploy cdi")
 	run.Flags().String("cdi-version", "", "cdi version")
@@ -164,7 +165,6 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().Bool("single-stack", false, "enable single stack IPv6")
 	run.Flags().Bool("no-etcd-fsync", false, "unsafe: disable fsyncs in etcd")
 	run.Flags().Bool("enable-audit", false, "enable k8s audit for all metadata events")
-	run.Flags().Bool("deploy-dnc", true, "deploy the dynamic networks controller with CNAO")
 	run.Flags().StringArrayVar(&usbDisks, "usb", []string{}, "size of the emulate USB disk to pass to the node")
 	run.Flags().StringArrayVar(&sharedDisks, "shared-block-device", []string{}, "size of block device to share between all nodes")
 
@@ -359,6 +359,10 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 	if err != nil {
 		return err
 	}
+	deployDNC, err := cmd.Flags().GetBool("deploy-dnc")
+	if err != nil {
+		return err
+	}
 
 	deployCdi, err := cmd.Flags().GetBool("deploy-cdi")
 	if err != nil {
@@ -416,11 +420,6 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	ksmScanInterval, err := cmd.Flags().GetUint("ksm-scan-interval")
-	if err != nil {
-		return err
-	}
-
-	deployDNC, err := cmd.Flags().GetBool("deploy-dnc")
 	if err != nil {
 		return err
 	}
@@ -849,12 +848,12 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		nodesconfig.WithNfsCsi(nfsCsiEnabled),
 		nodesconfig.WithCnao(cnaoEnabled),
 		nodesconfig.WithCNAOSkipCR(cnaoSkipCR),
+		nodesconfig.WithDNC(deployDNC),
 		nodesconfig.WithMultus(deployMultus),
 		nodesconfig.WithCdi(deployCdi),
 		nodesconfig.WithCdiVersion(cdiVersion),
 		nodesconfig.WithAAQ(deployAaq),
 		nodesconfig.WithAAQVersion(aaqVersion),
-		nodesconfig.WithDNC(deployDNC),
 	}
 	n := nodesconfig.NewNodeK8sConfig(k8sConfs)
 

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -131,7 +131,7 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().Bool("reverse", false, "reverse node setup order")
 	run.Flags().Bool("enable-cnao", false, "enable network extensions with istio")
 	run.Flags().Bool("skip-cnao-cr", false, "skip deploying cnao custom resource. if true, only cnao CRDS will be deployed")
-	run.Flags().Bool("deploy-dnc", true, "deploy the dynamic networks controller with CNAO")
+	run.Flags().Bool("deploy-dnc", false, "deploy the dynamic networks controller with CNAO")
 	run.Flags().Bool("deploy-multus", false, "deploy multus")
 	run.Flags().Bool("deploy-cdi", false, "deploy cdi")
 	run.Flags().String("cdi-version", "", "cdi version")

--- a/cluster-provision/gocli/opts/cnao/cnao.go
+++ b/cluster-provision/gocli/opts/cnao/cnao.go
@@ -20,15 +20,17 @@ type cnaoOpt struct {
 	client        k8s.K8sDynamicClient
 	sshClient     libssh.Client
 	multusEnabled bool
+	dncEnabled    bool
 	skipCR        bool
 }
 
-func NewCnaoOpt(c k8s.K8sDynamicClient, sshClient libssh.Client, multusEnabled, skipCR bool) *cnaoOpt {
+func NewCnaoOpt(c k8s.K8sDynamicClient, sshClient libssh.Client, multusEnabled, dncEnabled, skipCR bool) *cnaoOpt {
 	return &cnaoOpt{
 		client:        c,
 		sshClient:     sshClient,
 		multusEnabled: multusEnabled,
 		skipCR:        skipCR,
+		dncEnabled:    dncEnabled,
 	}
 }
 
@@ -54,7 +56,13 @@ func (o *cnaoOpt) Exec() error {
 					}
 
 					if o.multusEnabled {
-						re := regexp.MustCompile("(?m)[\r\n]+^.*multus.*$")
+						re := regexp.MustCompile("(?m)[\r\n]+^.*multus:.*$")
+						res := re.ReplaceAllString(string(yamlDoc), "")
+						yamlDoc = []byte(res)
+					}
+
+					if !o.dncEnabled {
+						re := regexp.MustCompile("(?m)[\r\n]+^.*multusDynamicNetworks:.*$")
 						res := re.ReplaceAllString(string(yamlDoc), "")
 						yamlDoc = []byte(res)
 					}

--- a/cluster-provision/gocli/opts/cnao/cnao_test.go
+++ b/cluster-provision/gocli/opts/cnao/cnao_test.go
@@ -35,7 +35,7 @@ var _ = Describe("CnaoOpt", func() {
 	})
 
 	It("should execute create CNAO with Multus", func() {
-		opt = NewCnaoOpt(client, sshClient, false, false)
+		opt = NewCnaoOpt(client, sshClient, false, true, false)
 		sshClient.EXPECT().Command("kubectl --kubeconfig=/etc/kubernetes/admin.conf wait deployment -n cluster-network-addons cluster-network-addons-operator --for condition=Available --timeout=200s")
 		opt.Exec()
 
@@ -51,7 +51,7 @@ var _ = Describe("CnaoOpt", func() {
 	})
 
 	It("should execute create CNAO without Multus", func() {
-		opt = NewCnaoOpt(client, sshClient, true, false)
+		opt = NewCnaoOpt(client, sshClient, true, false, false)
 		sshClient.EXPECT().Command("kubectl --kubeconfig=/etc/kubernetes/admin.conf wait deployment -n cluster-network-addons cluster-network-addons-operator --for condition=Available --timeout=200s")
 		opt.Exec()
 

--- a/cluster-provision/gocli/opts/cnao/cnao_test.go
+++ b/cluster-provision/gocli/opts/cnao/cnao_test.go
@@ -81,7 +81,7 @@ var _ = Describe("CnaoOpt", func() {
 	It("should execute create CNAO with dynamic networks controller", func() {
 		skipCR = false
 		dncEnabled = true
-		multusEnabled = true
+		multusEnabled = false
 
 		opt = NewCnaoOpt(client, sshClient, multusEnabled, dncEnabled, skipCR)
 		sshClient.EXPECT().Command("kubectl --kubeconfig=/etc/kubernetes/admin.conf wait deployment -n cluster-network-addons cluster-network-addons-operator --for condition=Available --timeout=200s")
@@ -95,5 +95,6 @@ var _ = Describe("CnaoOpt", func() {
 		spec, ok := obj.Object["spec"].(map[string]interface{})
 		Expect(ok).To(Equal(true))
 		Expect(spec).To(HaveKey("multusDynamicNetworks"))
+		Expect(spec).To(HaveKey("multus"))
 	})
 })

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -194,6 +194,10 @@ function _add_common_params() {
         params=" --deploy-multus $params"
     fi
 
+    if [ "$KUBEVIRT_WITH_DNC" == "true" ]; then
+        params=" --deploy-dnc $params"
+    fi
+
     if [ "$KUBEVIRT_WITH_CNAO" == "true" ]; then
         params=" --enable-cnao $params"
     fi

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -194,12 +194,12 @@ function _add_common_params() {
         params=" --deploy-multus $params"
     fi
 
-    if [ "$KUBEVIRT_WITH_DYN_NET_CTRL" == "true" ]; then
-        params=" --deploy-dnc $params"
-    fi
-
     if [ "$KUBEVIRT_WITH_CNAO" == "true" ]; then
         params=" --enable-cnao $params"
+    fi
+
+    if [ "$KUBEVIRT_WITH_DYN_NET_CTRL" == "true" ]; then
+        params=" --deploy-dnc $params"
     fi
 
     if [ "$KUBEVIRT_DEPLOY_CDI" == "true" ]; then

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -194,7 +194,7 @@ function _add_common_params() {
         params=" --deploy-multus $params"
     fi
 
-    if [ "$KUBEVIRT_WITH_DNC" == "true" ]; then
+    if [ "$KUBEVIRT_WITH_DYN_NET_CTRL" == "true" ]; then
         params=" --deploy-dnc $params"
     fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, if Multus V3 was enabled it also disables the deployment of DNC through CNAO. This patch makes this behavior in a separate flag

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1380 

**Special notes for your reviewer**:
cc @brianmcarey @orelmisan 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

