### PR TITLE
enable s390x support for alpine-test-tooling.

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/packages
@@ -8,3 +8,4 @@ openssh
 curl
 eudev
 udev-init-scripts
+pciutils

--- a/cluster-provision/images/vm-image-builder/common.sh
+++ b/cluster-provision/images/vm-image-builder/common.sh
@@ -44,3 +44,8 @@ go_style_local_arch() {
    local arch=$(uname -m)
    go_style_arch_name $arch
 }
+
+linux_style_local_arch() {
+   local arch=$(uname -m)
+   linux_style_arch_name $arch
+}

--- a/publish.sh
+++ b/publish.sh
@@ -214,11 +214,8 @@ function main() {
       publish_manifest k8s-$i ${KUBEVIRTCI_TAG}-slim
     fi
   done
-  
-  # Currently supported for amd64 only
-  if [ "$ARCH" == "amd64" ]; then
-   publish_alpine_container_disk
-  fi
+   
+  publish_alpine_container_disk
 
   push_gocli
   if [ $ARCH == "s390x" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds the s390x support for the alpine-test-tooling.
Pointed the alpine-make-vm-image to the kubevirt fork(s390x changes are present) instead of alpinelinux 
Added pciutils package which installs the pci utilities
Enabled the alpine_test_tooling publish for all the archs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.
```
