### PR TITLE
fedora-with-test-tooling: Upgrade to fedora43

### DIFF
--- a/cluster-provision/images/vm-image-builder/customize-image.sh
+++ b/cluster-provision/images/vm-image-builder/customize-image.sh
@@ -99,5 +99,5 @@ virt-sysprep -d $DOMAIN_NAME --operations machine-id,bash-history,logfiles,tmp-f
 # Remove VM
 undefine_vm "${DOMAIN_NAME}"
 
-# Convert image
-qemu-img convert -c -O qcow2 "${SOURCE_IMAGE_PATH}" "${CUSTOMIZE_IMAGE_PATH}"
+# Convert image, sparsify and compress
+virt-sparsify --compress "${SOURCE_IMAGE_PATH}" "${CUSTOMIZE_IMAGE_PATH}"

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -66,13 +66,12 @@ runcmd:
   - sudo grubby --update-kernel=ALL --args="net.ifnames=0 biosdevname=0"
   - sudo systemctl daemon-reload
   - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng virt-what vm-dump-metrics tpm2-tools netcat sg3_utils iperf3 wget tcpdump
-  # Download the busybox netcat and relpace it with the OpenBSD netcat
-  # To align with the netcat tool used in the Alpine image for network e2e testing
-  - if [ $(uname -m) == "aarch64" ]; then export CPUARCH="armv8l"; elif [ $(uname -m) == "s390x" ]; then export CPUARCH="s390x"; else export CPUARCH="x86_64"; fi
-  - sudo wget https://busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-${CPUARCH}
-  - sudo chmod +x busybox-${CPUARCH}
-  - sudo mv /usr/bin/nc /usr/bin/netcat-openbsd
-  - sudo mv busybox-${CPUARCH} /usr/bin/nc
+  # Install nmap-ncat in addition to OpenBSD netcat.
+  # Use "nc" when OpenBSD behavior is needed (cloud-init uses "nc -U").
+  # Use "ncat" when nmap-ncat behavior is needed (--recv-only, --no-shutdown,
+  # and server commands that use --sh-exec in tests).
+  - sudo dnf install -y nmap-ncat
+  - sudo alternatives --set nc /usr/bin/netcat
   - sudo dnf clean all
   - sudo systemctl enable wait-for-cloud-init
   - sudo systemctl enable qemu-guest-agent.service

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -45,6 +45,12 @@ write_files:
     - path: /etc/profile.d/disable-bracketed-paste.sh
       content: |
         bind 'set enable-bracketed-paste off'
+    # Note: systemd>=258 (Fedora 43+) injects OSC 3008/8003 escape sequences
+    # via PROMPT_COMMAND and PS0 for shell integration. These break goexpect
+    # regex matching in console tests. Disable them at the profile level.
+    - path: /etc/profile.d/disable-systemd-shell-integration.sh
+      content: |
+        unset PROMPT_COMMAND PS0
 runcmd:
   - sudo systemctl daemon-reload
   - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng virt-what vm-dump-metrics tpm2-tools netcat sg3_utils iperf3 wget tcpdump

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -51,6 +51,15 @@ write_files:
     - path: /etc/profile.d/disable-systemd-shell-integration.sh
       content: |
         unset PROMPT_COMMAND PS0
+    # Restrict cloud-init datasource search to NoCloud, ConfigDrive, and None
+    # so that VMs booted without a cloud-init ISO (e.g. Freeze/Unfreeze tests)
+    # complete datasource detection in seconds instead of timing out through
+    # network-based datasources (EC2, Azure, ...) which can take many minutes
+    # on arm64. With NoCloud or ConfigDrive data injected by KubeVirt the
+    # behaviour is unchanged; without data cloud-init falls through to None.
+    - path: /etc/cloud/cloud.cfg.d/99-kubevirt-datasource.cfg
+      content: |
+        datasource_list: [NoCloud, ConfigDrive, None]
 runcmd:
   # Fedora 43+ uses predictable network interface names (e.g. enp1s0).
   # Many KubeVirt tests assume "eth0". Restore classic naming.

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -88,4 +88,11 @@ runcmd:
   - |
     sudo sed -i 's/^hosts:.*/hosts:      files dns myhostname resolve [!UNAVAIL=return]/' /etc/nsswitch.conf
   - sudo sed -i '/pam_nologin/d' /etc/pam.d/sshd
+  # Ensure boot artifacts are refreshed on IBM Z. If cmdline/kernel artifacts drift,
+  # s390x can panic early with unknown-block and disabled-wait.
+  - |
+    if [ "$(uname -m)" = "s390x" ]; then
+      sudo dracut -f --regenerate-all
+      sudo zipl
+    fi
   - sudo shutdown

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -52,6 +52,9 @@ write_files:
       content: |
         unset PROMPT_COMMAND PS0
 runcmd:
+  # Fedora 43+ uses predictable network interface names (e.g. enp1s0).
+  # Many KubeVirt tests assume "eth0". Restore classic naming.
+  - sudo grubby --update-kernel=ALL --args="net.ifnames=0 biosdevname=0"
   - sudo systemctl daemon-reload
   - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng virt-what vm-dump-metrics tpm2-tools netcat sg3_utils iperf3 wget tcpdump
   # Download the busybox netcat and relpace it with the OpenBSD netcat

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -71,9 +71,13 @@ runcmd:
   - sudo hostnamectl set-hostname "" --transient
   - sudo sed -i '/users_groups/d' /etc/cloud/cloud.cfg
   - sudo sed -i 's/^SELINUX=.*/SELINUX=permissive/' /etc/selinux/config
-  # Adjust /etc/nsswitch.conf to mitigate the bug with nss-myhostame which
-  # breaks FQDN: https://bugzilla.redhat.com/show_bug.cgi?id=2038634
+  # Prefer "dns" before "resolve" in nsswitch.conf hosts lookup order.
+  # In our test setup, the "resolve" NSS module (systemd-resolved D-Bus path)
+  # can return the local short hostname before DNS search domains are applied,
+  # so "hostname -f" may return only the short name.
+  # Keep "resolve [!UNAVAIL=return]" at the end to preserve fallback semantics.
+  # Note: use a literal block (|) to avoid YAML misinterpreting "hosts:" as a mapping key.
   - |
-    sudo sed -i 's/hosts:      files myhostname resolve \[\!UNAVAIL=return\] dns/hosts:      resolve \[\!UNAVAIL=return\] files myhostname dns/' /etc/nsswitch.conf
+    sudo sed -i 's/^hosts:.*/hosts:      files dns myhostname resolve [!UNAVAIL=return]/' /etc/nsswitch.conf
   - sudo sed -i '/pam_nologin/d' /etc/pam.d/sshd
   - sudo shutdown

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -75,4 +75,5 @@ runcmd:
   # breaks FQDN: https://bugzilla.redhat.com/show_bug.cgi?id=2038634
   - |
     sudo sed -i 's/hosts:      files myhostname resolve \[\!UNAVAIL=return\] dns/hosts:      resolve \[\!UNAVAIL=return\] files myhostname dns/' /etc/nsswitch.conf
+  - sudo sed -i '/pam_nologin/d' /etc/pam.d/sshd
   - sudo shutdown

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -69,7 +69,7 @@ runcmd:
   - sudo systemctl enable qemu-guest-agent.service
   - sudo hostnamectl set-hostname ""
   - sudo hostnamectl set-hostname "" --transient
-  - sudo sed -i /users-groups/d /etc/cloud/cloud.cfg
+  - sudo sed -i '/users_groups/d' /etc/cloud/cloud.cfg
   - sudo sed -i 's/^SELINUX=.*/SELINUX=permissive/' /etc/selinux/config
   # Adjust /etc/nsswitch.conf to mitigate the bug with nss-myhostame which
   # breaks FQDN: https://bugzilla.redhat.com/show_bug.cgi?id=2038634

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -1,7 +1,11 @@
 #cloud-config
-password: fedora
-chpasswd: { expire: False }
 ssh_pwauth: yes
+chpasswd:
+  users:
+    - name: fedora
+      password: fedora
+      type: text
+  expire: false
 write_files:
     - path: /etc/modules-load.d/mlx5.conf
       content: |

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -37,7 +37,7 @@ write_files:
           RemainAfterExit=true
 
           [Install]
-          WantedBy=cloud-init.service
+          WantedBy=cloud-init.target
     # Note: bash and libreadline in Fedora 35 come with 'bracketed-paste' mode
     # enabled by default. This results in extra escape sequences in the
     # console output. The mode is explicitly disabled here to make the existing

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -1,9 +1,16 @@
 #cloud-config
 ssh_pwauth: yes
+users:
+  - name: cloud-user
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
 chpasswd:
   users:
     - name: fedora
       password: fedora
+      type: text
+    - name: cloud-user
+      password: cloud-user
       type: text
   expire: false
 write_files:

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2
+https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-arm64
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-arm64
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/aarch64/images/Fedora-Cloud-Base-39-1.5.aarch64.qcow2
+https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-43-1.6.aarch64.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-s390x
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-s390x
@@ -1,1 +1,1 @@
-https://archives.fedoraproject.org/pub/fedora-secondary/releases/39/Cloud/s390x/images/Fedora-Cloud-Base-39-1.5.s390x.qcow2
+https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images/Fedora-Cloud-Base-Generic-43-1.6.s390x.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/os-variant
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/os-variant
@@ -1,1 +1,1 @@
-fedora39
+fedora43


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Upgrade the `fedora-with-test-tooling` container-disk image from Fedora 39 (EOL)
to Fedora 43, with all the compatibility fixes required to keep KubeVirt tests
working on the newer distribution.
Can be built with latest osinfo `fedora43`.

Additional motivation is the flakes, see please this [comment](https://github.com/kubevirt/kubevirt/issues/17085#issuecomment-4149870482).
Update the baseline, remove `pam_nologin`, so we can advance from here on fresh and updated baseline.

Tested on Kubevirt using https://github.com/kubevirt/kubevirt/pull/17257
Images are smaller, and hopefully some tests might be faster (at least versus raw F43) due to the changes.

Core upgrade
- Bump base image from F39 to F43

F43 compatibility fixes

- **chpasswd syntax** — `password`/`chpasswd` top-level keys removed in cloud-init 24.x; switch to `chpasswd.users` list format
- **Systemd shell integration** — systemd ≥258 injects OSC escape sequences via `PROMPT_COMMAND`/`PS0`, breaking `goexpect` regex matching in console tests; disable via `profile.d` drop-in
- **Classic NIC naming** — F43 enables predictable names (`enp1s0`) by default; restore `eth0` via `net.ifnames=0 biosdevname=0` through `grubby`
- **pam_nologin** — blocks non-root SSH logins during early boot, causing flaky test failures; remove from the SSH PAM stack (this is one of the reasons we have flakes since F39, see [issue](https://github.com/kubevirt/kubevirt/issues/17085)).
- **cloud-init datasource restriction** — without an explicit datasource_list, cloud-init 25.x probes all datasources including network-based ones (EC2, Azure, ...) each with their own timeout, delaying boot completion and blocking wait-for-cloud-init.service before qemu-guest-agent can start; restrict to [NoCloud, ConfigDrive, None] to complete instantly when no matching ISO is present
- **cloud-init target** — `wait-for-cloud-init.service` was `WantedBy=cloud-init.service`; correct to `WantedBy=cloud-init.target` for proper ordering against cloud-init completion
- **hostname -f** — the `resolve` NSS module returns the short hostname via systemd-resolved D-Bus; switch to `dns` so the stub resolver applies search domains and returns the FQDN
- **users_groups sed pattern** — fix match to use underscore as introduced on F43
- **nc setup** — replace ad-hoc `busybox.net` binary download with `dnf install nmap-ncat`; keep OpenBSD netcat as default `nc` via alternatives so cloud-init 25.x using `-U` (Unix sockets) keeps working, while tests can use `ncat` when needed
- **cloud-user definition** — add explicit `cloud-user` in cloud-config so modules referencing it do not fail when `users_groups` is removed
- **s390x boot artifacts** — regenerate boot artifacts (`dracut` + `zipl`) during provisioning to avoid bootmap/initramfs drift and early boot panics

Image build improvements
- **virt-sparsify** — replace `qemu-img convert` with `virt-sparsify --compress` for smaller images (zeroes unused blocks before compressing)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
