### PR TITLE
rook-ceph: Pin rook ceph image to v1.16.6

### DIFF
--- a/cluster-provision/gocli/opts/rookceph/manifests/operator.yaml
+++ b/cluster-provision/gocli/opts/rookceph/manifests/operator.yaml
@@ -600,7 +600,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
         - name: rook-ceph-operator
-          image: docker.io/rook/ceph:master
+          image: quay.io/kubevirtci/rook-ceph:v1.16.6
           args: ["ceph", "operator"]
           securityContext:
             runAsNonRoot: true

--- a/cluster-provision/k8s/1.30/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.30/extra-pre-pull-images
@@ -1,4 +1,4 @@
-docker.io/rook/ceph:master
+quay.io/kubevirtci/rook-ceph:v1.16.6
 ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:c8bfe5bad3b5371a5677feb9e8e162da91b61bcac409c244f6f1b18c801ad006
 ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8
 ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247

--- a/cluster-provision/k8s/1.31/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.31/extra-pre-pull-images
@@ -1,4 +1,4 @@
-docker.io/rook/ceph:master
+quay.io/kubevirtci/rook-ceph:v1.16.6
 ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:c8bfe5bad3b5371a5677feb9e8e162da91b61bcac409c244f6f1b18c801ad006
 ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8
 ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247

--- a/cluster-provision/k8s/1.32/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.32/extra-pre-pull-images
@@ -1,4 +1,4 @@
-docker.io/rook/ceph:master
+quay.io/kubevirtci/rook-ceph:v1.16.6
 ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:c8bfe5bad3b5371a5677feb9e8e162da91b61bcac409c244f6f1b18c801ad006
 ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8
 ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247

--- a/cluster-provision/k8s/1.33/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.33/extra-pre-pull-images
@@ -1,4 +1,4 @@
-docker.io/rook/ceph:master
+quay.io/kubevirtci/rook-ceph:v1.16.6
 ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:c8bfe5bad3b5371a5677feb9e8e162da91b61bcac409c244f6f1b18c801ad006
 ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8
 ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247


### PR DESCRIPTION
**What this PR does / why we need it**:

Using the `master` tag for rook can led to changes breaking the deployment of ceph in kubevirtci

Such as the recent rbac issues:
https://github.com/kubevirt/kubevirtci/pull/1416

Pin the rook image to v1.16.6 and use the image that is mirrored to the kubevirtci quay repo


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @akalenyu @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
