### PR TITLE
cluster-provision: Add eth0 NM connection for CentOS 10

### DIFF
--- a/cluster-provision/k8s/1.36/provision.sh
+++ b/cluster-provision/k8s/1.36/provision.sh
@@ -99,5 +99,25 @@ fi
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 
+# NetworkManager-config-server sets no-auto-default=* which prevents auto-DHCP
+# on unconfigured interfaces. CentOS 9 has ifcfg-eth0 from cloud-init but
+# CentOS 10 uses keyfile format and has no persistent connection profile.
+if [ "$release" == "centos10" ]; then
+  cat > /etc/NetworkManager/system-connections/eth0.nmconnection << ETHEOF
+[connection]
+id=eth0
+type=ethernet
+interface-name=eth0
+autoconnect=true
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+ETHEOF
+  chmod 600 /etc/NetworkManager/system-connections/eth0.nmconnection
+fi
+
 # envsubst pkg is not available by default in s390x Architecture, so explicitly installing it as part of gettext
 dnf install -y gettext


### PR DESCRIPTION
## Summary

- `NetworkManager-config-server` (installed during linux provisioning) sets `no-auto-default=*`, preventing auto-DHCP on unconfigured interfaces
- CentOS 9 works because cloud-init's `sysconfig` renderer creates `/etc/sysconfig/network-scripts/ifcfg-eth0` which persists across reboots
- CentOS 10 uses the `network-manager` renderer which does not create a persistent NM keyfile connection profile, so after virt-sysprep resets the machine-id the VM boots without any network configuration and never acquires an IP
- This causes SSH timeouts when using the pre-built centos10 base image with `PHASES=k8s` (e.g. `check-provision-k8s-1.36` in #1665)

The fix adds a persistent NM keyfile connection (`eth0.nmconnection`) for CentOS 10 after installing `NetworkManager-config-server`.

## Test plan

- [ ] `check-provision-k8s-1.34-centos10` still passes
- [ ] Once merged, periodic centos10 bump rebuilds the base image with the fix
- [ ] `check-provision-k8s-1.36` in #1665 passes with the rebuilt base image

/cc @dhiller