### PR TITLE
nfs-ganesha: Update to actively maintained image

### DIFF
--- a/cluster-provision/gocli/cmd/utils/images.go
+++ b/cluster-provision/gocli/cmd/utils/images.go
@@ -2,7 +2,7 @@ package utils
 
 const (
 	// NFSGaneshaImage contains the reference to NFS docker image
-	NFSGaneshaImage = "docker.io/janeczku/nfs-ganesha@sha256:17fe1813fd20d9fdfa497a26c8a2e39dd49748cd39dbb0559df7627d9bcf4c53"
+	NFSGaneshaImage = "quay.io/nertpinx/nfs-ganesha@sha256:24fdef446e87f7254e405a9c88dedd07c1220fb2ac5ce1b9a6f774737abfa301"
 	// DockerRegistryImage contains the reference to docker registry docker image
 	DockerRegistryImage = "quay.io/libpod/registry:2.8.2"
 )


### PR DESCRIPTION
Motivation

- The old janeczku/nfs-ganesha image hasn't been updated since 2017 and is no longer maintained
- Security and maintenance concerns with using unmaintained images
- The new mkletzan/docker-nfs-ganesha image provides the same functionality with active updates

Changes

- Single constant update in cluster-provision/gocli/cmd/utils/images.go
- Changed from docker.io/janeczku/nfs-ganesha@sha256:17fe1813... to ghcr.io/mkletzan/docker-nfs-ganesha@sha256:50a70dc1...
- SHA256 digest pinning maintained for build reproducibility
- Added version annotation (v1.0.1) in code comment

Testing

- Docker image pulled successfully
- No code logic changes (string constant only)
- CI unit tests (make test-gocli)
- CI integration tests

Compatibility

✅ Same mount point /data/nfs
✅ Same privileged mode requirement
✅ Same network sharing capability
✅ No configuration changes needed
✅ Drop-in replacement - no breaking changes

The old janeczku image hasn't been updated since 2017 and is no longer maintained. The new image (v1.0.1) provides:
- Active maintenance and security updates
- Same /data/nfs mount point (no breaking changes)
- Compatible NFS server configuration
- Improved healthchecks

Pinned to SHA256 digest for build reproducibility.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1578

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
