### PR TITLE
fix: alpine-cloud-init load nbd module

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -11,10 +11,19 @@ ARCH="${ARCH:-"$(linux_style_local_arch)"}"
 if [ "$ARCHITECTURE" = "s390x" ]; then
    KERNEL_FLAVOR="lts"
    ALPINE_BRANCH="v3.20"
-fi 
+fi
 
 if [ "${ARCHITECTURE}" != ""  ]; then
     PLATFORM=linux/$ARCHITECTURE
+fi
+
+# Ensure the NBD (Network Block Device) module is loaded for alpine-make-vm-image,
+# which attaches the image to an NBD device during the build process.
+if lsmod | grep -qw nbd; then
+    echo "NBD Kernel module is already loaded."
+else
+    echo "NBD Kernel module was not loaded. Loading NBD kernel module on host system..."
+    modprobe nbd
 fi
 
 # s390x does not support qemu-user-static


### PR DESCRIPTION
The CI job is failing since ndb is not loaded on the host system.

Fixes #1678

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
