### PR TITLE
flannel: Increase max pods per node

### DIFF
--- a/cluster-provision/k8s/1.32/manifests/flannel.diff
+++ b/cluster-provision/k8s/1.32/manifests/flannel.diff
@@ -1,11 +1,12 @@
 --- flannel.do-not-change.yaml	2025-08-18 10:36:12.700182651 +0300
 +++ flannel-dual-stack.yaml	2025-08-19 09:16:08.103844196 +0300
-@@ -82,9 +82,13 @@
+@@ -82,9 +82,14 @@
    net-conf.json: |
      {
        "Network": "10.244.0.0/16",
 -      "EnableNFTables": false,
 +      "IPv6Network": "fd10:244::/56",
++      "SubnetLen": 20,
 +      "EnableNFTables": true,
 +      "EnableIPv4": true,
 +      "EnableIPv6": true,

--- a/cluster-provision/k8s/1.33/manifests/flannel.diff
+++ b/cluster-provision/k8s/1.33/manifests/flannel.diff
@@ -1,11 +1,12 @@
 --- flannel.do-not-change.yaml	2025-08-18 10:36:12.701182656 +0300
 +++ flannel-dual-stack.yaml	2025-08-19 09:13:46.809838069 +0300
-@@ -82,9 +82,13 @@
+@@ -82,9 +82,14 @@
    net-conf.json: |
      {
        "Network": "10.244.0.0/16",
 -      "EnableNFTables": false,
 +      "IPv6Network": "fd10:244::/56",
++      "SubnetLen": 20,
 +      "EnableNFTables": true,
 +      "EnableIPv4": true,
 +      "EnableIPv6": true,

--- a/cluster-provision/k8s/1.34/manifests/flannel.diff
+++ b/cluster-provision/k8s/1.34/manifests/flannel.diff
@@ -1,11 +1,12 @@
 --- flannel.do-not-change.yaml	2025-08-18 10:36:12.702182663 +0300
 +++ flannel-dual-stack.yaml	2025-08-19 09:17:26.321899911 +0300
-@@ -82,9 +82,13 @@
+@@ -82,9 +82,14 @@
    net-conf.json: |
      {
        "Network": "10.244.0.0/16",
 -      "EnableNFTables": false,
 +      "IPv6Network": "fd10:244::/56",
++      "SubnetLen": 20,
 +      "EnableNFTables": true,
 +      "EnableIPv4": true,
 +      "EnableIPv6": true,

--- a/cluster-provision/k8s/1.35/manifests/flannel.diff
+++ b/cluster-provision/k8s/1.35/manifests/flannel.diff
@@ -1,11 +1,12 @@
---- flannel.do-not-change.yaml	2025-08-18 10:36:12.702182663 +0300
-+++ flannel-dual-stack.yaml	2025-08-19 09:17:26.321899911 +0300
-@@ -82,9 +82,13 @@
+--- flannel.do-not-change.yaml	2025-08-18 10:36:12.700182651 +0300
++++ flannel-dual-stack.yaml	2025-08-19 09:16:08.103844196 +0300
+@@ -82,9 +82,14 @@
    net-conf.json: |
      {
        "Network": "10.244.0.0/16",
 -      "EnableNFTables": false,
 +      "IPv6Network": "fd10:244::/56",
++      "SubnetLen": 20,
 +      "EnableNFTables": true,
 +      "EnableIPv4": true,
 +      "EnableIPv6": true,


### PR DESCRIPTION
On CNAO [0] we saw that long tests such as lifecycle, might leak ips, resulting in cluster become unstable.
It seems it is a known issue [1] [2].

Until it is fixed correctly, lets extend max pods per node from 256 to 4k.

[0] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/2428/pull-e2e-cluster-network-addons-operator-lifecycle-k8s/1978786400497045504

[1] https://github.com/flannel-io/flannel/issues/2264
[2] https://github.com/kubernetes/kubernetes/issues/57280#issuecomment-2132809050

```
14m         Warning   FailedCreatePodSandBox   pod/secondary-dns-5fc6686967-t97vf   Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_secondary-dns-5fc6686967-t97vf_cluster-network-addons_9b165a5c-539f-41d4-9781-1f5ae2cb3311_0(5c39f1e51a02a48e2d99e0670c449379f2d45c9c631971d96f078b55931c3402): error adding pod cluster-network-addons_secondary-dns-5fc6686967-t97vf to CNI network "multus-cni-network": plugin type="multus-shim" name="multus-cni-network" failed (add): CmdAdd (shim): CNI request failed with status 400: 'ContainerID:"5c39f1e51a02a48e2d99e0670c449379f2d45c9c631971d96f078b55931c3402" Netns:"/var/run/netns/b30d651d-76fb-4e01-bcae-b162095eeba8" IfName:"eth0" Args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=cluster-network-addons;K8S_POD_NAME=secondary-dns-5fc6686967-t97vf;K8S_POD_INFRA_CONTAINER_ID=5c39f1e51a02a48e2d99e0670c449379f2d45c9c631971d96f078b55931c3402;K8S_POD_UID=9b165a5c-539f-41d4-9781-1f5ae2cb3311" Path:"" ERRORED: error configuring pod [cluster-network-addons/secondary-dns-5fc6686967-t97vf] networking: [cluster-network-addons/secondary-dns-5fc6686967-t97vf/9b165a5c-539f-41d4-9781-1f5ae2cb3311:cbr0]: error adding container to network "cbr0": plugin type="flannel" failed (add): failed to allocate for range 0: no IP addresses available in range set: 10.244.0.1-10.244.0.254...
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
