### PR TITLE
Show image pull progress for cluster image download

### DIFF
--- a/cluster-provision/gocli/docker/docker.go
+++ b/cluster-provision/gocli/docker/docker.go
@@ -295,16 +295,55 @@ func PrintProgress(progressReader io.ReadCloser, writer *os.File) error {
 			fmt.Print("\r" + line + strings.Repeat(" ", clearLength))
 		}
 	} else {
-		fmt.Fprint(writer, "Downloading ...")
+		// Non-interactive output (logs, CI, etc):
+		// print human-readable progress instead of just dots.
 		scanner := bufio.NewScanner(progressReader)
 		for scanner.Scan() {
 			line := scanner.Text()
+
+			// keep existing error handling
 			if err := checkForError(line); err != nil {
 				return err
 			}
-			fmt.Print(".")
+			if line == "" {
+				continue
+			}
+
+			// parse more details for progress display
+			var ps PullStatus
+			if err := json.Unmarshal([]byte(line), &ps); err != nil {
+				// if we can't parse, just print the raw line and continue
+				fmt.Fprintln(writer, line)
+				continue
+			}
+
+			// build a readable message
+			msg := ps.Status
+			if ps.ID != "" {
+				if msg != "" {
+					msg += " "
+				}
+				msg += ps.ID
+			}
+
+			if ps.ProgressDetail.Total > 0 && ps.ProgressDetail.Current > 0 {
+				pct := int(float64(ps.ProgressDetail.Current) / float64(ps.ProgressDetail.Total) * 100)
+				if pct < 0 {
+					pct = 0
+				}
+				if pct > 100 {
+					pct = 100
+				}
+				msg += fmt.Sprintf(" (%d%%)", pct)
+			}
+
+			if msg != "" {
+				fmt.Fprintln(writer, msg)
+			}
 		}
-		fmt.Print("\n")
+		if err := scanner.Err(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -324,8 +363,13 @@ func checkForError(line string) error {
 }
 
 type PullStatus struct {
-	Status string `json:"status,omitempty"`
-	Error  string `json:"error,omitempty"`
+	Status         string `json:"status,omitempty"`
+	ID             string `json:"id,omitempty"`
+	Error          string `json:"error,omitempty"`
+	ProgressDetail struct {
+		Current int64 `json:"current,omitempty"`
+		Total   int64 `json:"total,omitempty"`
+	} `json:"progressDetail,omitempty"`
 }
 
 func resizeTerminal(ctx context.Context, cli *client.Client, execID string, file *os.File) {

--- a/cluster-provision/gocli/docker/docker.go
+++ b/cluster-provision/gocli/docker/docker.go
@@ -296,12 +296,12 @@ func PrintProgress(progressReader io.ReadCloser, writer *os.File) error {
 		}
 	} else {
 		// Non-interactive output (logs, CI, etc):
-		// print human-readable progress instead of just dots.
+		// print human-readable status/progress lines derived from the JSON stream.
 		scanner := bufio.NewScanner(progressReader)
 		for scanner.Scan() {
 			line := scanner.Text()
 
-			// keep existing error handling
+			// First, surface any error reported in the pull status.
 			if err := checkForError(line); err != nil {
 				return err
 			}
@@ -309,10 +309,10 @@ func PrintProgress(progressReader io.ReadCloser, writer *os.File) error {
 				continue
 			}
 
-			// parse more details for progress display
+			// Decode progress details from the JSON message for human-readable output.
 			var ps PullStatus
 			if err := json.Unmarshal([]byte(line), &ps); err != nil {
-				// if we can't parse, just print the raw line and continue
+				// If parsing fails, fall back to printing the raw line.
 				fmt.Fprintln(writer, line)
 				continue
 			}

--- a/cluster-provision/gocli/docker/docker_test.go
+++ b/cluster-provision/gocli/docker/docker_test.go
@@ -99,18 +99,28 @@ func TestPrintProgress_NonTerminal_ShowsStatusAndPercent(t *testing.T) {
 		t.Fatalf("expected at least one line of output, got: %q", out)
 	}
 
-	// We expect at least one line with:
+	// Find a line that contains "Downloading"
+	var downloadingLine string
+	for _, line := range lines {
+		if strings.Contains(line, "Downloading") {
+			downloadingLine = line
+			break
+		}
+	}
+
+	if downloadingLine == "" {
+		t.Fatalf("expected at least one line containing 'Downloading', got: %q", out)
+	}
+
+	// We expect the downloading line to include:
 	// - the status "Downloading"
 	// - the layer id "sha256:abc"
 	// - the computed percent "50%"
-	first := lines[0]
-	if !strings.Contains(first, "Downloading") {
-		t.Fatalf("expected first line to contain 'Downloading', got: %q", first)
+	if !strings.Contains(downloadingLine, "sha256:abc") {
+		t.Fatalf("expected downloading line to contain 'sha256:abc', got: %q", downloadingLine)
 	}
-	if !strings.Contains(first, "sha256:abc") {
-		t.Fatalf("expected first line to contain 'sha256:abc', got: %q", first)
+	if !strings.Contains(downloadingLine, "50%") {
+		t.Fatalf("expected downloading line to contain '50%%', got: %q", downloadingLine)
 	}
-	if !strings.Contains(first, "50%") {
-		t.Fatalf("expected first line to contain '50%%', got: %q", first)
-	}
+
 }


### PR DESCRIPTION
## What this PR does

Improves the visibility of image downloads during `make cluster-up`.  
Previously the output only showed a long line of dots (`....................`) with no actual information about progress.

This PR parses the Docker `ImagePull` JSON stream and prints meaningful progress information for each layer, including:

- status (e.g., *Downloading*, *Extracting*, *Complete*)
- layer ID
- percentage when available (`current/total`)

This makes the image download process observable and helps users understand whether progress is occurring or stalled.

## References

Fixes [kubevirt/kubevirt#14242](https://github.com/kubevirt/kubevirt/issues/14242)

## Why we need it and why it was done this way

- The old output provided no insight into download speed or progress.
- Docker’s pull API already includes progress metadata, but kubevirtci previously ignored it.
- The implementation enhances the **non-terminal** output path (used during `cluster-up`) without changing terminal behavior.
- Progress is printed only when meaningful updates occur, reducing spam.

## Special notes for your reviewer

- Terminal mode (`IsTerminal`) remains unchanged.
- Errors from the Docker pull stream are still surfaced via the existing `checkForError` logic.
- A unit test (`TestPrintProgress_NonTerminal_ShowsStatusAndPercent`) validates that non-terminal output emits status, ID, and percentage.

## Checklist

- [ ] PR description is expressive and helpful for future contributors
- [ ] Code is simple and easy to understand
- [ ] Unit test added for the new behavior
- [ ] No user-facing documentation changes required
- [ ] No impact on upgrade flows

## Release note

```release-note
NONE
```
