### PR TITLE
fix(fg): set DisableCPUQuotaWithExclusiveCPUs false for 1.33

### DIFF
--- a/cluster-provision/k8s/1.33/k8s_provision.sh
+++ b/cluster-provision/k8s/1.33/k8s_provision.sh
@@ -160,6 +160,8 @@ kind: KubeletConfiguration
 cgroupDriver: systemd
 failSwapOn: false
 kubeletCgroups: /systemd/system.slice
+featureGates:
+  DisableCPUQuotaWithExclusiveCPUs: false
 EOF
 
 cat <<EOT >/etc/sysconfig/kubelet


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

On 1.33 lanes we currently are encountering an issue [1] that slows down VMI pods due to CPU throttling.

This change enables a feature gate documented here [2] in order to unblock the 1.33 lanes until the issue is fixed.

[1]: https://issues.redhat.com/browse/CNV-63585
[2]: https://github.com/kubernetes/kubernetes/blob/v1.33.2/pkg/features/kube_features.go#L978

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @xpivarc @fossedihelm 

FYI @brianmcarey 