### PR TITLE
Set provider_prefix always to KUBEVIRT_PROVIDER

### DIFF
--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -48,9 +48,7 @@ if [ -z "${JOB_NAME}" ]; then
     KUBEVIRT_PROVIDER_EXTRA_ARGS="${KUBEVIRT_PROVIDER_EXTRA_ARGS} --ocp-port 8443"
 fi
 
-#If run on jenkins, let us create isolated environments based on the job and
-# the executor number
-provider_prefix=${JOB_NAME:-${KUBEVIRT_PROVIDER}}${EXECUTOR_NUMBER}
+provider_prefix=${KUBEVIRT_PROVIDER}
 job_prefix=${JOB_NAME:-kubevirt}${EXECUTOR_NUMBER}
 
 mkdir -p $KUBEVIRTCI_CONFIG_PATH/$KUBEVIRT_PROVIDER


### PR DESCRIPTION
**What this PR does / why we need it**:
In the past we used Jenkins for CI and there was no isolation (one docker/podman daemon running) so Jobs would confict on bringing up nodes.

As of now we are using Prow where Pod is isolation and we therefore no longer require this hack.
