### PR TITLE
rbac: add resourceclaims/driver permissions for SR-IOV DRA

### DIFF
--- a/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
+++ b/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
@@ -115,6 +115,11 @@ rules:
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceclaims/status"]
   verbs: ["get","list","update","patch"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/driver"]
+  verbs:
+    - associated-node:update
+    - associated-node:patch
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]  # Cluster-scoped resource, needs cluster permissions


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `resourceclaims/driver` RBAC permissions required by the SR-IOV DRA driver for Kubernetes v1.36 associated-node operations.

This adds:

* `associated-node:update`
* `associated-node:patch`

permissions on:

* `resourceclaims/driver`

within the SR-IOV DRA ClusterRole manifest.

The change aligns the SR-IOV DRA RBAC with the granular authorization behavior introduced for ResourceClaim driver-scoped updates.

**Which issue(s) this PR fixes** :N/A


**Special notes for  reviewer**:

While investigating downstream CDI RBAC behavior, I found that the generated manifests there consume these assets from kubevirtci via the sync/update flow, so the RBAC change needs to originate upstream here.

**Release note**:

```release-note
Adds missing resourceclaims/driver RBAC permissions for SR-IOV DRA associated-node ResourceClaim operations.
```
