### PR TITLE
fedora guest: Add cloud-config tweaks summary doc

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config-tweaks.md
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config-tweaks.md
@@ -1,0 +1,40 @@
+# Fedora Test-Tooling Cloud-Config Tweaks
+
+- **Access and users**
+  - Create users and set non-expiring passwords for `fedora` and `cloud-user`.
+  - This provides stable login credentials for users and cloud automation.
+
+- **Kernel/module readiness**
+  - Auto-load SR-IOV-related Mellanox/Intel NIC modules at boot.
+  - This allows binding and using VFIO devices on the guest.
+
+- **Cloud-init and guest-agent ordering**
+  - Add a wait service so the guest agent starts after cloud-init.
+  - This way, waiting for guest agents guarantees that cloud-init has completed.
+  - Enable both services.
+
+- **Console stability for tests**
+  - Disable bracketed-paste output noise.
+  - Disable systemd shell integration escapes.
+  - This allows cleaner shell login without noisy characters.
+
+- **Faster datasource detection**
+  - Limit the datasource list to `NoCloud`, `ConfigDrive`, and `None`.
+  - This can reduce boot time, especially when cloud-init would otherwise probe unavailable datasources.
+
+- **Network and resolver behavior**
+  - Restore classic interface naming (`eth0`) - currently, tests depend on these names.
+  - Set NSS hosts order to `files dns myhostname` - this supports FQDN in subdomain tests.
+
+- **Packages and netcat behavior**
+  - Install VM/e2e tooling (guest agent, stress, perf/network/debug utilities).
+  - Keep `nc` as OpenBSD netcat for cloud-init; also install `ncat` (`nmap-ncat`) since KubeVirt e2e uses both.
+
+- **Image/test compatibility adjustments**
+  - Clear static + transient hostname.
+  - Remove `users_groups` so cloud-init does not remove the configured users.
+  - Set SELinux to permissive mode.
+  - Remove `pam_nologin` from sshd PAM - this allows login without waiting for non-required modules to settle.
+
+- **Architecture-specific boot safety**
+  - On `s390x`, regenerate initramfs and boot artifacts - this fixes boot panics.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add a concise markdown companion that lists the Fedora with-test-tooling
cloud-config tweaks in quick bullet form.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
