### PR TITLE
alpine-test-tooling: add arm64 build support

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -13,10 +13,6 @@ if [ "$ARCHITECTURE" = "s390x" ]; then
    ALPINE_BRANCH="v3.20"
 fi
 
-if [ "${ARCHITECTURE}" != ""  ]; then
-    PLATFORM=linux/$ARCHITECTURE
-fi
-
 # s390x does not support qemu-user-static
 if [ "${ARCHITECTURE}" != "s390x" ]; then
     podman run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
@@ -27,7 +23,7 @@ if [ ! -f alpine-make-vm-image ]; then
     chmod 755 alpine-make-vm-image
 fi
 
-podman run --rm --platform=$PLATFORM -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
+podman run --rm -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
 ./alpine-make-vm-image \
     --image-format qcow2 \
     --image-size 200M \

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -8,9 +8,17 @@ SCRIPT_PATH=$(dirname "$(dirname "$(realpath "$0")")")
 ARCHITECTURE="${ARCHITECTURE:-"$(go_style_local_arch)"}"
 ARCH="${ARCH:-"$(linux_style_arch_name "$ARCHITECTURE")"}"
 
+IMAGE_SIZE="200M"
+
 if [ "$ARCHITECTURE" = "s390x" ]; then
    KERNEL_FLAVOR="lts"
    ALPINE_BRANCH="v3.20"
+fi
+
+# arm64 uses UEFI boot which requires a separate 128M EFI partition,
+# so the image needs to be larger to fit both the EFI and root partitions.
+if [ "$ARCHITECTURE" = "arm64" ]; then
+   IMAGE_SIZE="512M"
 fi
 
 # s390x does not support qemu-user-static
@@ -26,7 +34,7 @@ fi
 podman run --rm -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
 ./alpine-make-vm-image \
     --image-format qcow2 \
-    --image-size 200M \
+    --image-size $IMAGE_SIZE \
     --branch $ALPINE_BRANCH \
     --kernel-flavor $KERNEL_FLAVOR \
     --arch $ARCH \

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -6,12 +6,12 @@ ALPINE_BRANCH="v3.19"
 SCRIPT_PATH=$(dirname "$(dirname "$(realpath "$0")")")
 . "${SCRIPT_PATH}/common.sh"
 ARCHITECTURE="${ARCHITECTURE:-"$(go_style_local_arch)"}"
-ARCH="${ARCH:-"$(linux_style_local_arch)"}"
+ARCH="${ARCH:-"$(linux_style_arch_name "$ARCHITECTURE")"}"
 
 if [ "$ARCHITECTURE" = "s390x" ]; then
    KERNEL_FLAVOR="lts"
    ALPINE_BRANCH="v3.20"
-fi 
+fi
 
 if [ "${ARCHITECTURE}" != ""  ]; then
     PLATFORM=linux/$ARCHITECTURE

--- a/cluster-provision/images/vm-image-builder/common.sh
+++ b/cluster-provision/images/vm-image-builder/common.sh
@@ -44,8 +44,3 @@ go_style_local_arch() {
    local arch=$(uname -m)
    go_style_arch_name $arch
 }
-
-linux_style_local_arch() {
-   local arch=$(uname -m)
-   linux_style_arch_name $arch
-}

--- a/cluster-provision/images/vm-image-builder/create-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/create-containerdisk.sh
@@ -88,10 +88,10 @@ if [ -f "${SCRIPT_PATH}/${IMAGE_NAME}/create-image.sh" ]; then
     readonly build_directory="${SCRIPT_PATH}/${IMAGE_NAME}/build"
 
     trap 'cleanup' EXIT SIGINT
-    mkdir -p "${build_directory}"
 
     pushd "${SCRIPT_PATH}/${IMAGE_NAME}"
-      cleanup
+      rm -rf "${build_directory}"
+      mkdir -p "${build_directory}"
       echo "Creating the image"
       ./create-image.sh "${build_directory}/${customized_image}"
 

--- a/hack/publish-alpine.sh
+++ b/hack/publish-alpine.sh
@@ -4,8 +4,6 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-ARCH=$(uname -m | grep -q s390x && echo s390x || echo amd64)
-
 source "${SCRIPT_DIR}/detect_cri.sh"
 
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)}
@@ -16,37 +14,66 @@ if [ -z "${CRI_BIN}" ]; then
     exit 1
 fi
 
-TARGET_REPO="quay.io/kubevirtci"
-TARGET_KUBEVIRT_REPO="quay.io/kubevirt"
+# s390x requires native hardware because alpine-make-vm-image runs zipl (the
+# s390x bootloader installer) in a chroot. zipl performs low-level ioctl calls
+# on the block device to write IPL boot records, which segfaults under
+# qemu-user-static. arm64 cross-builds fine because its UEFI bootloader setup
+# is just writing a text file (startup.nsh), with no low-level disk operations.
+if [ "$(uname -m)" = "s390x" ]; then
+    BUILD_ARCHES=${BUILD_ARCHES:-"s390x"}
+else
+    BUILD_ARCHES=${BUILD_ARCHES:-"amd64 arm64"}
+fi
+TARGET_REPO=${TARGET_REPO:-"quay.io/kubevirtci"}
+TARGET_KUBEVIRT_REPO=${TARGET_KUBEVIRT_REPO:-"quay.io/kubevirt"}
+IMAGE_NAME="alpine-with-test-tooling-container-disk"
 
-function build_alpine_container_disk() {
-  echo "INFO: build alpine container disk"
-  (cd cluster-provision/images/vm-image-builder && ./create-containerdisk.sh alpine-cloud-init)
-  if [[ "$ARCH" == "amd64" ]]; then
-    ${CRI_BIN} tag alpine-cloud-init:devel "${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}"
-    ${CRI_BIN} tag alpine-cloud-init:devel "${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel"
-  else
-    ${CRI_BIN} tag alpine-cloud-init:devel "${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}-${ARCH}"
-    ${CRI_BIN} tag alpine-cloud-init:devel "${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel-${ARCH}"
-  fi
+function build_and_push_alpine() {
+    local arch=$1
+    local tagged_image="${TARGET_REPO}/${IMAGE_NAME}:${KUBEVIRTCI_TAG}-${arch}"
+    local devel_image="${TARGET_KUBEVIRT_REPO}/${IMAGE_NAME}:devel-${arch}"
+
+    echo "INFO: building alpine container disk for ${arch}"
+    (cd cluster-provision/images/vm-image-builder && ARCHITECTURE=${arch} ./create-containerdisk.sh alpine-cloud-init)
+
+    ${CRI_BIN} tag alpine-cloud-init:devel "${tagged_image}"
+    ${CRI_BIN} tag alpine-cloud-init:devel "${devel_image}"
+
+    echo "INFO: pushing ${tagged_image}"
+    ${CRI_BIN} push "${tagged_image}"
+    echo "INFO: pushing ${devel_image}"
+    ${CRI_BIN} push "${devel_image}"
 }
 
-function push_alpine_container_disk() {
-  echo "INFO: push alpine container disk"
-  if [[ "$ARCH" == "amd64" ]]; then
-    TARGET_IMAGE="${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}"
-    TARGET_KUBEVIRT_IMAGE="${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel"
-  else
-    TARGET_IMAGE="${TARGET_REPO}/alpine-with-test-tooling-container-disk:${KUBEVIRTCI_TAG}-${ARCH}"
-    TARGET_KUBEVIRT_IMAGE="${TARGET_KUBEVIRT_REPO}/alpine-with-test-tooling-container-disk:devel-${ARCH}"
-  fi
-  ${CRI_BIN} push "$TARGET_IMAGE"
-  ${CRI_BIN} push "$TARGET_KUBEVIRT_IMAGE"
+function create_and_push_manifest() {
+    local base_name=$1
+    local repo=$2
+
+    local manifest_name="${repo}/${IMAGE_NAME}:${base_name}"
+    local images=""
+
+    for arch in ${BUILD_ARCHES}; do
+        images="${images} ${repo}/${IMAGE_NAME}:${base_name}-${arch}"
+    done
+
+    if [ -z "${images}" ]; then
+        echo "WARN: no images to include in manifest ${manifest_name}, skipping"
+        return
+    fi
+
+    if ${CRI_BIN} manifest exists "${manifest_name}" 2>/dev/null; then
+        ${CRI_BIN} manifest rm "${manifest_name}"
+    fi
+
+    echo "INFO: creating manifest ${manifest_name}"
+    ${CRI_BIN} manifest create "${manifest_name}" ${images}
+    echo "INFO: pushing manifest ${manifest_name}"
+    ${CRI_BIN} manifest push "${manifest_name}"
 }
 
-function publish_alpine_container_disk() {
-  build_alpine_container_disk
-  push_alpine_container_disk
-}
+for arch in ${BUILD_ARCHES}; do
+    build_and_push_alpine "${arch}"
+done
 
-publish_alpine_container_disk
+create_and_push_manifest "${KUBEVIRTCI_TAG}" "${TARGET_REPO}"
+create_and_push_manifest "devel" "${TARGET_KUBEVIRT_REPO}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Allow building Alpine container disk images for arm64 in addition to amd64.
The build script now loops over target architectures, builds each one, and
creates a multi-arch manifest so clients pull the right image for their
platform. Several bugs that broke multi-arch builds were fixed along the
way: wrong arch name during cross-builds, reuse of old disk images between
builds, disk images too small for arm64 UEFI layout, and podman running
tools under emulation instead of natively. s390x is kept as a native-only
build because its bootloader cannot run under emulation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Arm64 support for alpine-with-test-tooling
```
