### PR TITLE
fix: enable centos9 download curl command fail

### DIFF
--- a/cluster-provision/centos9/scripts/download_box.sh
+++ b/cluster-provision/centos9/scripts/download_box.sh
@@ -7,9 +7,9 @@ ARCH=$(uname -m)
 
 #For the s390x architecture, instead of vagrant box image, generic cloud (qcow2) image is used directly.
 if [ "$ARCH" == "s390x" ]; then
-    curl -L $1 -o box.qcow2
+    curl -L --fail $1 -o box.qcow2
 else
-    curl -L $1 | tar -zxvf - box.img
+    curl -L --fail $1 | tar -zxvf - box.img
     qemu-img convert -O qcow2 box.img box.qcow2
     rm box.img
 fi


### PR DESCRIPTION
The curl command does not fail when the download is unsuccesful, which causes the script to fail at a later point.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Error related to #1501

```release-note
NONE
```
