### PR TITLE
fix: replace NBD with loop device to fix alpine-test-tooling job 

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -23,7 +23,7 @@ if [ "${ARCHITECTURE}" != "s390x" ]; then
 fi
 
 if [ ! -f alpine-make-vm-image ]; then
-    curl  https://raw.githubusercontent.com/kubevirt/alpine-make-vm-image/master/alpine-make-vm-image -o alpine-make-vm-image
+    curl https://raw.githubusercontent.com/vamsikrishna-siddu/alpine-make-vm-image-1/refs/heads/replace-nbd-with-loop-device/alpine-make-vm-image -o alpine-make-vm-image
     chmod 755 alpine-make-vm-image
 fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Replaces qemu-nbd (NBD) with loop devices for building file-based Alpine VM images. The extlinux --install /boot command deadlocks when writing to an NBD-backed filesystem in CI because the I/O path goes through a userspace qemu-nbd process, causing the process to enter uninterruptible D-state. This results in:

Job timeouts (20min+) waiting for the hung extlinux process
Pods stuck in Terminating state because CRI-O cannot kill the D-state process
Leaked NBD devices that block subsequent builds on the same node ("No available nbd device found")
CI node load averages exceeding 100 from accumulated orphaned processes
Loop devices use kernel-internal I/O with no userspace middleman, eliminating this class of deadlock entirely. Images are now built as raw using a loop device and converted to the requested format (e.g. qcow2) after the build completes.

Additionally:

Adds timeout guards around extlinux and update-extlinux as a safety net
Adds edge/main repository for s390x alongside edge/community to satisfy the python3>=3.14 dependency now required by cloud-init

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The --image-format qcow2 API is unchanged. The script internally builds as raw, then converts to qcow2 in the cleanup handler (after loop device detach, before _apk del removes qemu-img).
Block device targets still work as before (no loop device, no conversion).
The attach_image() and get_available_nbd() functions are retained for backward compatibility.
losetup from util-linux is installed as a build dependency to get the atomic --find --show operation (BusyBox's losetup has a race condition on shared CI nodes).
Verified working on both x86_64 (BIOS/extlinux path) and native s390x (IPL/zipl path).

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
