### PR TITLE
gocli,ceph: Use a more specific tag v19.2.1-20250202 for the ceph image

### DIFF
--- a/cluster-provision/gocli/opts/rookceph/manifests/cluster-test.yaml
+++ b/cluster-provision/gocli/opts/rookceph/manifests/cluster-test.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: quay.io/ceph/ceph:v19
+    image: quay.io/ceph/ceph:v19.2.1-20250202
     allowUnsupported: true
   mon:
     count: 1

--- a/cluster-provision/k8s/1.30/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.30/extra-pre-pull-images
@@ -10,7 +10,7 @@ ghcr.io/kubevirt/passt-binding-cni@sha256:981c01e0b94ae691ba8ced43c486930085186e
 docker.io/grafana/grafana:11.1.0
 quay.io/brancz/kube-rbac-proxy:v0.18.0
 quay.io/brancz/kube-rbac-proxy:v0.8.0
-quay.io/ceph/ceph:v19
+quay.io/ceph/ceph:v19.2.1-20250202
 quay.io/cephcsi/cephcsi:v3.13.0
 quay.io/csiaddons/k8s-sidecar:v0.11.0
 quay.io/kubevirt/bridge-marker@sha256:18d954d58b9830738df9bf5c9a575d22b33096d1af26fb6bc2da09fb31c9f73a

--- a/cluster-provision/k8s/1.31/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.31/extra-pre-pull-images
@@ -10,7 +10,7 @@ ghcr.io/kubevirt/passt-binding-cni@sha256:981c01e0b94ae691ba8ced43c486930085186e
 docker.io/grafana/grafana:11.1.0
 quay.io/brancz/kube-rbac-proxy:v0.18.0
 quay.io/brancz/kube-rbac-proxy:v0.8.0
-quay.io/ceph/ceph:v19
+quay.io/ceph/ceph:v19.2.1-20250202
 quay.io/cephcsi/cephcsi:v3.13.0
 quay.io/csiaddons/k8s-sidecar:v0.11.0
 quay.io/kubevirt/bridge-marker@sha256:18d954d58b9830738df9bf5c9a575d22b33096d1af26fb6bc2da09fb31c9f73a

--- a/cluster-provision/k8s/1.32/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.32/extra-pre-pull-images
@@ -10,7 +10,7 @@ ghcr.io/kubevirt/passt-binding-cni@sha256:981c01e0b94ae691ba8ced43c486930085186e
 docker.io/grafana/grafana:11.1.0
 quay.io/brancz/kube-rbac-proxy:v0.18.0
 quay.io/brancz/kube-rbac-proxy:v0.8.0
-quay.io/ceph/ceph:v19
+quay.io/ceph/ceph:v19.2.1-20250202
 quay.io/cephcsi/cephcsi:v3.13.0
 quay.io/csiaddons/k8s-sidecar:v0.11.0
 quay.io/kubevirt/bridge-marker@sha256:18d954d58b9830738df9bf5c9a575d22b33096d1af26fb6bc2da09fb31c9f73a

--- a/cluster-provision/k8s/1.33/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.33/extra-pre-pull-images
@@ -10,7 +10,7 @@ ghcr.io/kubevirt/passt-binding-cni@sha256:981c01e0b94ae691ba8ced43c486930085186e
 docker.io/grafana/grafana:11.1.0
 quay.io/brancz/kube-rbac-proxy:v0.18.0
 quay.io/brancz/kube-rbac-proxy:v0.8.0
-quay.io/ceph/ceph:v19
+quay.io/ceph/ceph:v19.2.1-20250202
 quay.io/cephcsi/cephcsi:v3.13.0
 quay.io/csiaddons/k8s-sidecar:v0.11.0
 quay.io/kubevirt/bridge-marker@sha256:18d954d58b9830738df9bf5c9a575d22b33096d1af26fb6bc2da09fb31c9f73a


### PR DESCRIPTION
**What this PR does / why we need it**:

The v19 tagged image will change when there are new minor/patch versions created in v19 release.

This can introduce issues deploying ceph in kubevirtci that can be hard to track down.

Such as with the recent rbac changes:
https://github.com/kubevirt/kubevirtci/pull/1416

Using a more specific image tag that shouldn't change avoids hitting these problems

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @akalenyu 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
