### PR TITLE
Add missing fields to local StorageProfile on KinD cluster

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -275,6 +275,20 @@ function setup_kind() {
     # install the local storageClass for KubeVirt tests
     _kubectl apply -f $KIND_MANIFESTS_DIR/local-storage-class.yaml
 
+    # wait for the storage profile local to be created by CDI
+    kubectl wait --for=create --timeout=300s crd storageprofiles.cdi.kubevirt.io
+    kubectl wait --for=create storageprofile local
+
+    # set the accessModes and volumeMode for the storage profile,
+    # since CDI does not set it automatically
+    kubectl patch storageprofile local --type=merge -p '
+    spec:
+      claimPropertySets:
+      - accessModes:
+        - ReadWriteOnce
+        volumeMode: Filesystem
+    '
+
 }
 
 function _add_extra_mounts() {


### PR DESCRIPTION
**What this PR does / why we need it**: 

The local storage profile related to local storage class in KinD cluster is missing accessMode and volumeMode fields in its spec, causing DV population to fail. This is because CDI's storage profile auto-detection doesn't recognize the rancher.io/local-path provisioner used by KinD. 

This change explicitly patches the local storage profile to add the missing fields.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #17526

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
