### PR TITLE
[VEP-10] feat: add local registry setup for the minikube provider

### DIFF
--- a/cluster-up/cluster/minikube/README.md
+++ b/cluster-up/cluster/minikube/README.md
@@ -1,10 +1,9 @@
 # Minikube provider
 
 > **⚠️ EXPERIMENTAL**: This provider is in an experimental stage and is not production-ready.
-> Several features are not yet implemented, including local container registry support.
 
 Provides a pre-deployed Kubernetes cluster that runs using [Minikube](https://minikube.sigs.k8s.io/).
-The cluster uses Podman as the driver and is managed through the `kubevirtci` profile.
+The cluster uses docker as the driver and is managed through the `kubevirtci` profile.
 
 ## Prerequisites
 
@@ -44,6 +43,6 @@ The provider uses the following environment variables:
 
 ## Notes
 
-- The cluster runs with Podman as the driver (`--driver=podman`)
+- The cluster runs with docker as the default driver (`--driver=docker`)
 - The cluster uses the `kubevirtci` profile to avoid conflicts with other Minikube instances
 - kubectl binary is automatically copied to the configuration directory for convenience

--- a/cluster-up/cluster/minikube/provider.sh
+++ b/cluster-up/cluster/minikube/provider.sh
@@ -6,7 +6,9 @@ set -e
 : ${BASE_PATH:=${KUBEVIRTCI_CONFIG_PATH:-$PWD}}
 : ${CI_CONFIG:=${BASE_PATH}/${KUBEVIRT_PROVIDER}}
 : ${KUBECONFIG:=${CI_CONFIG}/.kubeconfig}
-: ${CRI_BIN:="podman"}
+: ${CRI_BIN:="docker"}
+: ${REGISTRY_NAME:="kubevirtci-registry"}
+: ${HOST_PORT:=5000}
 
 function _kubectl() {
   ${CI_CONFIG}/.kubectl "$@"
@@ -26,13 +28,55 @@ manifest_docker_prefix=\${DOCKER_PREFIX:-registry:5000/kubevirt}
 EOF
 }
 
+function remove_registry_if_present() {
+  if ${CRI_BIN} ps -a --format '{{.Names}}' | grep -q "^${REGISTRY_NAME}$"; then
+    echo "Removing existing registry container..."
+    ${CRI_BIN} stop ${REGISTRY_NAME} 2>/dev/null || true
+    ${CRI_BIN} rm ${REGISTRY_NAME} 2>/dev/null || true
+    echo "Registry container removed"
+  fi
+}
+
+function run_registry() {
+  echo "Setting up container registry..."
+  remove_registry_if_present
+  echo "Creating registry container on port ${HOST_PORT}..."
+  ${CRI_BIN} run -d \
+      --name ${REGISTRY_NAME} \
+      --restart=always \
+      -p ${HOST_PORT}:5000 \
+      quay.io/libpod/registry:2.8.2
+  echo "Registry container created successfully"
+}
+
+function configure_minikube_registry_connection() {
+   # Configure containerd using the modern certs.d directory structure
+  echo "Configuring containerd registry settings..."
+
+  # Configure both localhost and registry hostnames to point to the host's registry port.
+  # This ensures that images using the default 'registry:5000' prefix can be pulled.
+  for host in "localhost:${HOST_PORT}" "registry:5000"; do
+    ${MINIKUBE} ssh -- "sudo mkdir -p /etc/containerd/certs.d/${host} && cat <<'EOF' | sudo tee /etc/containerd/certs.d/${host}/hosts.toml
+server = \"http://host.minikube.internal:${HOST_PORT}\"
+
+[host.\"http://host.minikube.internal:${HOST_PORT}\"]
+  capabilities = [\"pull\", \"resolve\", \"push\"]
+  skip_verify = true
+EOF
+"
+  done
+}
+
 function up() {
-  ${MINIKUBE} --driver=${CRI_BIN} start
+  ${MINIKUBE} --driver=${CRI_BIN} --container-runtime=containerd --cni=flannel start
   prepare_config
+  run_registry
+  configure_minikube_registry_connection
   echo "${KUBEVIRT_PROVIDER} cluster is ready"
 }
 
 function down() {
   ${MINIKUBE} delete
   echo "${KUBEVIRT_PROVIDER} cluster is down"
+  remove_registry_if_present
 }


### PR DESCRIPTION
- create a local registry container
- configure minikube containerd to access the local registry
- remove the registry container during cluster-down
- change the minikube default driver to docker since podman is declared as experimental. For more info, visit: https://minikube.sigs.k8s.io/docs/drivers/podman/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
