### PR TITLE
vm-image-builder: Switch to using podman to build test containerdisks

### DIFF
--- a/cluster-provision/images/vm-image-builder/README.md
+++ b/cluster-provision/images/vm-image-builder/README.md
@@ -16,7 +16,7 @@ Use cases:
 
 The following RPM packages need to be present on your machine:
 - cloud-utils
-- docker-ce
+- podman
 - libguestfs
 - libguestfs-tools-c
 - libvirt

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -13,14 +13,14 @@ if [ "${ARCHITECTURE}" != ""  ]; then
     PLATFORM=linux/$ARCHITECTURE
 fi
 
-docker run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
+podman run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
 
 if [ ! -f alpine-make-vm-image ]; then
     curl  https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image -o alpine-make-vm-image
     chmod 755 alpine-make-vm-image
 fi
 
-docker run --rm --platform=$PLATFORM -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
+podman run --rm --platform=$PLATFORM -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
 ./alpine-make-vm-image \
     --image-format qcow2 \
     --image-size 200M \

--- a/cluster-provision/images/vm-image-builder/create-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/create-containerdisk.sh
@@ -60,12 +60,11 @@ function build_container() {
     local -r image_name=$4
 
     if [[ $arch = $(go_style_local_arch) ]]; then
-        docker_build="docker build . -t ${image_name}:${arch}"
+        podman_build="podman build . -t ${image_name}:${arch}"
     else
-        echo "When performing cross builds, make sure 'docker buildx' is installed."
-        docker_build="docker buildx build --platform "linux/${arch}" . -t ${image_name}:${arch}"
+        podman_build="podman build --platform "linux/${arch}" . -t ${image_name}:${arch}"
     fi
-    DOCKER_CLI_EXPERIMENTAL=enabled $docker_build -f - <<END
+    $podman_build -f - <<END
 FROM scratch
 ADD --chown=107:107 ${build_directory}/${new_vm_image_name} /disk/
 END
@@ -97,7 +96,7 @@ if [ -f "${SCRIPT_PATH}/${IMAGE_NAME}/create-image.sh" ]; then
       ./create-image.sh "${build_directory}/${customized_image}"
 
       echo "Creating the containerdisk ..."
-      docker build . -t ${IMAGE_NAME}:${TAG} -f - <<END
+      podman build . -t ${IMAGE_NAME}:${TAG} -f - <<END
 FROM scratch
 ADD --chown=107:107 build/${customized_image} /disk/
 END

--- a/cluster-provision/images/vm-image-builder/publish-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/publish-containerdisk.sh
@@ -15,5 +15,5 @@ fi
 export IMAGE_NAME=$1
 export FULL_IMAGE_NAME=$2
 
-docker tag "${IMAGE_NAME}:${TAG}" "${FULL_IMAGE_NAME}"
-docker push "${FULL_IMAGE_NAME}"
+podman tag "${IMAGE_NAME}:${TAG}" "${FULL_IMAGE_NAME}"
+podman push "${FULL_IMAGE_NAME}"

--- a/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
@@ -88,8 +88,8 @@ build_image() {
 publish_image() {
     local full_image_name="${1:?}"
     for arch in ${archs[*]};do
-        docker tag ${build_target}:${arch} ${full_image_name}-${arch}
-        skopeo copy "docker-daemon:${full_image_name}-${arch}" "docker://${full_image_name}-${arch}"
+        podman tag ${build_target}:${arch} ${full_image_name}-${arch}
+        skopeo copy "containers-storage:${full_image_name}-${arch}" "docker://${full_image_name}-${arch}"
     done
 }
 
@@ -100,8 +100,8 @@ publish_manifest() {
     for arch in ${archs[*]};do
         amend+=" --amend ${full_image_name}-${arch}"
     done
-    docker manifest create ${full_image_name} ${amend}
-    docker manifest push ${full_image_name} "docker://${full_image_name}"
+    podman manifest create ${full_image_name} ${amend}
+    podman manifest push ${full_image_name} "docker://${full_image_name}"
 }
 
 main "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:

We have switched to using podman in CI some time ago - update the vm-image-builder scripts to also use podman

This also makes the resulting images compatible with tools such as crane that require OCI manifest types. 
```
podman inspect quay.io/bcarey/fedora-with-test-tooling:v20251029-d463d51-amd64 | grep Manifest
          "ManifestType": "application/vnd.oci.image.manifest.v1+json",
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
