### PR TITLE
Add CRI-O version sync automation scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,16 @@ cluster-down:
 bump-net-resources-injector:
 	./hack/bump-net-resources-injector.sh
 
+crio-verify:
+	./hack/verify-crio-sync.sh
+
+crio-sync:
+	./hack/sync-crio-versions.sh
+
 .PHONY: \
 	cluster-up \
 	cluster-down \
 	bump-net-resources-injector \
-	bump
+	bump \
+	crio-verify \
+	crio-sync

--- a/hack/sync-crio-versions.sh
+++ b/hack/sync-crio-versions.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright The KubeVirt Authors.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+K8S_PROVIDERS_DIR="${SCRIPT_DIR}/../cluster-provision/k8s"
+
+get_minor_version() {
+    local version=$1
+    echo "$version" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/'
+}
+
+get_current_crio_version() {
+    local provision_script=$1
+    grep -E '^export CRIO_VERSION=' "$provision_script" | sed 's/export CRIO_VERSION=//'
+}
+
+is_prerelease_version() {
+    local version=$1
+    [[ "$version" == *"alpha"* ]] || [[ "$version" == *"beta"* ]] || [[ "$version" == *"rc"* ]]
+}
+
+update_crio_version() {
+    local provision_script=$1
+    local new_version=$2
+    local is_prerelease=$3
+
+    sed -i.bak "s/^export CRIO_VERSION=.*/export CRIO_VERSION=${new_version}/" "$provision_script"
+
+    if [ "$is_prerelease" = "true" ]; then
+        sed -i.bak "s|\[isv_cri-o_stable_v\${CRIO_VERSION}\]|[isv_cri-o_prerelease_v\${CRIO_VERSION}]|" "$provision_script"
+        sed -i.bak "s|name=CRI-O v\${CRIO_VERSION} (Stable) (rpm)|name=CRI-O v\${CRIO_VERSION} (Prerelease) (rpm)|" "$provision_script"
+        sed -i.bak "s|baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/isv_cri-o_stable_v\${CRIO_VERSION}|baseurl=https://download.opensuse.org/repositories/isv:/cri-o:/prerelease:/v\${CRIO_VERSION}:/build/rpm|" "$provision_script"
+    else
+        sed -i.bak "s|\[isv_cri-o_prerelease_v\${CRIO_VERSION}\]|[isv_cri-o_stable_v\${CRIO_VERSION}]|" "$provision_script"
+        sed -i.bak "s|name=CRI-O v\${CRIO_VERSION} (Prerelease) (rpm)|name=CRI-O v\${CRIO_VERSION} (Stable) (rpm)|" "$provision_script"
+        sed -i.bak "s|baseurl=https://download.opensuse.org/repositories/isv:/cri-o:/prerelease:/v\${CRIO_VERSION}:/build/rpm|baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/isv_cri-o_stable_v\${CRIO_VERSION}|" "$provision_script"
+    fi
+
+    rm -f "${provision_script}.bak"
+}
+
+main() {
+    if [ ! -d "$K8S_PROVIDERS_DIR" ]; then
+        echo "ERROR: K8s providers directory not found: $K8S_PROVIDERS_DIR"
+        exit 1
+    fi
+
+    local changes_made=0
+    local total_providers=0
+    local updated_files=()
+
+    for provider_dir in "$K8S_PROVIDERS_DIR"/*/; do
+        [ -d "$provider_dir" ] || continue
+
+        total_providers=$((total_providers + 1))
+
+        local provider_name
+        provider_name=$(basename "$provider_dir")
+        local version_file="${provider_dir}version"
+        local provision_script="${provider_dir}k8s_provision.sh"
+
+        if [ ! -f "$version_file" ] || [ ! -f "$provision_script" ]; then
+            echo "Skipping $provider_name: missing version or k8s_provision.sh"
+            continue
+        fi
+
+        local k8s_version
+        k8s_version=$(tr -d '\n' < "$version_file")
+        local minor_version
+        minor_version=$(get_minor_version "$k8s_version")
+        local current_crio
+        current_crio=$(get_current_crio_version "$provision_script")
+        local expected_crio="$minor_version"
+
+        echo "Provider $provider_name: K8s=$k8s_version CRI-O=$current_crio expected=$expected_crio"
+
+        if [ "$current_crio" != "$expected_crio" ]; then
+            local prerelease="false"
+            if is_prerelease_version "$k8s_version"; then
+                prerelease="true"
+            fi
+            update_crio_version "$provision_script" "$expected_crio" "$prerelease"
+            updated_files+=("cluster-provision/k8s/$provider_name/k8s_provision.sh")
+            changes_made=$((changes_made + 1))
+            echo "  Updated CRI-O $current_crio -> $expected_crio (prerelease=$prerelease)"
+        fi
+    done
+
+    echo ""
+    echo "Scanned $total_providers providers, updated $changes_made"
+
+    if [ $changes_made -gt 0 ]; then
+        echo "Changed files:"
+        for f in "${updated_files[@]}"; do
+            echo "  $f"
+        done
+    fi
+}
+
+main

--- a/hack/verify-crio-sync.sh
+++ b/hack/verify-crio-sync.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright The KubeVirt Authors.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+K8S_PROVIDERS_DIR="${SCRIPT_DIR}/../cluster-provision/k8s"
+
+get_minor_version() {
+    local version=$1
+    echo "$version" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/'
+}
+
+get_current_crio_version() {
+    local provision_script=$1
+    grep -E '^export CRIO_VERSION=' "$provision_script" | sed 's/export CRIO_VERSION=//'
+}
+
+is_prerelease_version() {
+    local version=$1
+    [[ "$version" == *"alpha"* ]] || [[ "$version" == *"beta"* ]] || [[ "$version" == *"rc"* ]]
+}
+
+get_repo_type() {
+    local provision_script=$1
+    if grep -q "isv_cri-o_prerelease" "$provision_script"; then
+        echo "prerelease"
+    else
+        echo "stable"
+    fi
+}
+
+main() {
+    if [ ! -d "$K8S_PROVIDERS_DIR" ]; then
+        echo "ERROR: K8s providers directory not found: $K8S_PROVIDERS_DIR"
+        exit 1
+    fi
+
+    local mismatches=0
+    local total_providers=0
+
+    for provider_dir in "$K8S_PROVIDERS_DIR"/*/; do
+        [ -d "$provider_dir" ] || continue
+
+        total_providers=$((total_providers + 1))
+
+        local provider_name
+        provider_name=$(basename "$provider_dir")
+        local version_file="${provider_dir}version"
+        local provision_script="${provider_dir}k8s_provision.sh"
+
+        if [ ! -f "$version_file" ] || [ ! -f "$provision_script" ]; then
+            echo "WARN: Skipping $provider_name: missing version or k8s_provision.sh"
+            continue
+        fi
+
+        local k8s_version
+        k8s_version=$(tr -d '\n' < "$version_file")
+        local minor_version
+        minor_version=$(get_minor_version "$k8s_version")
+        local current_crio
+        current_crio=$(get_current_crio_version "$provision_script")
+        local repo_type
+        repo_type=$(get_repo_type "$provision_script")
+        local expected_crio="$minor_version"
+
+        local expected_repo_type="stable"
+        if is_prerelease_version "$k8s_version"; then
+            expected_repo_type="prerelease"
+        fi
+
+        echo "Provider $provider_name: K8s=$k8s_version CRI-O=$current_crio($repo_type) expected=$expected_crio($expected_repo_type)"
+
+        if [ "$current_crio" != "$expected_crio" ]; then
+            echo "  FAIL: CRI-O version mismatch"
+            mismatches=$((mismatches + 1))
+        fi
+
+        if [ "$repo_type" != "$expected_repo_type" ]; then
+            echo "  FAIL: repository type mismatch"
+            mismatches=$((mismatches + 1))
+        fi
+    done
+
+    echo ""
+    if [ "$mismatches" -eq 0 ]; then
+        echo "OK: All $total_providers providers have correct CRI-O configurations"
+        return 0
+    else
+        echo "FAIL: $mismatches issue(s) found across $total_providers providers"
+        echo "Run: ./hack/sync-crio-versions.sh"
+        return 1
+    fi
+}
+
+main


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

CRI-O follows Kubernetes version alignment — CRI-O 1.X is designed to work with K8s 1.X. Currently, bumping CRI-O versions when a new K8s provider is added or updated is a manual process (e.g. #1637).

This PR adds two scripts under `hack/` to automate the process:

- **`hack/verify-crio-sync.sh`** — read-only check that exits non-zero if any provider's CRI-O version or repository type (stable vs prerelease) doesn't match its Kubernetes version. Suitable as a CI gate.
- **`hack/sync-crio-versions.sh`** — detects mismatches and fixes them by updating `CRIO_VERSION`, the repo section name, and the `baseurl` in each provider's `k8s_provision.sh`. Handles both stable and prerelease CRI-O repositories.

Two Makefile targets are added: `make crio-verify` and `make crio-sync`, following the existing `bump-net-resources-injector` pattern.

**How it works**

For each provider under `cluster-provision/k8s/*/`:
1. Reads the K8s version from the `version` file (e.g. `1.35.3`)
2. Extracts the minor version (`1.35`)
3. Compares against `export CRIO_VERSION=` in `k8s_provision.sh`
4. For prerelease K8s versions (alpha/beta/rc), expects the prerelease CRI-O repo; for stable, expects the stable mirror

**Example output of `make crio-verify`**

    Provider 1.33: K8s=1.33.10 CRI-O=1.33(stable) expected=1.33(stable)
    Provider 1.34: K8s=1.34.6 CRI-O=1.34(stable) expected=1.34(stable)
    Provider 1.35: K8s=1.35.3 CRI-O=1.35(stable) expected=1.35(stable)
    Provider 1.36: K8s=1.36.0-beta.0 CRI-O=1.36(prerelease) expected=1.36(prerelease)

    OK: All 4 providers have correct CRI-O configurations

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This is a POC. CI integration is intentionally not included in this PR, the repo currently uses Prow and has no GitHub Actions workflows. We'd like maintainer input on the preferred approach:

- **Option A**: Add this as a Prow presubmit job
- **Option B**: Introduce a GitHub Actions workflow for this

Happy to follow up with a CI integration PR once there's alignment on the approach.

Reference: #1637 was the manual CRI-O 1.35 update — this automates that pattern.
[CRI-O compatibility matrix](https://github.com/cri-o/cri-o#compatibility-matrix-cri-o--kubernetes)

**Checklist**

- [ ] Design: Not required — lightweight scripting addition following existing `hack/` conventions
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than found (Boy Scout Rule)
- [ ] Upgrade: No impact on upgrade flows
- [ ] Testing: CI integration to be decided with maintainers (see special notes above)
- [ ] Documentation: Not required at this stage — scripts are self-documenting
- [ ] Community: Will announce pending maintainer feedback on CI approach

**Release note**:
```release-note
NONE
```
