### PR TITLE
sr-iov: enable ExternalNetResourceInjection feature gate

### DIFF
--- a/cluster-up/cluster/kind/check-cluster-up.sh
+++ b/cluster-up/cluster/kind/check-cluster-up.sh
@@ -62,14 +62,19 @@ export CRI_BIN=${CRI_BIN:-$(detect_cri)}
     echo "Deploy latest nighly build Kubevirt"
     if [ "$(kubectl get kubevirts -n kubevirt kubevirt -ojsonpath='{.status.phase}')" != "Deployed" ]; then
       ${kubectl} apply -f "${nightly_build_base_url}/${latest}/kubevirt-operator.yaml"
-      ${kubectl} apply -f "${nightly_build_base_url}/${latest}/kubevirt-cr.yaml"
+
+      curl -sL "${nightly_build_base_url}/${latest}/kubevirt-cr.yaml" -o /tmp/kubevirt-cr.yaml
+      if [[ "$KUBEVIRT_PROVIDER" =~ "sriov" ]]; then
+        # SR-IOV requires CPUManager and ExternalNetResourceInjection feature gates
+        ${kubectl} patch --local -f /tmp/kubevirt-cr.yaml --type=merge -p '{}' -o json \
+          | jq '.spec.configuration.developerConfiguration.featureGates |= ((. // []) + ["CPUManager","ExternalNetResourceInjection"] | unique)' \
+          > /tmp/kubevirt-cr-patched.json
+        ${kubectl} apply -f /tmp/kubevirt-cr-patched.json
+      else
+        ${kubectl} apply -f /tmp/kubevirt-cr.yaml
+      fi
     fi
     ${kubectl} wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m
-
-    if [[ "$KUBEVIRT_PROVIDER" =~ "sriov" ]]; then
-      # Some SR-IOV tests require Kubevirt CPUManager feature
-      ${kubectl} patch kubevirts -n kubevirt kubevirt --type=json -p='[{"op": "replace", "path": "/spec/configuration/developerConfiguration/featureGates","value": ["CPUManager"]}]'
-    fi
 
     echo "Run latest nighly build Kubevirt conformance tests"
     kubevirt_plugin="--plugin ${nightly_build_base_url}/${latest}/conformance.yaml"


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
SR-IOV tests expect ExternalNetResourceInjection FG to be enabled.

Download kubevirt-cr.yaml and patch it locally with jq to append ExternalNetResourceInjection to the developerConfiguration featureGates before applying, instead of applying the stock CR directly. This way no additional rollout is required.

Also `CPUManager` is added in the same manner, both for simplicity and so it won't override the pre-set FGs using the previous patch command.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
als