### PR TITLE
vm-image: Upgrade fedora-with-test-tooling to Fedora 39

### DIFF
--- a/cluster-provision/images/vm-image-builder/example/image-url
+++ b/cluster-provision/images/vm-image-builder/example/image-url
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/example/image-url-arm64
+++ b/cluster-provision/images/vm-image-builder/example/image-url-arm64
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/32/Cloud/aarch64/images/Fedora-Cloud-Base-32-1.6.aarch64.qcow2
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/aarch64/images/Fedora-Cloud-Base-39-1.5.aarch64.qcow2

--- a/cluster-provision/images/vm-image-builder/example/os-variant
+++ b/cluster-provision/images/vm-image-builder/example/os-variant
@@ -1,1 +1,1 @@
-fedora32
+fedora39

--- a/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url
+++ b/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url
@@ -1,1 +1,1 @@
-https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url-arm64
+++ b/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url-arm64
@@ -1,1 +1,1 @@
-https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/aarch64/images/Fedora-Cloud-Base-35-1.2.aarch64.qcow2
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/aarch64/images/Fedora-Cloud-Base-39-1.5.aarch64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-kubeadm/os-variant
+++ b/cluster-provision/images/vm-image-builder/fedora-kubeadm/os-variant
@@ -1,1 +1,1 @@
-fedora35
+fedora39

--- a/cluster-provision/images/vm-image-builder/fedora-realtime/image-url
+++ b/cluster-provision/images/vm-image-builder/fedora-realtime/image-url
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-realtime/image-url-arm64
+++ b/cluster-provision/images/vm-image-builder/fedora-realtime/image-url-arm64
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/32/Cloud/aarch64/images/Fedora-Cloud-Base-32-1.6.aarch64.qcow2
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/aarch64/images/Fedora-Cloud-Base-39-1.5.aarch64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-realtime/os-variant
+++ b/cluster-provision/images/vm-image-builder/fedora-realtime/os-variant
@@ -1,1 +1,1 @@
-fedora32
+fedora39

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -43,7 +43,7 @@ write_files:
         bind 'set enable-bracketed-paste off'
 runcmd:
   - sudo systemctl daemon-reload
-  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng virt-what vm-dump-metrics tpm2-tools nc sg3_utils iperf3 wget tcpdump
+  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng virt-what vm-dump-metrics tpm2-tools netcat sg3_utils iperf3 wget tcpdump
   # Download the busybox netcat and relpace it with the OpenBSD netcat
   # To align with the netcat tool used in the Alpine image for network e2e testing
   - if [ $(uname -m) == "aarch64" ]; then export CPUARCH="armv8l"; elif [ $(uname -m) == "s390x" ]; then export CPUARCH="s390x"; else export CPUARCH="x86_64"; fi

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-arm64
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-arm64
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/35/Cloud/aarch64/images/Fedora-Cloud-Base-35-1.2.aarch64.qcow2
+https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/aarch64/images/Fedora-Cloud-Base-39-1.5.aarch64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/os-variant
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/os-variant
@@ -1,1 +1,1 @@
-fedora35
+fedora39


### PR DESCRIPTION
**What this PR does / why we need it**:

Fedora 35 has been EOL for a very long time and it doesn't make sense to
continue to test against it.

Updating to Fedora 39 (also EOL but more recent)

This has been tested against the kubevirt test suite and all tests are
passing apart from some ipbv6 only tests which have a fix on the way.

[1] https://github.com/kubevirt/kubevirt/pull/13322
[2] https://github.com/kubevirt/kubevirt/pull/14275

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
