### PR TITLE
Bump Multus to v4.2.1

### DIFF
--- a/cluster-provision/gocli/opts/multus/manifests/multus-daemonset-thick.yaml
+++ b/cluster-provision/gocli/opts/multus/manifests/multus-daemonset-thick.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -10,7 +11,7 @@ spec:
     singular: network-attachment-definition
     kind: NetworkAttachmentDefinition
     shortNames:
-    - net-attach-def
+      - net-attach-def
   versions:
     - name: v1
       served: true
@@ -60,7 +61,9 @@ rules:
       - pods/status
     verbs:
       - get
+      - list
       - update
+      - watch
   - apiGroups:
       - ""
       - events.k8s.io
@@ -80,9 +83,9 @@ roleRef:
   kind: ClusterRole
   name: multus
 subjects:
-- kind: ServiceAccount
-  name: multus
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: multus
+    namespace: kube-system
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -93,50 +96,22 @@ metadata:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: multus-cni-config
+  name: multus-daemon-config
   namespace: kube-system
   labels:
     tier: node
     app: multus
 data:
-  # NOTE: If you'd prefer to manually apply a configuration file, you may create one here.
-  # In the case you'd like to customize the Multus installation, you should change the arguments to the Multus pod
-  # change the "args" line below from
-  # - "--multus-conf-file=auto"
-  # to:
-  # "--multus-conf-file=/tmp/multus-conf/70-multus.conf"
-  # Additionally -- you should ensure that the name "70-multus.conf" is the alphabetically first name in the
-  # /etc/cni/net.d/ directory on each node, otherwise, it will not be used by the Kubelet.
-  cni-conf.json: |
+  daemon-config.json: |
     {
-      "name": "multus-cni-network",
-      "type": "multus",
-      "capabilities": {
-        "portMappings": true
-      },
-      "delegates": [
-        {
-          "cniVersion": "0.3.1",
-          "name": "default-cni-network",
-          "plugins": [
-            {
-              "type": "flannel",
-              "name": "flannel.1",
-                "delegate": {
-                  "isDefaultGateway": true,
-                  "hairpinMode": true
-                }
-              },
-              {
-                "type": "portmap",
-                "capabilities": {
-                  "portMappings": true
-                }
-              }
-          ]
-        }
-      ],
-      "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
+      "chrootDir": "/hostroot",
+      "cniVersion": "0.3.1",
+      "logLevel": "verbose",
+      "logToStderr": true,
+      "cniConfigDir": "/host/etc/cni/net.d",
+      "multusAutoconfigDir": "/host/etc/cni/net.d",
+      "multusConfigFile": "auto",
+      "socketDir": "/host/run/multus/"
     }
 ---
 apiVersion: apps/v1
@@ -162,50 +137,74 @@ spec:
         name: multus
     spec:
       hostNetwork: true
+      hostPID: true
       tolerations:
-      - operator: Exists
-        effect: NoSchedule
-      - operator: Exists
-        effect: NoExecute
+        - operator: Exists
+          effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
       serviceAccountName: multus
       containers:
-      - name: kube-multus
-        image: ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8
-        command: ["/entrypoint.sh"]
-        args:
-        - "--multus-conf-file=auto"
-        - "--cni-version=0.3.1"
-        - "--multus-log-level=debug"
-        - "--multus-log-file=/var/log/multus.log"
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
-          limits:
-            cpu: "100m"
-            memory: "50Mi"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: cni
-          mountPath: /host/etc/cni/net.d
-        - name: cnibin
-          mountPath: /host/opt/cni/bin
-        - name: multus-cfg
-          mountPath: /tmp/multus-conf
+        - name: kube-multus
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1-thick
+          command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "50Mi"
+            limits:
+              cpu: "100m"
+              memory: "50Mi"
+          securityContext:
+            privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: cni
+              mountPath: /host/etc/cni/net.d
+            # multus-daemon expects that cnibin path must be identical between pod and container host.
+            # e.g. if the cni bin is in '/opt/cni/bin' on the container host side, then it should be mount to '/opt/cni/bin' in multus-daemon,
+            # not to any other directory, like '/opt/bin' or '/usr/bin'.
+            - name: cnibin
+              mountPath: /opt/cni/bin
+            - name: host-run
+              mountPath: /host/run
+            - name: host-var-lib-cni-multus
+              mountPath: /var/lib/cni/multus
+            - name: host-var-lib-kubelet
+              mountPath: /var/lib/kubelet
+              mountPropagation: HostToContainer
+            - name: host-run-k8s-cni-cncf-io
+              mountPath: /run/k8s.cni.cncf.io
+            - name: host-run-netns
+              mountPath: /run/netns
+              mountPropagation: HostToContainer
+            - name: multus-daemon-config
+              mountPath: /etc/cni/net.d/multus.d
+              readOnly: true
+            - name: hostroot
+              mountPath: /hostroot
+              mountPropagation: HostToContainer
+            - mountPath: /etc/cni/multus/net.d
+              name: multus-conf-dir
+          env:
+            - name: MULTUS_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
       initContainers:
         - name: install-multus-binary
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1-thick
           command:
-            - "cp"
-            - "/usr/src/multus-cni/bin/multus"
-            - "/host/opt/cni/bin/multus"
+            - "sh"
+            - "-c"
+            - "cp /usr/src/multus-cni/bin/multus-shim /host/opt/cni/bin/multus-shim && cp /usr/src/multus-cni/bin/passthru /host/opt/cni/bin/passthru"
           resources:
             requests:
               cpu: "10m"
               memory: "15Mi"
           securityContext:
             privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: cnibin
               mountPath: /host/opt/cni/bin
@@ -218,9 +217,30 @@ spec:
         - name: cnibin
           hostPath:
             path: /opt/cni/bin
-        - name: multus-cfg
+        - name: hostroot
+          hostPath:
+            path: /
+        - name: multus-daemon-config
           configMap:
-            name: multus-cni-config
+            name: multus-daemon-config
             items:
-            - key: cni-conf.json
-              path: 70-multus.conf
+              - key: daemon-config.json
+                path: daemon-config.json
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: host-var-lib-cni-multus
+          hostPath:
+            path: /var/lib/cni/multus
+        - name: host-var-lib-kubelet
+          hostPath:
+            path: /var/lib/kubelet
+        - name: host-run-k8s-cni-cncf-io
+          hostPath:
+            path: /run/k8s.cni.cncf.io
+        - name: host-run-netns
+          hostPath:
+            path: /run/netns/
+        - name: multus-conf-dir
+          hostPath:
+            path: /etc/cni/multus/net.d

--- a/cluster-provision/gocli/opts/multus/multus.go
+++ b/cluster-provision/gocli/opts/multus/multus.go
@@ -10,7 +10,7 @@ import (
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/libssh"
 )
 
-//go:embed manifests/multus.yaml
+//go:embed manifests/multus-daemonset-thick.yaml
 var multus []byte
 
 type multusOpt struct {

--- a/cluster-provision/k8s/1.31/pre-pull-images
+++ b/cluster-provision/k8s/1.31/pre-pull-images
@@ -3,7 +3,7 @@ docker.io/calico/kube-controllers:v3.26.5
 docker.io/calico/node:v3.26.5
 docker.io/grafana/grafana:11.1.0
 docker.io/rook/ceph:master
-ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8
+ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1-thick
 ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:c8bfe5bad3b5371a5677feb9e8e162da91b61bcac409c244f6f1b18c801ad006
 ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247
 ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:54be8fcacee50af64deafa9e99f3fe079033630c00c4ed9f74d17b0d91009f10

--- a/cluster-provision/k8s/1.32/pre-pull-images
+++ b/cluster-provision/k8s/1.32/pre-pull-images
@@ -3,7 +3,7 @@ docker.io/calico/kube-controllers:v3.26.5
 docker.io/calico/node:v3.26.5
 docker.io/grafana/grafana:11.1.0
 docker.io/rook/ceph:master
-ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8
+ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1-thick
 ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:c8bfe5bad3b5371a5677feb9e8e162da91b61bcac409c244f6f1b18c801ad006
 ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247
 ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:54be8fcacee50af64deafa9e99f3fe079033630c00c4ed9f74d17b0d91009f10

--- a/cluster-provision/k8s/1.33/pre-pull-images
+++ b/cluster-provision/k8s/1.33/pre-pull-images
@@ -3,7 +3,7 @@ docker.io/calico/kube-controllers:v3.26.5
 docker.io/calico/node:v3.26.5
 docker.io/grafana/grafana:11.1.0
 docker.io/rook/ceph:master
-ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8
+ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1-thick
 ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:c8bfe5bad3b5371a5677feb9e8e162da91b61bcac409c244f6f1b18c801ad006
 ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller@sha256:0bdf7dc9c15bdf7e5760955f05077c23868f3421141e8e623d75cf6b8cf36247
 ghcr.io/k8snetworkplumbingwg/ovs-cni-plugin@sha256:54be8fcacee50af64deafa9e99f3fe079033630c00c4ed9f74d17b0d91009f10

--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -73,12 +73,12 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
         ${ssh} node02 -- ip l show eth1
         ${ssh} node02 -- ip l show eth2
 
-        # Verify Multus v3 image is used
-        ${ksh} get ds -n kube-system kube-multus-ds -o yaml | grep multus-cni:v3
+        # Verify Multus v4 image is used
+        ${ksh} get ds -n kube-system kube-multus-ds -o yaml | grep multus-cni:v4
 
         # Sanity check that Multus is able to connect secondary networks
         ${ksh} create -f "$DIR/test-multi-net.yaml"
-        ${ksh} wait pod test-multi-net --for condition=ready=true
+        ${ksh} wait pod test-multi-net --for condition=ready=true --timeout=2m
         ${ksh} delete -f "$DIR/test-multi-net.yaml"
 
         # check whether all is good wrt pull policies and pre-pulled images

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -194,7 +194,7 @@ function _add_common_params() {
         params=" --enable-fips $params"
     fi
 
-    if [ "$KUBEVIRT_WITH_MULTUS_V3" == "true" ] || [ "$KUBEVIRT_WITH_MULTUS" == "true" ]; then
+    if [ "$KUBEVIRT_WITH_MULTUS" == "true" ]; then
         params=" --deploy-multus $params"
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, the gocli application deploys Multus v3 when using the `--deploy-multus` command line option.

Upgrade to the latest Multus version which is v4.2.1 [1]. 
Drop the `KUBEVIRT_WITH_MULTUS_V3` environment variable, as it no longer reflects the current version being deployed.

[1] https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
