### PR TITLE
Remove standard SC deletion from kind-1.35/provider.sh

### DIFF
--- a/cluster-up/cluster/kind-1.35/provider.sh
+++ b/cluster-up/cluster/kind-1.35/provider.sh
@@ -43,9 +43,6 @@ function up() {
 
   configure_registry_proxy
 
-  # remove the rancher.io kind default storageClass
-  _kubectl delete sc standard
-
   echo "$KUBEVIRT_PROVIDER cluster '$CLUSTER_NAME' is ready"
 }
 


### PR DESCRIPTION
The deletion of KinD's default SC `storage` is already done in kind/common.sh. Having double delete statements results in error in CI. Keep only the delete statement in kind/common.sh.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The deletion of KinD's default SC `storage` is already done in kind/common.sh.   Having a second delete statement in `kind-1.35/provider.sh` results in error in CI. Keep only the delete statement in kind/common.sh.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes CI failure described here: https://github.com/kubevirt/kubevirt/pull/16972#issuecomment-4005993053

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
