### PR TITLE
Fix: ensure terminal commands wrap on SSH in KubeVirtCI (#1280)

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,0 +1,8 @@
+# Ensure proper terminal line wrapping with SSH
+function _ssh_into_node() {
+    if [[ $2 != "" ]]; then
+        ${CRI_BIN} exec "$@"
+    else
+        ${CRI_BIN} exec -e COLUMNS="$COLUMNS" -e LINES="$LINES" -it "$1" bash
+    fi
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR ensures **long terminal commands are wrapped properly** when SSHing into `kind-*` KubeVirtCI clusters.

#### Before this PR:
SSH sessions invoked via `docker exec` did not pass `COLUMNS` and `LINES` from the host terminal, causing long commands to break formatting or overflow the terminal without wrapping.

#### After this PR:
`COLUMNS` and `LINES` are explicitly passed when executing `docker exec`, which allows commands to wrap neatly as expected.

Fixes: #1280

---

### Why we need it and why it was done in this way

**Why:**  
Terminal formatting was broken during SSH access to CI nodes, especially for long commands. This affected readability and usability in developer workflows.

**How it was solved:**  
Updated the `_ssh_into_node()` helper in `hack/common.sh` to include `-e COLUMNS="$COLUMNS" -e LINES="$LINES"` in the `docker exec` command.

---

### The following alternatives were considered:

- Placing the fix only in `kind/common.sh`, but opted for `hack/common.sh` for shared logic across multiple providers.
- Adding a global wrapper, but this approach keeps the scope narrow and avoids side effects.

---

### Special notes for your reviewer

- The change has been tested locally using `kind-1.28` and behaves as expected.
- A screenshot and full reproduction are available in the issue thread.
- Happy to relocate the logic or adjust scope based on your feedback!

---

### Checklist

This checklist is not enforcing, but a reminder for completeness:

- [x] PR: The PR description is expressive enough and helpful to reviewers and future contributors
- [x] Code: Simple, maintainable, and localized to one shell helper
- [ ] Testing: Manual verification attached; automated test coverage not added as it’s a minor CLI behavior fix
- [ ] Documentation: Not required for this internal developer tool behavior
- [x] Community: Guidance requested via issue comment

---

### Release note

```release-note
Fix terminal command wrapping when SSHing into kind-* providers by exporting COLUMNS and LINES into the container shell
