### PR TITLE
Detect container runtime in gocli Makefile

### DIFF
--- a/cluster-provision/gocli/Makefile
+++ b/cluster-provision/gocli/Makefile
@@ -4,6 +4,12 @@ IMAGES_FILE ?= images.json
 KUBEVIRTCI_IMAGE_REPO ?= quay.io/kubevirtci
 GOARCH ?= $$(uname -m | grep -q s390x && echo s390x || echo amd64)
 
+# Container runtime detection
+CRI_BIN ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null || echo "")
+ifeq ($(CRI_BIN),)
+$(error No container runtime found. Please install either docker or podman)
+endif
+
 export GO111MODULE=on
 export GOPROXY=direct
 export GOSUMDB=off
@@ -32,11 +38,11 @@ fmt:
 
 .PHONY: container
 container: cli
-	docker build -t ${KUBEVIRTCI_IMAGE_REPO}/gocli build/
+	$(CRI_BIN) build -t ${KUBEVIRTCI_IMAGE_REPO}/gocli build/
 
 .PHONY: container-run
 container-run: container
-	docker run --rm ${KUBEVIRTCI_IMAGE_REPO}/gocli
+	$(CRI_BIN) run --rm ${KUBEVIRTCI_IMAGE_REPO}/gocli
 
 .PHONY: vendor
 vendor:
@@ -45,4 +51,4 @@ vendor:
 
 .PHONY: push
 push: container
-	docker push ${KUBEVIRTCI_IMAGE_REPO}/gocli
+	$(CRI_BIN) push ${KUBEVIRTCI_IMAGE_REPO}/gocli


### PR DESCRIPTION
Current code hardcodes the use of docker as container runtime. This commit adds logic to detect container runtime (docker/podman) on the node and uses it.

**What this PR does / why we need it**:

We need this PR to be able to build, test and push the `gocli` container image on a machines that could have either `docker` or `podman` as the container runtime installed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1480

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
