### PR TITLE
k8s: Enable cpuManagerPolicy static in kubelet drop-in config

### DIFF
--- a/cluster-provision/k8s/1.34/k8s_provision.sh
+++ b/cluster-provision/k8s/1.34/k8s_provision.sh
@@ -171,6 +171,11 @@ kind: KubeletConfiguration
 cgroupDriver: systemd
 failSwapOn: false
 kubeletCgroups: /systemd/system.slice
+cpuManagerPolicy: static
+kubeReserved:
+  cpu: 500m
+systemReserved:
+  cpu: 500m
 EOF
 
 cat <<EOT >/etc/sysconfig/kubelet

--- a/cluster-provision/k8s/1.35/k8s_provision.sh
+++ b/cluster-provision/k8s/1.35/k8s_provision.sh
@@ -171,6 +171,11 @@ kind: KubeletConfiguration
 cgroupDriver: systemd
 failSwapOn: false
 kubeletCgroups: /systemd/system.slice
+cpuManagerPolicy: static
+kubeReserved:
+  cpu: 500m
+systemReserved:
+  cpu: 500m
 EOF
 
 cat <<EOT >/etc/sysconfig/kubelet

--- a/cluster-provision/k8s/1.36/k8s_provision.sh
+++ b/cluster-provision/k8s/1.36/k8s_provision.sh
@@ -171,6 +171,11 @@ kind: KubeletConfiguration
 cgroupDriver: systemd
 failSwapOn: false
 kubeletCgroups: /systemd/system.slice
+cpuManagerPolicy: static
+kubeReserved:
+  cpu: 500m
+systemReserved:
+  cpu: 500m
 EOF
 
 cat <<EOT >/etc/sysconfig/kubelet


### PR DESCRIPTION
## Summary

- Enable `cpuManagerPolicy: static` in the kubelet drop-in config (`50-kubevirt.conf`) during base image provisioning for k8s 1.33, 1.34, and 1.35
- Add required `kubeReserved` and `systemReserved` CPU reservations (500m each) to match the existing gocli worker node configuration

## Problem

On single-node clusters where the control-plane node also has the `worker` role, CPUManager was not enabled. The gocli provisioner only sets `--cpu-manager-policy=static` during the worker node join path (`nodes.go`), which the control-plane node never executes. This was previously handled by the `configure_cpu_manager` shell function removed in #1289.

The KubeVirt functional test suite's `SynchronizedBeforeSuite` enables the CPUManager feature gate and then waits for all schedulable nodes to have the `cpumanager=true` label, causing a 360-second timeout on single-node clusters.

## Fix

Add `cpuManagerPolicy: static` and CPU reservations directly to the kubelet drop-in config file that is written during base image provisioning. This ensures CPUManager is configured on all nodes regardless of their role, including control-plane+worker nodes in single-node clusters.

Fixes: https://github.com/kubevirt/kubevirtci/issues/1648