### PR TITLE
publish,alpine: Add separate publish script for the alpine-with-test-tooling image

### DIFF
--- a/hack/publish-alpine.sh
+++ b/hack/publish-alpine.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ARCH=$(uname -m | grep -q s390x && echo s390x || echo amd64)
+
+source "${SCRIPT_DIR}/detect_cri.sh"
+
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)}
+export CRI_BIN=${CRI_BIN:-$(detect_cri)}
+
+if [ -z "${CRI_BIN}" ]; then
+    echo "ERROR: Neither podman nor docker is available." >&2
+    exit 1
+fi
+
+TARGET_REPO="quay.io/kubevirtci"
+TARGET_KUBEVIRT_REPO="quay.io/kubevirt"
+
+function build_alpine_container_disk() {
+  echo "INFO: build alpine container disk"
+  (cd cluster-provision/images/vm-image-builder && ./create-containerdisk.sh alpine-cloud-init)
+  if [[ "$ARCH" == "amd64" ]]; then
+    ${CRI_BIN} tag alpine-cloud-init:devel "${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}"
+    ${CRI_BIN} tag alpine-cloud-init:devel "${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel"
+  else
+    ${CRI_BIN} tag alpine-cloud-init:devel "${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}-${ARCH}"
+    ${CRI_BIN} tag alpine-cloud-init:devel "${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel-${ARCH}"
+  fi
+}
+
+function push_alpine_container_disk() {
+  echo "INFO: push alpine container disk"
+  if [[ "$ARCH" == "amd64" ]]; then
+    TARGET_IMAGE="${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}"
+    TARGET_KUBEVIRT_IMAGE="${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel"
+  else
+    TARGET_IMAGE="${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}-${ARCH}"
+    TARGET_KUBEVIRT_IMAGE="${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel-${ARCH}"
+  fi
+  ${CRI_BIN} push "$TARGET_IMAGE"
+  ${CRI_BIN} push "$TARGET_KUBEVIRT_IMAGE"
+}
+
+function publish_alpine_container_disk() {
+  build_alpine_container_disk
+  push_alpine_container_disk
+}
+
+publish_alpine_container_disk

--- a/publish.sh
+++ b/publish.sh
@@ -144,35 +144,6 @@ function publish_clusters() {
   push_cluster_images
 }
 
-function build_alpine_container_disk() {
-  echo "INFO: build alpine container disk"
-  (cd cluster-provision/images/vm-image-builder && ./create-containerdisk.sh alpine-cloud-init)
-  if [ $ARCH == "amd64" ]; then
-    ${CRI_BIN} tag alpine-cloud-init:devel ${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}
-    ${CRI_BIN} tag alpine-cloud-init:devel ${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel
-  else
-    ${CRI_BIN} tag alpine-cloud-init:devel ${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}-$ARCH
-    ${CRI_BIN} tag alpine-cloud-init:devel ${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel-$ARCH
-  fi
-}
-
-function push_alpine_container_disk() {
-  echo "INFO: push alpine container disk"
-    if [ $ARCH == "amd64" ]; then
-     TARGET_IMAGE="${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}"
-     TARGET_KUBEVIRT_IMAGE="${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel"
-    else
-     TARGET_IMAGE="${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}-$ARCH"
-     TARGET_KUBEVIRT_IMAGE="${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel-$ARCH"
-    fi
-  podman push $TARGET_IMAGE
-  podman push $TARGET_KUBEVIRT_IMAGE
-}
-
-function publish_alpine_container_disk() {
-  build_alpine_container_disk
-  push_alpine_container_disk
-}
 
 function create_git_tag() {
   if [ "$CI" == "true" ]; then
@@ -192,7 +163,7 @@ publish_manifest() {
   local image_tag="${2:?}"
   local target_image_repo="${3:-$TARGET_REPO}"
   local full_image_name="${target_image_repo}/${image_name}:${image_tag}"
-  if [[ "$image_name" != "alpine-with-test-tooling-container-disk" && "$image_name" != "centos9" && "$image_name" != "centos10" && "$image_name" != "gocli" && ! ( "$image_name" == "k8s-1.34" && "$image_tag" =~ "slim" ) ]]; then
+  if [[ "$image_name" != "centos9" && "$image_name" != "centos10" && "$image_name" != "gocli" && ! ( "$image_name" == "k8s-1.34" && "$image_tag" =~ "slim" ) ]]; then
     unset 'cur_archs[1]'
   fi
   for arch in ${cur_archs[*]};do
@@ -233,13 +204,6 @@ function main() {
       publish_manifest k8s-$i ${KUBEVIRTCI_TAG}-slim
     fi
   done
-
-  publish_alpine_container_disk
-
-  if [ $ARCH == "s390x" ]; then
-   publish_manifest "alpine-with-test-tooling-container-disk" $KUBEVIRTCI_TAG
-   publish_manifest "alpine-with-test-tooling-container-disk" "devel" $TARGET_KUBEVIRT_REPO
-  fi
 
   push_gocli
   if [ $ARCH == "s390x" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Publishing the alpine-with-test-tooling image in publish.sh is causing frequent failures, which in turn causes the kubevirtci publish job to fail.

Splitting out the publish of the alpine VM image will help to avoid alpine publish failures blocking the delivery of the kubevirtci node images to kubevirt/kubevirt

This new script can be run from a separate dedicated postsubmit job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/kubevirtci/issues/1336

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```
