### PR TITLE
Add KUBEVIRT_VSOCK_CHILD_NS_MODE

### DIFF
--- a/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
@@ -23,6 +23,7 @@ type NodeLinuxConfig struct {
 	SwapBehavior         string
 	SwapSize             int
 	SecondaryNicBridges  bool
+	VsockChildNsMode     string
 }
 
 // NodeK8sConfig type holds the config k8s options for kubevirt cluster

--- a/cluster-provision/gocli/cmd/nodesconfig/opts.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/opts.go
@@ -136,6 +136,12 @@ func WithSecondaryNicBridges(secondaryNicBridges bool) LinuxConfigFunc {
 	}
 }
 
+func WithVsockChildNsMode(mode string) LinuxConfigFunc {
+	return func(n *NodeLinuxConfig) {
+		n.VsockChildNsMode = mode
+	}
+}
+
 func WithCeph(ceph bool) K8sConfigFunc {
 	return func(n *NodeK8sConfig) {
 		n.Ceph = ceph

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -50,6 +50,7 @@ import (
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/opts/rookceph"
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/opts/rootkey"
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/opts/swap"
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/opts/vsock"
 	k8s "kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/k8s"
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/libssh"
 
@@ -171,6 +172,7 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().StringArrayVar(&usbDisks, "usb", []string{}, "size of the emulate USB disk to pass to the node")
 	run.Flags().StringArrayVar(&sharedDisks, "shared-block-device", []string{}, "size of block device to share between all nodes")
 	run.Flags().Bool("deploy-network-resources-injector", false, "deploys Network Resources Injector")
+	run.Flags().String("vsock-child-ns-mode", "", "vsock child namespace mode (global or local)")
 
 	return run
 }
@@ -438,6 +440,11 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	deployNetworkResourcesInjector, err := cmd.Flags().GetBool("deploy-network-resources-injector")
+	if err != nil {
+		return err
+	}
+
+	vsockChildNsMode, err := cmd.Flags().GetString("vsock-child-ns-mode")
 	if err != nil {
 		return err
 	}
@@ -840,6 +847,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			nodesconfig.WithSwapBehavior(swapBehavior),
 			nodesconfig.WithSwapSize(int(swapSize)),
 			nodesconfig.WithSecondaryNicBridges(secondaryNicBridges),
+			nodesconfig.WithVsockChildNsMode(vsockChildNsMode),
 		}
 
 		n := nodesconfig.NewNodeLinuxConfig(x+1, prefix, linuxConfigFuncs)
@@ -1051,6 +1059,14 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 	if n.SwapEnabled {
 		swapOpt := swap.NewSwapOpt(sshClient, n.Swappiness, n.SwapBehavior, n.SwapSize)
 		opts = append(opts, swapOpt)
+	}
+
+	if n.VsockChildNsMode != "" {
+		vsockOpt, err := vsock.NewVsockOpt(sshClient, n.VsockChildNsMode)
+		if err != nil {
+			return err
+		}
+		opts = append(opts, vsockOpt)
 	}
 
 	for _, o := range opts {

--- a/cluster-provision/gocli/opts/vsock/vsock.go
+++ b/cluster-provision/gocli/opts/vsock/vsock.go
@@ -1,0 +1,36 @@
+package vsock
+
+import (
+	"fmt"
+
+	"kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/libssh"
+)
+
+type vsockOpt struct {
+	sshClient libssh.Client
+	mode      string
+}
+
+func NewVsockOpt(sc libssh.Client, mode string) (*vsockOpt, error) {
+	if mode != "global" && mode != "local" {
+		return nil, fmt.Errorf("invalid vsock child namespace mode %q, must be one of: global, local", mode)
+	}
+	return &vsockOpt{
+		sshClient: sc,
+		mode:      mode,
+	}, nil
+}
+
+func (o *vsockOpt) Exec() error {
+	cmds := []string{
+		"modprobe vsock",
+		fmt.Sprintf("sysctl --write net.vsock.child_ns_mode=%s", o.mode),
+	}
+
+	for _, cmd := range cmds {
+		if err := o.sshClient.Command(cmd); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cluster-provision/gocli/opts/vsock/vsock_test.go
+++ b/cluster-provision/gocli/opts/vsock/vsock_test.go
@@ -1,0 +1,60 @@
+package vsock
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	kubevirtcimocks "kubevirt.io/kubevirtci/cluster-provision/gocli/utils/mock"
+)
+
+func TestVsockOpt(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VsockOpt Suite")
+}
+
+var _ = Describe("VsockOpt", func() {
+	var sshClient *kubevirtcimocks.MockSSHClient
+
+	It("should execute VsockOpt successfully with global mode", func() {
+		sshClient = kubevirtcimocks.NewMockSSHClient(gomock.NewController(GinkgoT()))
+		opt, err := NewVsockOpt(sshClient, "global")
+		Expect(err).NotTo(HaveOccurred())
+
+		cmds := []string{
+			"modprobe vsock",
+			"sysctl --write net.vsock.child_ns_mode=global",
+		}
+
+		for _, cmd := range cmds {
+			sshClient.EXPECT().Command(cmd)
+		}
+
+		Expect(opt.Exec()).To(Succeed())
+	})
+
+	It("should execute VsockOpt successfully with local mode", func() {
+		sshClient = kubevirtcimocks.NewMockSSHClient(gomock.NewController(GinkgoT()))
+		opt, err := NewVsockOpt(sshClient, "local")
+		Expect(err).NotTo(HaveOccurred())
+
+		cmds := []string{
+			"modprobe vsock",
+			"sysctl --write net.vsock.child_ns_mode=local",
+		}
+
+		for _, cmd := range cmds {
+			sshClient.EXPECT().Command(cmd)
+		}
+
+		Expect(opt.Exec()).To(Succeed())
+	})
+
+	It("should fail with invalid mode", func() {
+		sshClient = kubevirtcimocks.NewMockSSHClient(gomock.NewController(GinkgoT()))
+		_, err := NewVsockOpt(sshClient, "invalid")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid vsock child namespace mode"))
+	})
+})

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -258,6 +258,10 @@ function _add_common_params() {
         params=" --swap-behavior=$KUBEVIRT_SWAP_BEHAVIOR $params"
     fi
 
+    if [ -n "$KUBEVIRT_VSOCK_CHILD_NS_MODE" ]; then
+        params=" --vsock-child-ns-mode=$KUBEVIRT_VSOCK_CHILD_NS_MODE $params"
+    fi
+
     if [ -n "$KUBEVIRTCI_PROXY" ]; then
         params=" --docker-proxy=$KUBEVIRTCI_PROXY $params"
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds a new cluster-up option to set net.vsock.child_ns_mode on each node via modprobe vsock + sysctl. Example usage: KUBEVIRT_VSOCK_CHILD_NS_MODE=local make cluster-up.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://redhat.atlassian.net/browse/CNV-86488

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
