### PR TITLE
fedora: pin kernel install to fixed release across arches

### DIFF
--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -71,11 +71,18 @@ write_files:
       content: |
         datasource_list: [NoCloud, ConfigDrive, None]
 runcmd:
+  - |
+    set -e
+    KERNEL_VER_REL="7.0.10-101.fc43"
+    KERNEL_NEVRA="${KERNEL_VER_REL}.$(uname -m)"
+    echo "KERNEL_NEVRA=${KERNEL_NEVRA}" > /etc/kernel-nevra.env
+    sudo dnf -y install "kernel-${KERNEL_NEVRA}"
+    sudo grubby --set-default="/boot/vmlinuz-${KERNEL_NEVRA}"
+  - sudo systemctl daemon-reload
+  - sudo dnf install -y qemu-guest-agent stress-ng virt-what vm-dump-metrics tpm2-tools netcat sg3_utils iperf3 wget tcpdump
   # Fedora 43+ uses predictable network interface names (e.g. enp1s0).
   # Many KubeVirt tests assume "eth0". Restore classic naming.
   - sudo grubby --update-kernel=ALL --args="net.ifnames=0 biosdevname=0"
-  - sudo systemctl daemon-reload
-  - sudo dnf install -y kernel-modules-$(uname -r) qemu-guest-agent stress-ng virt-what vm-dump-metrics tpm2-tools netcat sg3_utils iperf3 wget tcpdump
   # Install nmap-ncat in addition to OpenBSD netcat.
   # Use "nc" when OpenBSD behavior is needed (cloud-init uses "nc -U").
   # Use "ncat" when nmap-ncat behavior is needed (--recv-only, --no-shutdown,
@@ -102,7 +109,13 @@ runcmd:
   # s390x can panic early with unknown-block and disabled-wait.
   - |
     if [ "$(uname -m)" = "s390x" ]; then
-      sudo dracut -f --regenerate-all
+      set -e
+      source /etc/kernel-nevra.env
+      echo -e '[defaultboot]\ntarget=/boot' > /etc/zipl.conf
+      sudo zipl-switch-to-blscfg
+      sudo dracut -f "/boot/initramfs-${KERNEL_NEVRA}.img" "${KERNEL_NEVRA}"
       sudo zipl
+      # Fail image build if bootmap was not refreshed to include the newly pinned kernel.
+      test /boot/bootmap -nt "/boot/vmlinuz-${KERNEL_NEVRA}"
     fi
   - sudo shutdown

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/cloud-config
@@ -25,7 +25,6 @@ write_files:
     - path: /etc/modules-load.d/mlx4.conf
       content: |
         mlx4_core
-        mlx4_ib
     - path: /etc/modules-load.d/i40e.conf
       content: |
         i40e


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In continuation of https://github.com/kubevirt/kubevirtci/pull/1712, 
we still see other modules fail due to the same underlying problem.
Which means it is not module specific.

For example, `zram`, which is installed by default, is also failing in CI:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17922/pull-kubevirt-e2e-k8s-1.36-sig-compute/2059717554628202496

Since we are using a pretty old kernel, the first step is to update the kernel.
From `6.17.1-300.fc43` to `7.0.10-101.fc43`.

* Pin Fedora test-tooling image kernel packages to the latest validated release as of today while keeping architecture dynamic via uname -m, so image builds stay reproducible on x86_64, aarch64, and s390x.
* Fix the s390x flow to support the kernel bump and ensure the new kernel is active.
* Remove `mlx4_ib` which is not used, as clean-up, to keep symmetry of #1712.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Image was tested on all lanes of Kubevirt https://github.com/kubevirt/kubevirt/pull/17979.
Checked s390x boot and that it uses the new kernel.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
