### PR TITLE
gocli, net-res-injector: Set webhook fail policy to Ignore

### DIFF
--- a/cluster-provision/gocli/opts/network_resources_injector/manifests/server.yaml
+++ b/cluster-provision/gocli/opts/network_resources_injector/manifests/server.yaml
@@ -45,6 +45,7 @@ spec:
         - -logtostderr
         - -v=2
         - -insecure
+        - -failure-policy=Ignore
         env:
         - name: NAMESPACE
           valueFrom:


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently various tests flake randomly with communication problems attempting to call the network-resources-injector webhook [1]. The vast majority of the failing scenarios do not even need to call it (only macvtap and bridge-marker).
The main consumer is SR-IOV however those tests run with the sriov-kind provider, which is not affected by this change.

This quick and dirty solution will spare flakes from unrelated tests. Should this problem occur in relevant tests they will most likely fail anyway, although the failure reason could be harder to identify. Look for scheduling issues with missing custom resource requests/limits in virt-launcher pod.
A proper solution could be introduced by manipulating the MutatingWebhookConfiguration manifest to increase timeout, however we currently do not explicitly deploy that manifest, and rather rely on the network-resources-injector's server to inject that object in its init container.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17805/pull-kubevirt-e2e-k8s-1.35-sig-network/2056297617125543936


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
