### PR TITLE
Continue the fix of the issue with job names w/o k8s version

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -45,7 +45,7 @@ else
 fi
 
 _cli_container="${KUBEVIRTCI_GOCLI_CONTAINER:-quay.io/kubevirtci/gocli:${KUBEVIRTCI_TAG}}"
-_cli="${_cri_bin} run --privileged --net=host --rm ${USE_TTY} -v ${_cri_socket}:/var/run/docker.sock"
+_cli="${_cri_bin} run --privileged --net=host --rm ${USE_TTY} -v ${_cri_socket}:/var/run/docker.sock -e KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER}"
 # gocli will try to mount /lib/modules to make it accessible to dnsmasq in
 # in case it exists
 if [ -d /lib/modules ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up #1473

The previous try to fix the issue didn't help, because the code is failing when running inside the gocli container, where the `KUBEVIRT_PROVIDER` environment variable is not defined.

This PR adds the missing environment variable when running the container.

**Release note**:
```release-note
None
```
