### PR TITLE
ci(ppc64le): support alpine building with ibm power and accounting for slightly larger size

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -21,6 +21,11 @@ if [ "$ARCHITECTURE" = "arm64" ]; then
    IMAGE_SIZE="512M"
 fi
 
+# The compiled image was 203M on ppc64le, so we needed to increase the size
+if [ "$ARCHITECTURE" = "ppc64le" ]; then
+   IMAGE_SIZE="250M"
+fi
+
 # Ensure the NBD (Network Block Device) module is loaded for alpine-make-vm-image,
 # which attaches the image to an NBD device during the build process.
 if lsmod | grep -qw nbd; then

--- a/hack/publish-alpine.sh
+++ b/hack/publish-alpine.sh
@@ -21,6 +21,9 @@ fi
 # is just writing a text file (startup.nsh), with no low-level disk operations.
 if [ "$(uname -m)" = "s390x" ]; then
     BUILD_ARCHES=${BUILD_ARCHES:-"s390x"}
+elif [ "$(uname -m)" = "ppc64le" ]; then
+    # ppc64le doesn't build cross because it doesn't have a qemu-user-static
+    BUILD_ARCHES=${BUILD_ARCHES:-"ppc64le"}
 else
     BUILD_ARCHES=${BUILD_ARCHES:-"amd64 arm64"}
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add support for ppc64le with alpine tooling image

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
