### PR TITLE
fix(alpine-cloud-init): enable optional network backend

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -40,7 +40,14 @@ if [ ! -f alpine-make-vm-image ]; then
     chmod 755 alpine-make-vm-image
 fi
 
-podman run --rm -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
+# Users can set the network backend by setting the environment variable PODMAN_NETWORK_BACKEND
+# for example: export PODMAN_NETWORK_BACKEND=slirp4netns
+PODMAN_NETWORK_ARG=""
+if [ -n "${PODMAN_NETWORK_BACKEND}" ]; then
+    PODMAN_NETWORK_ARG="--network ${PODMAN_NETWORK_BACKEND}"
+fi
+
+podman run --rm ${PODMAN_NETWORK_ARG} -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
 ./alpine-make-vm-image \
     --image-format qcow2 \
     --image-size $IMAGE_SIZE \


### PR DESCRIPTION
Podman's rootful mode with systemd-resolved disables internal DNS.
Therefore, the user has the option to enable another network
backend if necessary.

Assisted-by: IBM Bob
Co-Authored-By: Or Shoval <oshoval@redhat.com>
