### PR TITLE
Export CDI upload proxy lower-band port in CI clusters

### DIFF
--- a/PODMAN.md
+++ b/PODMAN.md
@@ -15,7 +15,7 @@ instead of eth0.
 The current rules - [ssh](https://github.com/kubevirt/kubevirtci/blob/962d90cead28fc2aadcc07388b18d2479b2b6714/cluster-provision/centos8/scripts/vm.sh#L73), [restricted ports](https://github.com/kubevirt/kubevirtci/blob/962d90cead28fc2aadcc07388b18d2479b2b6714/cluster-provision/centos8/scripts/vm.sh#L83) - allow `make cluster-up` to run successfully, but
 unfortunately they break the cluster's network connectivity in a subtle way:
 image pulling fails because outgoing traffic to ports 22 6443 8443 80 443 30007
-30008 31001 is redirected to the VM in the respective node container (i.e.
+30008 31001 30085 is redirected to the VM in the respective node container (i.e.
 itself) instead of going to the specified host (e.g. quay.io).
 
 This will use `fuse-overlayfs` as storage layer. If the performance is not

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -104,7 +104,7 @@ function create_ip_rules {
 
 # Route ports from container to VM for first node
 if [ "$n" = "01" ] ; then
-  tcp_ports=( 6443 8443 80 443 30007 30008 31001 )
+  tcp_ports=( 6443 8443 80 443 30007 30008 31001 30085)
   create_ip_rules "tcp" "${tcp_ports[@]}"
 
   udp_ports=( 31111 )

--- a/cluster-provision/gocli/cmd/ports.go
+++ b/cluster-provision/gocli/cmd/ports.go
@@ -32,7 +32,7 @@ Known port names are 'ssh', 'registry', 'ocp', 'k8s', 'prometheus' and 'grafana'
 
 			if len(args) == 1 {
 				switch args[0] {
-				case utils.PortNameSSH, utils.PortNameSSHWorker, utils.PortNameAPI, utils.PortNameOCP, utils.PortNameOCPConsole, utils.PortNameRegistry, utils.PortNameVNC, utils.PortNameHTTP, utils.PortNameHTTPS, utils.PortNamePrometheus, utils.PortNameGrafana, utils.PortNameUploadProxy, utils.PortNameDNS:
+				case utils.PortNameSSH, utils.PortNameSSHWorker, utils.PortNameAPI, utils.PortNameOCP, utils.PortNameOCPConsole, utils.PortNameRegistry, utils.PortNameVNC, utils.PortNameHTTP, utils.PortNameHTTPS, utils.PortNamePrometheus, utils.PortNameGrafana, utils.PortNameUploadProxy, utils.PortNameDNS, utils.PortNameUploadProxyLowerBand:
 					return nil
 				default:
 					return fmt.Errorf("unknown port name %s", args[0])
@@ -109,6 +109,8 @@ func ports(cmd *cobra.Command, args []string) error {
 			err = utils.PrintPublicPort(utils.PortGrafana, container.NetworkSettings.Ports)
 		case utils.PortNameUploadProxy:
 			err = utils.PrintPublicPort(utils.PortUploadProxy, container.NetworkSettings.Ports)
+		case utils.PortNameUploadProxyLowerBand:
+			err = utils.PrintPublicPort(utils.PortUploadProxyLowerBand, container.NetworkSettings.Ports)
 		case utils.PortNameDNS:
 			err = utils.PrintPublicPort(utils.PortDNS, container.NetworkSettings.Ports)
 		}

--- a/cluster-provision/gocli/cmd/utils/ports.go
+++ b/cluster-provision/gocli/cmd/utils/ports.go
@@ -32,9 +32,10 @@ const (
 	PortGrafana = 30008
 	//PortUploadProxy contains CDI UploadProxy port
 	PortUploadProxy = 31001
+	//PortUploadProxyLowerBand contains CDI UploadProxy port from lower-band range
+	PortUploadProxyLowerBand = 30085
 	//PortDNS contains DNS port
 	PortDNS = 31111
-
 	// PortNameSSH contains control-plane node SSH port name
 	PortNameSSH = "ssh"
 	// PortNameSSHWorker contains worker node SSH port name
@@ -60,6 +61,8 @@ const (
 	PortNameGrafana = "grafana"
 	// PortNameUploadProxy contains CDI UploadProxy port
 	PortNameUploadProxy = "uploadproxy"
+	// PortNameUploadProxyLowerBand contains CDI UploadProxy port lower-band range
+	PortNameUploadProxyLowerBand = "uploadproxy-lowerband"
 	// PortNameDNS contains UDP port
 	PortNameDNS = "dns"
 )

--- a/cluster-provision/gocli/containers/dnsmasq.go
+++ b/cluster-provision/gocli/containers/dnsmasq.go
@@ -56,6 +56,7 @@ func DNSMasq(cli *client.Client, ctx context.Context, options *DNSMasqOptions) (
 			utils.TCPPortOrDie(utils.PortPrometheus):  {},
 			utils.TCPPortOrDie(utils.PortGrafana):     {},
 			utils.TCPPortOrDie(utils.PortUploadProxy): {},
+			utils.TCPPortOrDie(utils.PortUploadProxyLowerBand): {},
 			utils.UDPPortOrDie(utils.PortDNS):         {},
 		},
 	}, &container.HostConfig{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently CI clusters already expose the upload proxy port which is later used for setting up a node-port.

Because the port belongs to the dynamic node-port allocation range (ala upper-band) by default[1] it makes it so that node-port can be claimed by a dynamic service which in turns causes a conflict once the upload proxy service is attempted to be created.

This commit adds a temporary UploadProxyLowerBand port from the static range to fix that.

[1] https://kubernetes.io/blog/2023/05/11/nodeport-dynamic-and-static-allocation/#default-range-30000-32767

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
See https://github.com/kubevirt/kubevirtci/pull/653 for reference.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
