### PR TITLE
[VEP-10]: feat: add experimental Minikube provider

### DIFF
--- a/cluster-up/cluster/minikube/README.md
+++ b/cluster-up/cluster/minikube/README.md
@@ -1,0 +1,49 @@
+# Minikube provider
+
+> **⚠️ EXPERIMENTAL**: This provider is in an experimental stage and is not production-ready.
+> Several features are not yet implemented, including local container registry support.
+
+Provides a pre-deployed Kubernetes cluster that runs using [Minikube](https://minikube.sigs.k8s.io/).
+The cluster uses Podman as the driver and is managed through the `kubevirtci` profile.
+
+## Prerequisites
+
+- Minikube installed on your system
+- Podman installed and configured
+- kubectl installed
+
+## Bringing the cluster up
+
+```bash
+make cluster-up
+```
+
+The cluster can be accessed as usual:
+
+```bash
+$ cluster-up/kubectl.sh get nodes
+NAME       STATUS   ROLES           AGE   VERSION
+minikube   Ready    control-plane   1m    v1.x.x
+```
+
+## Bringing the cluster down
+
+```bash
+make cluster-down
+```
+
+This destroys the whole cluster.
+
+## Configuration
+
+The provider uses the following environment variables:
+
+- `MINIKUBE`: Minikube command with profile (default: `minikube --profile=kubevirtci`)
+- `BASE_PATH`: Base configuration path (default: `$KUBEVIRTCI_CONFIG_PATH` or `$PWD`)
+- `KUBECONFIG`: Path to kubeconfig file (default: `${CI_CONFIG}/.kubeconfig`)
+
+## Notes
+
+- The cluster runs with Podman as the driver (`--driver=podman`)
+- The cluster uses the `kubevirtci` profile to avoid conflicts with other Minikube instances
+- kubectl binary is automatically copied to the configuration directory for convenience

--- a/cluster-up/cluster/minikube/provider.sh
+++ b/cluster-up/cluster/minikube/provider.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+: ${MINIKUBE:="minikube --profile=kubevirtci"}
+: ${BASE_PATH:=${KUBEVIRTCI_CONFIG_PATH:-$PWD}}
+: ${CI_CONFIG:=${BASE_PATH}/${KUBEVIRT_PROVIDER}}
+: ${KUBECONFIG:=${CI_CONFIG}/.kubeconfig}
+: ${CRI_BIN:="podman"}
+
+function _kubectl() {
+  ${CI_CONFIG}/.kubectl "$@"
+}
+
+function prepare_config() {
+  # Copy kubectl binary
+  cp $(which kubectl) ${CI_CONFIG}/.kubectl 2>/dev/null || true
+}
+
+function up() {
+  ${MINIKUBE} --driver=${CRI_BIN} start
+  prepare_config
+  echo "${KUBEVIRT_PROVIDER} cluster is ready"
+}
+
+function down() {
+  ${MINIKUBE} delete
+  echo "${KUBEVIRT_PROVIDER} cluster is down"
+}

--- a/hack/pman/rules.yaml
+++ b/hack/pman/rules.yaml
@@ -25,3 +25,4 @@ regex:
   - cluster-up/cluster/k8s-[0-9].[0-9][0-9]*
 regex_none:
   - cluster-up/cluster/kind*
+  - cluster-up/cluster/minikube*


### PR DESCRIPTION
Introduce a new cluster provider using Minikube with docker driver, managed through the 'kubevirtci' profile. Includes provider script and documentation.

The aim is to be used for DRA testing on s390x platforms, where Kind is not supported.

Note: experimental feature - local registry support pending.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
