### PR TITLE
s390x: Skip checking single stack on s390x

### DIFF
--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -139,17 +139,19 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
         export SONOBUOY_EXTRA_ARGS="--plugin systemd-logs --plugin e2e"
         hack/conformance.sh $conformance_config
 
-        echo "Sanity check cluster-up of single stack cluster"
-        make cluster-down
-        export KUBEVIRT_WITH_CNAO=false
-        export KUBEVIRT_WITH_MULTUS=false
-        export KUBEVIRT_DEPLOY_ISTIO=false
-        export KUBEVIRT_DEPLOY_PROMETHEUS=false
-        export KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER=false
-        export KUBEVIRT_DEPLOY_GRAFANA=false
-        export KUBEVIRT_SINGLE_STACK=true
-        export KUBEVIRT_DEPLOY_CDI=false
-        unset KUBEVIRT_STORAGE
-        make cluster-up
+        if [[ $(uname -m) != *s390x* ]]; then
+            echo "Sanity check cluster-up of single stack cluster"
+            make cluster-down
+            export KUBEVIRT_WITH_CNAO=false
+            export KUBEVIRT_WITH_MULTUS=false
+            export KUBEVIRT_DEPLOY_ISTIO=false
+            export KUBEVIRT_DEPLOY_PROMETHEUS=false
+            export KUBEVIRT_DEPLOY_PROMETHEUS_ALERTMANAGER=false
+            export KUBEVIRT_DEPLOY_GRAFANA=false
+            export KUBEVIRT_SINGLE_STACK=true
+            export KUBEVIRT_DEPLOY_CDI=false
+            unset KUBEVIRT_STORAGE
+            make cluster-up
+        fi
     fi
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a flake on s390x, where cluster-up fails
from time to time.

Skip checking it on s390x, since single stack is less used with s390x, and we can reduce CI noise this way.

Note: it fails also sometimes during the main cluster-up of check-up, but reducing cluster-ups during check-up improves the failure rate nicely.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
