### PR TITLE
fix(check-pod-images.sh): use pre-pull-images, add --auto-update

### DIFF
--- a/cluster-provision/k8s/check-pod-images.sh
+++ b/cluster-provision/k8s/check-pod-images.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
-# DO NOT RUN THIS SCRIPT, USE SCRIPTS UNDER VERSIONS DIRECTORIES
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright The KubeVirt Authors.
+#
+#
 
 set -exuo pipefail
 
@@ -8,29 +25,32 @@ ksh="$(cd "$DIR/../.." && pwd)/cluster-up/kubectl.sh"
 provision_dir="$1"
 export KUBEVIRT_PROVIDER="k8s-${provision_dir}"
 
-pre_pull_image_file="$DIR/${provision_dir}/extra-pre-pull-images"
+pre_pull_image_file="$DIR/${provision_dir}/pre-pull-images"
 if [ ! -f "${pre_pull_image_file}" ]; then
+    echo "$DIR/${provision_dir}/pre-pull-images not found!"
+    exit 1
+fi
+
+extra_pre_pull_image_file="$DIR/${provision_dir}/extra-pre-pull-images"
+if [ ! -f "${extra_pre_pull_image_file}" ]; then
+    echo "$DIR/${provision_dir}/extra-pre-pull-images not found!"
     exit 1
 fi
 
 # check image version for pods
 images_not_in_list=$(mktemp)
-images_from_manifests=$(mktemp)
-trap 'rm -f $images_not_in_list $images_from_manifests' EXIT SIGINT SIGTERM
-$DIR/fetch-images.sh "$DIR/${provision_dir}" > "${images_from_manifests}"
-$DIR/fetch-images.sh "$DIR/../gocli/opts/" >> "${images_from_manifests}"
+trap 'rm -f $images_not_in_list' EXIT SIGINT SIGTERM
 for image in $(${ksh} get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | grep -v 'registry.k8s.io' | sort | uniq); do
     set +e
-    if ! grep -q "$image" "${pre_pull_image_file}"; then
-        if ! grep -q "$image" "${images_from_manifests}"; then
-            echo "$image" >>"${images_not_in_list}"
-        fi
+    if ! grep -q "$image" "${pre_pull_image_file}" && ! grep -q "$image" "${extra_pre_pull_image_file}"; then
+        echo "$image" >>"${images_not_in_list}"
     fi
     set -e
 done
 if [ -s "${images_not_in_list}" ]; then
     echo "Images found in cluster that are not in list!"
-    cat "${images_not_in_list}"
-    echo "(Please add them to file ${pre_pull_image_file})"
-    exit 1
+    cat "${images_not_in_list}" >>"${extra_pre_pull_image_file}"
+    echo "${extra_pre_pull_image_file} updated with images not in list."
+else
+    echo "No images found in cluster that are not in list."
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

* fix: Instead of calling fetch-images.sh we can use the pre-pull-images file which
is a result of the update-images logic and contains all the images.
* feat: adds --auto-update flag which instead of printing the missing images will directly append them to the `extra-pre-pull-images` file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

As discussed we want an auto bump mechanism. The `--auto-update` is the base for the periodic jobs that will create PRs.

/cc @brianmcarey 