### PR TITLE
gocli: refresh centos scripts during k8s provision

### DIFF
--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -60,6 +60,9 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		// default to Centos Stream 9
 		centosVersion = "9"
 	}
+
+	centosScriptsPath := filepath.Join(packagePath, "..", "..", fmt.Sprintf("centos%s", centosVersion), "scripts")
+
 	versionBytes, err := os.ReadFile(filepath.Join(packagePath, "version"))
 	if err != nil {
 		return err
@@ -175,6 +178,11 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 	containers <- dnsmasq.ID
+
+	err = copyDirectory(ctx, cli, dnsmasq.ID, centosScriptsPath, "/")
+	if err != nil {
+		return fmt.Errorf("failed copying centos scripts into dnsmasq container: %v", err)
+	}
 	if err := cli.ContainerStart(ctx, dnsmasq.ID, container.StartOptions{}); err != nil {
 		return err
 	}
@@ -229,6 +237,11 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 	containers <- node.ID
+
+	err = copyDirectory(ctx, cli, node.ID, centosScriptsPath, "/")
+	if err != nil {
+		return fmt.Errorf("failed copying centos scripts into node container: %v", err)
+	}
 	if err := cli.ContainerStart(ctx, node.ID, container.StartOptions{}); err != nil {
 		return err
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Changing `vm.sh` or `dnsmasq.sh` should not require rebuilding the centos base image,
which is typically rebuilt only in periodic linux phase jobs. 
Copy centos scripts into dnsmasq and node provision containers so k8s-only provisioning picks up those script updates immediately.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
