### PR TITLE
cluster-provision: Switch CRI-O 1.36 to stable repository

### DIFF
--- a/cluster-provision/k8s/1.36/k8s_provision.sh
+++ b/cluster-provision/k8s/1.36/k8s_provision.sh
@@ -68,10 +68,10 @@ function pull_container_retry() {
 
 export CRIO_VERSION=1.36
 cat << EOF >/etc/yum.repos.d/devel_kubic_libcontainers_stable_cri-o_${CRIO_VERSION}.repo
-[isv_cri-o_prerelease_v${CRIO_VERSION}]
-name=CRI-O v${CRIO_VERSION} (Prerelease) (rpm)
+[isv_cri-o_stable_v${CRIO_VERSION}]
+name=CRI-O v${CRIO_VERSION} (Stable) (rpm)
 type=rpm-md
-baseurl=https://download.opensuse.org/repositories/isv:/cri-o:/prerelease:/v${CRIO_VERSION}:/build/rpm
+baseurl=https://storage.googleapis.com/kubevirtci-crio-mirror/isv_cri-o_stable_v${CRIO_VERSION}
 gpgcheck=0
 enabled=1
 EOF


### PR DESCRIPTION
CRI-O 1.36 stable has been released. Switch the k8s 1.36
provisioning from the prerelease openSUSE OBS repository to the
stable GCS mirror, matching the pattern used by 1.34 and 1.35.

Depends on https://github.com/kubevirt/project-infra/pull/5062 to
populate the GCS mirror with the stable CRI-O 1.36 packages.