### PR TITLE
gocli: Increase default etcd in-memory tmpfs size from 512M to 1G

### DIFF
--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -157,7 +157,7 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().StringArrayVar(&nvmeDisks, "nvme", []string{}, "size of the emulate NVMe disk to pass to the node")
 	run.Flags().StringArrayVar(&scsiDisks, "scsi", []string{}, "size of the emulate SCSI disk to pass to the node")
 	run.Flags().Bool("run-etcd-on-memory", false, "configure etcd to run on RAM memory, etcd data will not be persistent")
-	run.Flags().String("etcd-capacity", "512M", "set etcd data mount size.\nthis flag takes affect only when 'run-etcd-on-memory' is specified")
+	run.Flags().String("etcd-capacity", etcdinmemory.DefaultEtcdCapacity, "set etcd data mount size.\nthis flag takes affect only when 'run-etcd-on-memory' is specified")
 	run.Flags().Uint("hugepages-2m", 64, "number of hugepages of size 2M to allocate")
 	run.Flags().Uint("hugepages-1g", 0, "number of hugepages of size 1Gi to allocate")
 	run.Flags().Bool("enable-realtime-scheduler", false, "configures the kernel to allow unlimited runtime for processes that require realtime scheduling")

--- a/cluster-provision/gocli/cmd/run_test.go
+++ b/cluster-provision/gocli/cmd/run_test.go
@@ -47,13 +47,13 @@ var _ = Describe("Node Provisioning", func() {
 		It("should execute the correct commands", func() {
 			linuxConfigFuncs := []nodesconfig.LinuxConfigFunc{
 				nodesconfig.WithEtcdInMemory(true),
-				nodesconfig.WithEtcdSize("512M"),
+				nodesconfig.WithEtcdSize("1G"),
 				nodesconfig.WithPSA(true),
 			}
 
 			n := nodesconfig.NewNodeLinuxConfig(1, "k8s-1.30", linuxConfigFuncs)
 
-			etcdinmemory.AddExpectCalls(sshClient, "512M")
+			etcdinmemory.AddExpectCalls(sshClient, "1G")
 			bindvfio.AddExpectCalls(sshClient, "8086:2668")
 			bindvfio.AddExpectCalls(sshClient, "8086:2415")
 			psa.AddExpectCalls(sshClient)

--- a/cluster-provision/gocli/opts/etcd/etcd.go
+++ b/cluster-provision/gocli/opts/etcd/etcd.go
@@ -6,6 +6,8 @@ import (
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/libssh"
 )
 
+const DefaultEtcdCapacity = "1G"
+
 type etcdInMemOpt struct {
 	etcdSize  string
 	sshClient libssh.Client
@@ -13,7 +15,7 @@ type etcdInMemOpt struct {
 
 func NewEtcdInMemOpt(sc libssh.Client, size string) *etcdInMemOpt {
 	if size == "" {
-		size = "512M"
+		size = DefaultEtcdCapacity
 	}
 	return &etcdInMemOpt{
 		etcdSize:  size,


### PR DESCRIPTION
## Summary

- Increases the default etcd in-memory tmpfs size from 512M to 1G to avoid etcd failures due to insufficient space.

Ref: https://github.com/kubevirt/kubevirt/issues/17019