### PR TITLE
cluster-provision: Move v1.37 to CentOS Stream 10

### DIFF
--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -57,8 +57,12 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 	packagePath := args[0]
 	centosVersion := os.Getenv("PROVISION_CENTOS_VERSION")
 	if centosVersion == "" {
-		// default to Centos Stream 9
-		centosVersion = "9"
+		baseBytes, err := os.ReadFile(filepath.Join(packagePath, "base"))
+		if err != nil {
+			return err
+		}
+		baseName := strings.TrimSpace(string(baseBytes))
+		centosVersion = strings.TrimPrefix(baseName, "centos")
 	}
 	versionBytes, err := os.ReadFile(filepath.Join(packagePath, "version"))
 	if err != nil {

--- a/cluster-provision/k8s/1.36/base
+++ b/cluster-provision/k8s/1.36/base
@@ -1,1 +1,1 @@
-centos9
+centos10

--- a/cluster-provision/k8s/provision.sh
+++ b/cluster-provision/k8s/provision.sh
@@ -13,7 +13,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 provision_dir="$(basename "$(pwd)")"
 base_from_file="$(cat base | tr -d '\n')"
 
-PROVISION_CENTOS_VERSION="${PROVISION_CENTOS_VERSION:-9}"
+PROVISION_CENTOS_VERSION="${PROVISION_CENTOS_VERSION:-}"
 if [[ "$PROVISION_CENTOS_VERSION" == "10" ]]; then
   base="centos10"
 elif [[ "$PROVISION_CENTOS_VERSION" == "9" ]]; then


### PR DESCRIPTION
## Summary

- Updates the `base` file for v1.36 to use CentOS Stream 10
- Removes the default `PROVISION_CENTOS_VERSION` value in `provision.sh` so the `base` file is respected when the variable is not explicitly set
- Fixes the gocli to read the `base` file when `PROVISION_CENTOS_VERSION` is not set, instead of hardcoding a default of CentOS Stream 9

## Related

- https://github.com/kubevirt/enhancements/issues/210