### PR TITLE
cluster-up: Support global config

### DIFF
--- a/K8S.md
+++ b/K8S.md
@@ -25,13 +25,23 @@ cluster-up/kubectl.sh get pods --all-namespaces
 ```                                                                        
                                                                            
 Use your own kubectl client by defining the KUBECONFIG environment variable
-```                                                                        
-export KUBECONFIG=$(cluster-up/kubeconfig.sh)                              
-                                                                           
-kubectl get nodes                                                          
-kubectl apply -f <some file>                                               
-```                                                                        
-                                                                           
+```
+export KUBECONFIG=$(cluster-up/kubeconfig.sh)
+
+kubectl get nodes
+kubectl apply -f <some file>
+```
+
+## Global kubeconfig location
+
+If you want the kubeconfig to be automatically copied to a specific location after cluster startup,
+you can set the `GLOBAL_KUBECONFIG` environment variable:
+
+```bash
+export GLOBAL_KUBECONFIG=/path/to/your/kubeconfig
+make cluster-up
+```
+
 SSH into a node                                                            
 ```                                                                        
 cluster-up/ssh.sh node01                                                   

--- a/cluster-up/up.sh
+++ b/cluster-up/up.sh
@@ -22,6 +22,18 @@ function validate_single_stack_ipv6() {
     fi
 }
 
+function copy_kubeconfig_to_global() {
+    if [[ -n "$GLOBAL_KUBECONFIG" ]] && [[ "$KUBEVIRT_PROVIDER" != "external" ]]; then
+        local kubeconfig_path="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig"
+        if [ -f "$kubeconfig_path" ]; then
+            echo "Copying kubeconfig to GLOBAL_KUBECONFIG: $GLOBAL_KUBECONFIG"
+            cp "$kubeconfig_path" "$GLOBAL_KUBECONFIG"
+        else
+            echo "Warning: No kubeconfig found to copy to GLOBAL_KUBECONFIG"
+        fi
+    fi
+}
+
 if [ -z "$KUBEVIRTCI_PATH" ]; then
     KUBEVIRTCI_PATH="$(
         cd "$(dirname "$BASH_SOURCE[0]")/"
@@ -33,6 +45,8 @@ fi
 source ${KUBEVIRTCI_PATH}hack/common.sh
 source ${KUBEVIRTCI_CLUSTER_PATH}/$KUBEVIRT_PROVIDER/provider.sh
 up
+
+copy_kubeconfig_to_global
 
 if [ ${KUBEVIRT_SINGLE_STACK} == true ]; then
     validate_single_stack_ipv6


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In case `GLOBAL_KUBECONFIG` is declared, copy the .kubeconfig there. It allows having a fixed kubeconfig path, shared between different repositories, instead updating the `KUBECONFIG` each time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
