### PR TITLE
fedora: Remove mlx5_ib due to kernel panic

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -22,7 +22,6 @@ write_files:
     - path: /etc/modules-load.d/mlx5.conf
       content: |
         mlx5_core
-        mlx5_ib
     - path: /etc/modules-load.d/mlx4.conf
       content: |
         mlx4_core


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

F43 has a kernel panic about mlx5_ib [1],
since we don't actively use it, remove it.
It affects only ib, not SR-IOV.
In case someone needs it, he can modprobe it.

We are using `6.17.1-300.fc43`, which already has a fix [2] around it, but it doesn't seem enough.
If desired we can update the kernel in addition to `7.0.9-102.fc43`.

Tested on kubevirt via https://github.com/kubevirt/kubevirt/pull/17894

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17832/pull-kubevirt-e2e-k8s-1.36-sig-network/2057043406697271296
[2] https://git.sceen.net/linux/linux-stable.git/commit/?id=2aebf5ee43bf0ed225a09a30cf515d9f2813b759

More details below.

<details>
  <summary>Click to expand details</summary>

<pre>
[   11.273632] ------------[ cut here ]------------
[   11.275942] kernel BUG at arch/x86/kernel/alternative.c:2456!
[   11.284910] Oops: invalid opcode: 0000 [#1] SMP NOPTI
[   11.287653] CPU: 0 UID: 0 PID: 508 Comm: systemd-modules Not tainted 6.17.1-300.fc43.x86_64 #1 PREEMPT(lazy) 
[   11.292010] Hardware name: KubeVirt None/RHEL, BIOS 1.16.3-4.el9 04/01/2014
[   11.295443] RIP: 0010:__text_poke+0x29e/0x400
[   11.297821] Code: 35 7f f2 ca 01 48 85 c0 74 20 48 01 f2 48 c1 ea 0c 48 c1 e2 06 48 8d 04 0a 48 89 44 24 28 48 83 7c 24 28 00 0f 85 28 fe ff ff <0f> 0b 48 c7 44 24 18 00 00 00 00 48 21 c7 e9 bf fe ff ff 48 8b 15
[   11.306451] RSP: 0018:ff7c6403c034f918 EFLAGS: 00010246
[   11.309110] RAX: 0000000000000000 RBX: ffffffffc05b64bd RCX: 0000000008433000
[   11.312578] RDX: 0000000000000043 RSI: ff1e426540000ff8 RDI: 0000000000000000
[   11.316034] RBP: 00000000000004bd R08: ffffffffbb62c000 R09: 0000000000000001
[   11.319485] R10: ff7c6403c034fa60 R11: 00000000ffffffff R12: 00000000077b64bd
[   11.322819] R13: 00000000000004be R14: 0000000000000000 R15: 0000000000000001
[   11.325589] FS:  00007f86cdf65040(0000) GS:ff1e4265a2c47000(0000) knlGS:0000000000000000
[   11.328773] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[   11.331098] CR2: 00007f5884aaacc5 CR3: 0000000002876004 CR4: 0000000000771ef0
[   11.334270] PKRU: 55555554
[   11.338408] Call Trace:
[   11.339669]  <TASK>
[   11.340692]  ? __pfx_text_poke_memcpy+0x10/0x10
[   11.342599]  ? mlx5_ib_handler_MLX5_IB_METHOD_DM_MAP_OP_ADDR+0x2bd/0x380 [mlx5_ib]
[   11.346164]  smp_text_poke_batch_finish+0x104/0x5a0
[   11.348236]  ? mlx5_ib_handler_MLX5_IB_METHOD_DM_MAP_OP_ADDR+0x2bd/0x380 [mlx5_ib]
[   11.351282]  __static_call_transform+0xc3/0x200
[   11.353121]  ? mlx5_ib_handler_MLX5_IB_METHOD_DM_MAP_OP_ADDR+0x2bd/0x380 [mlx5_ib]
[   11.356061]  ? __pfx___static_call_return0+0x10/0x10
[   11.357997]  arch_static_call_transform+0x5b/0xb0
[   11.359941]  ? mlx5_ib_handler_MLX5_IB_METHOD_DM_MAP_OP_ADDR+0x2bd/0x380 [mlx5_ib]
[   11.362837]  __static_call_init+0x15d/0x2f0
[   11.364572]  ? jump_label_add_module+0x57/0x470
[   11.366406]  ? __SCT__cond_resched+0x8/0x8
[   11.368545]  ? __SCT__cond_resched+0x8/0x8
[   11.370380]  static_call_module_notify+0x133/0x160
[   11.372760]  notifier_call_chain+0x5a/0xd0
[   11.374407]  blocking_notifier_call_chain_robust+0x63/0xc0
[   11.376880]  load_module+0x5ae/0x900
[   11.378440]  init_module_from_file+0x8a/0xe0
[   11.380292]  idempotent_init_module+0x114/0x310
[   11.382275]  __x64_sys_finit_module+0x6d/0xd0
[   11.384163]  do_syscall_64+0x7e/0x250
[   11.385763]  ? vfs_read+0x165/0x390
[   11.387332]  ? vfs_read+0x165/0x390
[   11.388925]  ? rseq_get_rseq_cs.isra.0+0x12/0x220
[   11.390951]  ? rseq_ip_fixup+0x90/0x1d0
[   11.392645]  ? switch_fpu_return+0x4e/0xd0
[   11.394338]  ? arch_exit_to_user_mode_prepare.isra.0+0x6a/0x80
[   11.396708]  ? do_syscall_64+0xb6/0x250
[   11.398321]  ? do_syscall_64+0xb6/0x250
[   11.399970]  ? arch_exit_to_user_mode_prepare.isra.0+0x6a/0x80
[   11.402282]  ? do_syscall_64+0xb6/0x250
[   11.403924]  ? do_syscall_64+0xb6/0x250
[   11.405787]  ? do_syscall_64+0xb6/0x250
[   11.407434]  ? irqentry_exit_to_user_mode+0x2c/0x1c0
[   11.409433]  entry_SYSCALL_64_after_hwframe+0x76/0x7e
[   11.411486] RIP: 0033:0x7f86ce2ff34d
[   11.413086] Code: ff c3 66 2e 0f 1f 84 00 00 00 00 00 90 f3 0f 1e fa 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d 83 6a 0f 00 f7 d8 64 89 01 48
[   11.420287] RSP: 002b:00007ffd0276bd98 EFLAGS: 00000246 ORIG_RAX: 0000000000000139
[   11.424411] RAX: ffffffffffffffda RBX: 000055a6f6df8680 RCX: 00007f86ce2ff34d
[   11.428128] RDX: 0000000000000004 RSI: 00007f86cdf5d5e1 RDI: 0000000000000006
[   11.431882] RBP: 00007ffd0276be30 R08: 0000000000000000 R09: 000055a6f6dfe040
[   11.435705] R10: 0000000000000000 R11: 0000000000000246 R12: 00007f86cdf5d5e1
[   11.438853] R13: 0000000000020000 R14: 000055a6f6df82d0 R15: 0000000000000000
[   11.441596]  </TASK>
[   11.442670] Modules linked in: net_failover(+) mlx5_ib(+) lpc_ich(+) i2c_smbus virtio_balloon(+) macsec failover mlx5_core mlxfw psample tls pci_hyperv_intf mlx4_ib ib_uverbs ib_core mlx4_core igb i2c_algo_bit dca i40e libie libie_adminq loop nfnetlink vsock_loopback vmw_vsock_virtio_transport_common zram lz4hc_compress vmw_vsock_vmci_transport lz4_compress vsock vmw_vmci polyval_clmulni ghash_clmulni_intel virtio_scsi serio_raw fuse qemu_fw_cfg
[   11.459377] ---[ end trace 0000000000000000 ]---
</pre>

</details>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
