### PR TITLE
kind: Move overlayfs workaround to containerdConfigPatches

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -109,22 +109,6 @@ server = "http://registry:5000"
 EOF
     '
 }
-
-function _configure_overlayfs_on_node() {
-    local -r node=${1}
-    _configure_overlayfs_mount_options "${NODE_CMD} ${node} bash -c"
-}
-
-function _configure_overlayfs_mount_options() {
-    local cmd_context="${1}" # context to run command e.g. sudo, docker exec
-    ${cmd_context} "$(_overlayfs_volatile_cmd)"
-    ${cmd_context} "$(_reload-containerd-daemon-cmd)"
-}
-
- function _overlayfs_volatile_cmd(){
-    echo "sed -i '/^\[plugins\]$/a\  [plugins.\"io.containerd.snapshotter.v1.overlayfs\"]\n    mount_options = [\"volatile\"]' /etc/containerd/config.toml"
- }
-
 # this works since the nodes use the same names as containers
 function _ssh_into_node() {
     if [[ $2 != "" ]]; then
@@ -273,7 +257,6 @@ function setup_kind() {
     _run_registry "$KIND_DEFAULT_NETWORK"
 
     for node in $(_get_nodes | awk '{print $1}'); do
-        _configure_overlayfs_on_node "$node"
         _configure_registry_on_node "$node" "$KIND_DEFAULT_NETWORK"
         _configure_network "$node"
     done

--- a/cluster-up/cluster/kind/manifests/kind.yaml
+++ b/cluster-up/cluster/kind/manifests/kind.yaml
@@ -1,5 +1,9 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    mount_options = ["volatile"]
 networking:
   serviceSubnet: "10.76.0.0/12"
 nodes:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is much cleaner and applies the config correctly:

```
$ env | grep KUBEVIRT
KUBEVIRT_PROVIDER=kind-1.34
KUBEVIRT_MEMORY_SIZE=16384
$ make cluster-up
[..]
$ ./cluster-up/ssh.sh kind-1.34-control-plane
root@kind-1:/# cat /etc/containerd/config.toml
version = 2

[plugins]
  [plugins."io.containerd.grpc.v1.cri"]
    restrict_oom_score_adj = false
    sandbox_image = "registry.k8s.io/pause:3.10"
    tolerate_missing_hugepages_controller = true
    [plugins."io.containerd.grpc.v1.cri".containerd]
      default_runtime_name = "runc"
      discard_unpacked_layers = true
      snapshotter = "overlayfs"
      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
          base_runtime_spec = "/etc/containerd/cri-base.json"
          runtime_type = "io.containerd.runc.v2"
          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
            SystemdCgroup = true
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
          base_runtime_spec = "/etc/containerd/cri-base.json"
          runtime_type = "io.containerd.runc.v2"
          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.options]
            SystemdCgroup = true
  [plugins."io.containerd.snapshotter.v1.overlayfs"]
    mount_options = ["volatile"]

[proxy_plugins]
  [proxy_plugins.fuse-overlayfs]
    address = "/run/containerd-fuse-overlayfs.sock"
    type = "snapshot"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1611

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
