### PR TITLE
vm-image-builder: pin arm64 emulation CPU model and fix login

### DIFF
--- a/cluster-provision/images/vm-image-builder/customize-image.sh
+++ b/cluster-provision/images/vm-image-builder/customize-image.sh
@@ -61,6 +61,11 @@ if [[ ${ARCH} = $(go_style_local_arch) ]]; then
   buildconfig="--virt-type kvm"
 else
   buildconfig="--arch $(linux_style_arch_name ${ARCH})"
+  if [[ "${ARCH}" = "arm64" ]]; then
+    # Under TCG emulation, cpu=max can trap in EDK2 very early (PC=0x6200).
+    # Pin to a stable model for cross-arch arm64 customization boots.
+    buildconfig="${buildconfig} --cpu model=cortex-a57"
+  fi
 fi
 
 if [[ ${DEBUG} = "true" ]]; then

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -1,9 +1,14 @@
 #cloud-config
 ssh_pwauth: yes
 users:
+  - name: fedora
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    lock_passwd: false
   - name: cloud-user
     sudo: ALL=(ALL) NOPASSWD:ALL
     shell: /bin/bash
+    lock_passwd: false
 chpasswd:
   users:
     - name: fedora


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

* Fix login configuration and ensure the fedora and cloud-user accounts are not password-locked in
cloud-init so image provisioning and login setup work reliably in CI.

* Use cortex-a57 for cross-arch arm64 customization boots to avoid 
the EDK2 exception-loop failure seen with cpu=max under TCG emulation.
Related to https://github.com/tianocore/edk2/issues/11962
Fix exist but unreleased yet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
