### PR TITLE
kind-sriov: Allow to use DRA driver

### DIFF
--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
@@ -1,0 +1,297 @@
+---
+# Source: dra-driver-sriov-chart/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-dra-dra-driver-sriov-chart-service-account
+  namespace: dra-driver-sriov
+  labels:
+    app.kubernetes.io/name: dra-driver-sriov-chart
+    app.kubernetes.io/instance: sriov-dra
+---
+# Source: dra-driver-sriov-chart/templates/sriovnetwork.k8snetworkplumbingwg.io_sriovresourcefilters.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: sriovresourcefilters.sriovnetwork.k8snetworkplumbingwg.io
+spec:
+  group: sriovnetwork.k8snetworkplumbingwg.io
+  names:
+    kind: SriovResourceFilter
+    listKind: SriovResourceFilterList
+    plural: sriovresourcefilters
+    singular: sriovresourcefilter
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SriovResourceFilter is a filter for SR-IOV resources
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovResourceFilterSpec is the spec for a SriovResourceFilter
+            properties:
+              configs:
+                items:
+                  properties:
+                    resourceFilters:
+                      items:
+                        description: ResourceFilter is a filter for a resource
+                        properties:
+                          devices:
+                            items:
+                              type: string
+                            type: array
+                          drivers:
+                            items:
+                              type: string
+                            type: array
+                          numaNodes:
+                            items:
+                              type: string
+                            type: array
+                          pciAddresses:
+                            items:
+                              type: string
+                            type: array
+                          pfNames:
+                            items:
+                              type: string
+                            type: array
+                          rootDevices:
+                            items:
+                              type: string
+                            type: array
+                          vendors:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    resourceName:
+                      type: string
+                  type: object
+                type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+# Source: dra-driver-sriov-chart/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sriov-dra-dra-driver-sriov-chart-role
+  namespace: dra-driver-sriov
+rules:
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims"]
+  verbs: ["get"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/status"]
+  verbs: ["get","list","update","patch"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]  # Cluster-scoped resource, needs cluster permissions
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceslices"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources: ["network-attachment-definitions"]
+  verbs: ["get"]
+- apiGroups: ["sriovnetwork.k8snetworkplumbingwg.io"]
+  resources: ["sriovresourcefilters"]
+  verbs: ["get", "list", "watch"]  # SriovResourceFilter resources
+---
+# Source: dra-driver-sriov-chart/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sriov-dra-dra-driver-sriov-chart-role-binding
+  namespace: dra-driver-sriov
+subjects:
+- kind: ServiceAccount
+  name: sriov-dra-dra-driver-sriov-chart-service-account
+  namespace: dra-driver-sriov
+roleRef:
+  kind: ClusterRole
+  name: sriov-dra-dra-driver-sriov-chart-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dra-driver-sriov-chart/templates/dra-driver.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sriov-dra-dra-driver-sriov-chart-kubeletplugin
+  namespace: dra-driver-sriov
+  labels:
+    app.kubernetes.io/name: dra-driver-sriov-chart
+    app.kubernetes.io/instance: sriov-dra
+    app.kubernetes.io/component: kubeletplugin
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dra-driver-sriov-chart
+      app.kubernetes.io/instance: sriov-dra
+      app.kubernetes.io/component: kubeletplugin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dra-driver-sriov-chart
+        app.kubernetes.io/instance: sriov-dra
+        app.kubernetes.io/component: kubeletplugin
+    spec:
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      hostPID: true
+      priorityClassName: system-node-critical
+      serviceAccountName: sriov-dra-dra-driver-sriov-chart-service-account
+      securityContext:
+        {}
+      initContainers:
+      - args:
+        - --no-sleep
+        image: ghcr.io/k8snetworkplumbingwg/sriov-cni:v2.10.0
+        imagePullPolicy: IfNotPresent
+        name: sriov-cni
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin
+        - mountPath: /host/etc/os-release
+          name: os-release
+          readOnly: true
+      containers:
+      - name: plugin
+        securityContext:
+          privileged: true
+        image: ghcr.io/k8snetworkplumbingwg/dra-driver-sriov:4889196
+        imagePullPolicy: Always
+        command:
+          # - dlv
+          # - --listen=:2345
+          # - --headless=true
+          # - --api-version=2
+          # - --accept-multiclient
+          # - exec
+          - /usr/bin/dra-driver-sriov
+        resources:
+          {}
+        
+        env:
+        - name: CDI_ROOT
+          value: /var/run/cdi
+        - name: KUBELET_REGISTRAR_DIRECTORY_PATH
+          value: "/var/lib/kubelet/plugins_registry"
+        - name: KUBELET_PLUGINS_DIRECTORY_PATH
+          value: "/var/lib/kubelet/plugins"
+        - name: NRI_PLUGIN_NAME
+          value: "dra-driver-sriov"
+        - name: NRI_PLUGIN_IDX
+          value: "42"
+        - name: DEFAULT_INTERFACE_PREFIX
+          value: "vfnet"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: HEALTHCHECK_PORT
+          value: "-1"
+        # Logging configuration
+        - name: V
+          value: "3"
+        - name: LOG_FORMAT
+          value: "text"
+        - name: ALSOLOGTOSTDERR
+          value: "true"
+        volumeMounts:
+        - name: plugins-registry
+          mountPath: "/var/lib/kubelet/plugins_registry"
+        - name: plugins
+          mountPath: "/var/lib/kubelet/plugins"
+        - name: cdi
+          mountPath: /var/run/cdi
+        - name: cri-socket
+          mountPath: /var/run/nri/nri.sock
+        - name: netns
+          mountPath: /var/run/netns
+          mountPropagation: HostToContainer
+        - name: cni-results
+          mountPath: /var/lib/cni/
+        - name: cni-bin
+          mountPath: /opt/cni/bin
+      volumes:
+      - name: cni-results
+        hostPath:
+          path: /var/lib/cni/
+      - name: netns
+        hostPath:
+          path: /var/run/netns
+      - name: cri-socket
+        hostPath:
+          path: /var/run/nri/nri.sock
+          type: Socket
+      - name: plugins-registry
+        hostPath:
+          path: "/var/lib/kubelet/plugins_registry"
+      - name: plugins
+        hostPath:
+          path: "/var/lib/kubelet/plugins"
+      - name: cdi
+        hostPath:
+          path: /var/run/cdi
+      - hostPath:
+          path: /opt/cni/bin
+        name: cni-bin
+      - hostPath:
+          path: /etc/os-release
+          type: File
+        name: os-release
+---
+# Source: dra-driver-sriov-chart/templates/deviceclass.yaml
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: sriovnetwork.k8snetworkplumbingwg.io
+spec:
+  selectors:
+  - cel: 
+      expression: "device.driver == 'sriovnetwork.k8snetworkplumbingwg.io'"

--- a/cluster-up/cluster/kind-sriov/sriov-components/sriov_components.sh
+++ b/cluster-up/cluster/kind-sriov/sriov-components/sriov_components.sh
@@ -20,6 +20,9 @@ PATCH_NODE_SELECTOR="${CUSTOM_MANIFESTS}/patch-node-selector.yaml"
 KUBECONFIG="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig"
 KUBECTL="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl --kubeconfig=${KUBECONFIG}"
 
+SRIOV_DRA_MANIFEST="${MANIFESTS_DIR}/dra/sriov_dra.yaml"
+SRIOV_DRA_NAMESPACE="dra-driver-sriov"
+
 function _kubectl() {
     ${KUBECTL} "$@"
 }
@@ -134,6 +137,13 @@ function sriov_components::deploy() {
     "$resource_name" \
     "$drivers"
   _deploy_sriov_components
+
+  return 0
+}
+
+function sriov_components::deploy_dra() {
+  _kubectl create namespace "$SRIOV_DRA_NAMESPACE"
+  _kubectl apply -f "$SRIOV_DRA_MANIFEST"
 
   return 0
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In order to allow using DRA driver,
`export KUBEVIRT_USE_DRA=true`.

It will skip installing the DP and CNI, and install DRA driver (includes sriov-cni) instead.

We still create VFs, and unbind them.
It suits vfio driver of DRA.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
