### PR TITLE
swap: prefer fallocate over dd to allocate the file

### DIFF
--- a/cluster-provision/gocli/opts/swap/swap.go
+++ b/cluster-provision/gocli/opts/swap/swap.go
@@ -24,7 +24,7 @@ func NewSwapOpt(sc libssh.Client, swapiness int, us bool, size int) *swapOpt {
 
 func (o *swapOpt) Exec() error {
 	if o.size != 0 {
-		if err := o.sshClient.Command("dd if=/dev/zero of=/swapfile count=" + fmt.Sprintf("%d", o.size) + " bs=1G"); err != nil {
+		if err := o.sshClient.Command("fallocate -l " + fmt.Sprintf("%dG", o.size) + " /swapfile"); err != nil {
 			return err
 		}
 		if err := o.sshClient.Command("mkswap /swapfile"); err != nil {

--- a/cluster-provision/gocli/opts/swap/swap_test.go
+++ b/cluster-provision/gocli/opts/swap/swap_test.go
@@ -28,7 +28,7 @@ var _ = Describe("SwapOpt", func() {
 
 	It("should execute SwapOpt successfully", func() {
 		cmds := []string{
-			"dd if=/dev/zero of=/swapfile count=" + fmt.Sprintf("%d", opt.size) + " bs=1G",
+			"fallocate -l " + fmt.Sprintf("%dG", opt.size) + " /swapfile",
 			"mkswap /swapfile",
 			"swapon -a",
 			"/bin/su -c \"echo vm.swappiness = " + fmt.Sprintf("%d", opt.swapiness) + " >> /etc/sysctl.conf\"",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR reduces the cluster creation time by improving the swap provisioning.

Some figures:

    > time sudo fallocate -l '30G' /var/tmp/swapfile

    real	0m0.105s
    user	0m0.005s
    sys	0m0.017s

    > time sudo dd if=/dev/zero of=/var/tmp/swapfile count=30 bs=1G
    30+0 records in
    30+0 records out
    32212254720 bytes (32 GB, 30 GiB) copied, 105.648 s, 305 MB/s

    real	1m45.674s
    user	0m0.005s
    sys	0m22.602s

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
