### PR TITLE
istio: Remove Multus settings from the default Istio config

### DIFF
--- a/cluster-provision/gocli/opts/istio/manifests/istio-operator.cr.yaml
+++ b/cluster-provision/gocli/opts/istio/manifests/istio-operator.cr.yaml
@@ -18,7 +18,6 @@ spec:
     global:
       jwtPolicy: third-party-jwt
     cni:
-      provider: multus
       chained: true
       cniBinDir: /opt/cni/bin
       cniConfDir: /etc/cni/net.d


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following recent Istio bump a regression has been introduced in CDI+Istio lane 
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/3694/pull-containerized-data-importer-e2e-istio/1909911853820022784

The default Istio config 'istio-operator.cr.yaml' is intended to be used when Multus is not installed in the cluster.
Multus depends on the NetworkAttachmentDefinition CRD to be installed.

Currently the default Istio config is invalid, because it specify setting that installs the istio-cni NetworkAttachmentDefinition CR, where it should be used when no Multus is installed. For setups that have Multus installed, the 'istio-operator-with-cnao.cr.yaml' config should be used.

Remove Multus related settings from the default Istio config.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
