### PR TITLE
vm-image-builder: collect customization logs into artifacts

### DIFF
--- a/cluster-provision/images/vm-image-builder/customize-image.sh
+++ b/cluster-provision/images/vm-image-builder/customize-image.sh
@@ -6,31 +6,58 @@ source ${SCRIPT_PATH}/common.sh
 ARCH=${ARCHITECTURE:-"$(go_style_local_arch)"}
 CONSOLE=${CONSOLE:-"true"}
 DEBUG=${DEBUG:-"false"}
+ARTIFACTS=${ARTIFACTS:-"${PWD}/artifacts"}
+
+function debug_logs() {
+  local -a logs=(
+    "/tmp/provision-vm-console.log"
+    "/var/log/libvirtd.log"
+    "/var/log/virtlogd.log"
+    "/var/log/swtpm/libvirt/qemu/provision-vm-swtpm.log"
+  )
+  local qemu_log
+  if [[ -d /var/log/libvirt/qemu ]]; then
+    for qemu_log in /var/log/libvirt/qemu/*; do
+      [[ -f "${qemu_log}" ]] && logs+=("${qemu_log}")
+    done
+  fi
+
+  printf '%s\n' "${logs[@]}"
+}
 
 function print_debug_log() {
-  local debuglog="/tmp/provision-vm-console.log /var/log/libvirtd.log /var/log/virtlogd.log /var/log/swtpm/libvirt/qemu/provision-vm-swtpm.log"
-  for i in `ls /var/log/libvirt/qemu/`; do
-    debuglog="/var/log/libvirt/qemu/${i} ${debuglog}"
-  done
-  for log in ${debuglog}; do
+  local log
+  while IFS= read -r log; do
     printf "*%.0s" {1..15}
     echo "print ${log}"
-    [[ -f ${log} ]] && cat ${log}
-  done
+    [[ -f "${log}" ]] && cat "${log}"
+  done < <(debug_logs)
+}
+
+function collect_artifacts() {
+  mkdir -p "${ARTIFACTS}" || return 0
+
+  local log
+  while IFS= read -r log; do
+    [[ -f "${log}" ]] || continue
+    cp -f "${log}" "${ARTIFACTS}/$(basename "${log}")" || true
+  done < <(debug_logs)
 }
 
 function cleanup() {
-  if [ $? -ne 0 ]; then
+  local exit_code=$?
+
+  if [[ ${exit_code} -ne 0 ]]; then
     rm -f "${CUSTOMIZE_IMAGE_PATH}"
   fi
 
-  if [[ ${DEBUG} = "true" ]]; then
-    print_debug_log
-  fi
+  collect_artifacts
 
   virsh destroy "${DOMAIN_NAME}" || true
   undefine_vm "${DOMAIN_NAME}"
   rm -rf "${CLOUD_INIT_ISO}"
+
+  return "${exit_code}"
 }
 
 function undefine_vm() {
@@ -73,7 +100,7 @@ if [[ ${DEBUG} = "true" ]]; then
 fi
 
 if [[ ${CONSOLE} = "false" ]]; then
-  consoleconfig="--noautoconsole --wait 120"
+  consoleconfig="--noautoconsole --wait 90"
 else
   consoleconfig=""
 fi


### PR DESCRIPTION
Always gather libvirt and VM console logs from customize-image cleanup so CI keeps actionable diagnostics even when virt-install exits on timeout or failure.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
