### PR TITLE
kind-sriov: Deploy network-resources-injector

### DIFF
--- a/cluster-up/cluster/kind-sriov/config_sriov_cluster.sh
+++ b/cluster-up/cluster/kind-sriov/config_sriov_cluster.sh
@@ -70,6 +70,9 @@ if [[ "$KUBEVIRT_USE_DRA" != "true" ]]; then
 
   # Verify that each sriov capable node has sriov VFs allocatable resource
   validate_nodes_sriov_allocatable_resource
+  
+  ## Deploy network-resources-injector
+  sriov_components::deploy_network_resources_injector
 else
   sriov_components::deploy_dra
 fi

--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/network_resources_injector/auth.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/network_resources_injector/auth.yaml
@@ -1,0 +1,163 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: kube-system
+  name: network-resources-injector-sa
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: network-resources-injector-sa-secret
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: network-resources-injector-sa
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: network-resources-injector
+rules:
+- apiGroups:
+  - ""
+  - k8s.cni.cncf.io
+  - extensions
+  - apps
+  resources:
+  - replicationcontrollers
+  - replicasets
+  - daemonsets
+  - statefulsets
+  - pods
+  - network-attachment-definitions
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: network-resources-injector-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: network-resources-injector-webhook-configs
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: network-resources-injector-service
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: network-resources-injector-configmaps
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - 'get'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: network-resources-injector-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: network-resources-injector
+subjects:
+- kind: ServiceAccount
+  name: network-resources-injector-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: network-resources-injector-secrets-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: network-resources-injector-secrets
+subjects:
+- kind: ServiceAccount
+  name: network-resources-injector-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: network-resources-injector-webhook-configs-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: network-resources-injector-webhook-configs
+subjects:
+- kind: ServiceAccount
+  name: network-resources-injector-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: network-resources-injector-service-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: network-resources-injector-service
+subjects:
+- kind: ServiceAccount
+  name: network-resources-injector-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: network-resources-injector-configmaps-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: network-resources-injector-configmaps
+subjects:
+- kind: ServiceAccount
+  name: network-resources-injector-sa
+  namespace: kube-system
+

--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/network_resources_injector/server.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/network_resources_injector/server.yaml
@@ -1,0 +1,110 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: network-resources-injector
+  name: network-resources-injector
+  namespace: kube-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: network-resources-injector
+  template:
+    metadata:
+      labels:
+        app: network-resources-injector
+    spec:
+      serviceAccount: network-resources-injector-sa
+      containers:
+      - name: webhook-server
+        image: ghcr.io/k8snetworkplumbingwg/network-resources-injector:v1.8.0
+        imagePullPolicy: Always
+        command:
+        - webhook
+        args:
+        - -bind-address=0.0.0.0
+        - -port=8443
+        - -tls-private-key-file=/etc/tls/tls.key
+        - -tls-cert-file=/etc/tls/tls.crt
+        - -health-check-port=8444
+        - -logtostderr
+        - -v=2
+        - -insecure
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          runAsUser: 10000
+          runAsGroup: 10000
+          capabilities:
+            drop:
+              - ALL
+            add: ["NET_BIND_SERVICE"]
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /etc/tls
+          name: tls
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "250m"
+          limits:
+            memory: "200Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8444
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      initContainers:
+      - name: installer
+        image: ghcr.io/k8snetworkplumbingwg/network-resources-injector:v1.8.0
+        imagePullPolicy: Always
+        command:
+        - installer
+        args:
+        - -name=network-resources-injector
+        - -namespace=kube-system
+        - -alsologtostderr
+        securityContext:
+          runAsUser: 10000
+          runAsGroup: 10000
+        volumeMounts:
+        - name: tls
+          mountPath: /etc/tls
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      volumes:
+      - name: tls
+        emptyDir: {}
+
+# For third-party certificate, use secret resource
+# instead of self-generated one from installer as below:
+#
+# 1) Remove initContainers from Pod spec.
+# 2) Replace `emptyDir: {}` with below config
+#
+#   secret:
+#     secretName: network-resources-injector-secret

--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/network_resources_injector/service.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/network_resources_injector/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: network-resources-injector-service
+  namespace: kube-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 8443
+  selector:
+    app: network-resources-injector

--- a/cluster-up/cluster/kind-sriov/sriov-components/sriov_components.sh
+++ b/cluster-up/cluster/kind-sriov/sriov-components/sriov_components.sh
@@ -23,6 +23,10 @@ KUBECTL="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl --kubeconfig=${KU
 SRIOV_DRA_MANIFEST="${MANIFESTS_DIR}/dra/sriov_dra.yaml"
 SRIOV_DRA_NAMESPACE="dra-driver-sriov"
 
+NETWORK_RESOURCES_INJECTOR_AUTH_MANIFEST="${MANIFESTS_DIR}/network_resources_injector/auth.yaml"
+NETWORK_RESOURCES_INJECTOR_SERVICE_MANIFEST="${MANIFESTS_DIR}/network_resources_injector/service.yaml"
+NETWORK_RESOURCES_INJECTOR_SERVER_MANIFEST="${MANIFESTS_DIR}/network_resources_injector/server.yaml"
+
 function _kubectl() {
     ${KUBECTL} "$@"
 }
@@ -145,6 +149,13 @@ function sriov_components::deploy_dra() {
   _kubectl create namespace "$SRIOV_DRA_NAMESPACE"
   _kubectl apply -f "$SRIOV_DRA_MANIFEST"
 
+  return 0
+}
+
+function sriov_components::deploy_network_resources_injector() {
+  _kubectl apply -f "$NETWORK_RESOURCES_INJECTOR_AUTH_MANIFEST"
+  _kubectl apply -f "$NETWORK_RESOURCES_INJECTOR_SERVICE_MANIFEST"
+  _kubectl apply -f "$NETWORK_RESOURCES_INJECTOR_SERVER_MANIFEST"
   return 0
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In order to support the KubVirt Decouple NAD
VEP #106, deploy network-resources-injector [1]
to sriov-kind provider.
Manifests copied from [2].

[1] https://github.com/k8snetworkplumbingwg/network-resources-injector

[2] https://github.com/k8snetworkplumbingwg/network-resources-injector/tree/v1.8.0/deployments
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Please review only [kind-sriov: Deploy network-resources-injector](https://github.com/kubevirt/kubevirtci/pull/1609/changes/35657c57dfc585e2e310dbae2def3e42aa1e7062) commit. The previous one belongs to https://github.com/kubevirt/kubevirtci/pull/1610.


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
network-resources-injector deployment added to sriov-kind provider
```
