### PR TITLE
vm based providers: make PCI topology explicit for SR-IOV and extra disks

### DIFF
--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -146,13 +146,13 @@ fi
 # Prevent the emulated soundcard from messing with host sound
 export QEMU_AUDIO_DRV=none
 
-block_dev_arg=""
+block_dev_drive_arg=""
 
 if [ -n "${BLOCK_DEV}" ]; then
   # 10Gi default
   block_device_size="${BLOCK_DEV_SIZE:-10737418240}"
   qemu-img create -f qcow2 ${BLOCK_DEV} ${block_device_size}
-  block_dev_arg="-drive format=qcow2,file=${BLOCK_DEV},if=virtio,cache=unsafe"
+  block_dev_drive_arg="-drive format=qcow2,file=${BLOCK_DEV},if=none,id=extdisk,cache=unsafe"
 fi
 
 disk_num=0
@@ -191,6 +191,7 @@ if [ "$n" = "01" ] ; then
 fi
 
 numa_arg=""
+sriov_pxb_numa_arg=""
 if [ "${NUMA}" -gt 1 ]; then
     numa_mem_unit="${MEMORY//[[:digit:]]/}"
     numa_mem_value="${MEMORY//[!0-9]/}"
@@ -207,14 +208,16 @@ if [ "${NUMA}" -gt 1 ]; then
         numa_arg+=" -numa node,nodeid=${node_id},memdev=m${node_id},cpus=${node_first_cpu}-${node_last_cpu}"
         node_first_cpu=$((node_last_cpu + 1))
     done
+    sriov_pxb_numa_arg=",numa_node=0"
 fi
 
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
   qemu_system_cmd="qemu-system-s390x \
     -enable-kvm \
-    -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_arg} \
+    -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
     -device virtio-blk,drive=drive1,bootindex=1 \
+    ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \
     -device virtio-net-ccw,netdev=network0,mac=52:55:00:d1:55:${n} \
     -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
     -device virtio-rng \
@@ -234,13 +237,16 @@ else
   #Docs: https://www.qemu.org/docs/master/system/invocation.html
   qemu_system_cmd="qemu-system-x86_64 \
     -enable-kvm \
-    -drive format=qcow2,file=${next},if=virtio,cache=unsafe ${block_dev_arg} \
-    -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n} \
+    -drive format=qcow2,file=${next},if=none,id=bootdisk,cache=unsafe ${block_dev_drive_arg} \
+    -device virtio-blk-pci,drive=bootdisk,bus=pcie.0 \
+    ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk,bus=pcie.0} \
+    -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n},bus=pcie.0 \
     -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
-    -device pcie-root-port,id=sriovrp,slot=3,chassis=3,bus=pcie.0 \
+    -device pxb-pcie,id=sriovpxb,bus=pcie.0,bus_nr=128${sriov_pxb_numa_arg} \
+    -device pcie-root-port,id=sriovrp,slot=3,chassis=3,bus=sriovpxb \
     -device igb,id=igb0,bus=sriovrp,netdev=sriovnet0,mac=52:55:00:d1:57:${n} \
     -netdev tap,id=sriovnet0,ifname=tap-sriov${n},script=no,downscript=no \
-    -device virtio-rng-pci \
+    -device virtio-rng-pci,bus=pcie.0 \
     -initrd /initrd.img \
     -kernel /vmlinuz \
     -append \"$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
@@ -251,9 +257,7 @@ else
     -serial pty \
     -machine q35,accel=kvm,kernel_irqchip=split \
     -device intel-iommu,intremap=on,caching-mode=on \
-    -device intel-hda \
-    -device hda-duplex \
-    -device AC97 \
+    -device intel-hda,bus=pcie.0 -device hda-duplex -device AC97,bus=pcie.0 \
     -uuid $(cat /proc/sys/kernel/random/uuid) \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
     ${QEMU_ARGS}"

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -146,13 +146,13 @@ fi
 # Prevent the emulated soundcard from messing with host sound
 export QEMU_AUDIO_DRV=none
 
-block_dev_arg=""
+block_dev_drive_arg=""
 
 if [ -n "${BLOCK_DEV}" ]; then
   # 10Gi default
   block_device_size="${BLOCK_DEV_SIZE:-10737418240}"
   qemu-img create -f qcow2 ${BLOCK_DEV} ${block_device_size}
-  block_dev_arg="-drive format=qcow2,file=${BLOCK_DEV},if=virtio,cache=unsafe"
+  block_dev_drive_arg="-drive format=qcow2,file=${BLOCK_DEV},if=none,id=extdisk,cache=unsafe"
 fi
 
 disk_num=0
@@ -191,6 +191,7 @@ if [ "$n" = "01" ] ; then
 fi
 
 numa_arg=""
+sriov_pxb_numa_arg=""
 if [ "${NUMA}" -gt 1 ]; then
     numa_mem_unit="${MEMORY//[[:digit:]]/}"
     numa_mem_value="${MEMORY//[!0-9]/}"
@@ -207,14 +208,16 @@ if [ "${NUMA}" -gt 1 ]; then
         numa_arg+=" -numa node,nodeid=${node_id},memdev=m${node_id},cpus=${node_first_cpu}-${node_last_cpu}"
         node_first_cpu=$((node_last_cpu + 1))
     done
+    sriov_pxb_numa_arg=",numa_node=0"
 fi
 
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
   qemu_system_cmd="qemu-system-s390x \
     -enable-kvm \
-    -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_arg} \
+    -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
     -device virtio-blk,drive=drive1,bootindex=1 \
+    ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \
     -device virtio-net-ccw,netdev=network0,mac=52:55:00:d1:55:${n} \
     -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
     -device virtio-rng \
@@ -234,13 +237,16 @@ else
   #Docs: https://www.qemu.org/docs/master/system/invocation.html
   qemu_system_cmd="qemu-system-x86_64 \
     -enable-kvm \
-    -drive format=qcow2,file=${next},if=virtio,cache=unsafe ${block_dev_arg} \
-    -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n} \
+    -drive format=qcow2,file=${next},if=none,id=bootdisk,cache=unsafe ${block_dev_drive_arg} \
+    -device virtio-blk-pci,drive=bootdisk,bus=pcie.0 \
+    ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk,bus=pcie.0} \
+    -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n},bus=pcie.0 \
     -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
-    -device pcie-root-port,id=sriovrp,slot=3,chassis=3,bus=pcie.0 \
+    -device pxb-pcie,id=sriovpxb,bus=pcie.0,bus_nr=128${sriov_pxb_numa_arg} \
+    -device pcie-root-port,id=sriovrp,slot=3,chassis=3,bus=sriovpxb \
     -device igb,id=igb0,bus=sriovrp,netdev=sriovnet0,mac=52:55:00:d1:57:${n} \
     -netdev tap,id=sriovnet0,ifname=tap-sriov${n},script=no,downscript=no \
-    -device virtio-rng-pci \
+    -device virtio-rng-pci,bus=pcie.0 \
     -initrd /initrd.img \
     -kernel /vmlinuz \
     -append \"$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
@@ -251,9 +257,7 @@ else
     -serial pty \
     -machine q35,accel=kvm,kernel_irqchip=split \
     -device intel-iommu,intremap=on,caching-mode=on \
-    -device intel-hda \
-    -device hda-duplex \
-    -device AC97 \
+    -device intel-hda,bus=pcie.0 -device hda-duplex -device AC97,bus=pcie.0 \
     -uuid $(cat /proc/sys/kernel/random/uuid) \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
     ${QEMU_ARGS}"

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -601,6 +601,10 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 	qemuArgs += " -serial pty"
 
 	var qemuNetDevice = getNetDeviceByArch()
+	pcieBus := ""
+	if qemuNetDevice != QEMU_DEVICE_S390X {
+		pcieBus = ",bus=pcie.0"
+	}
 
 	wg := sync.WaitGroup{}
 	wg.Add(int(nodes))
@@ -621,7 +625,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			if qemuNetDevice == QEMU_DEVICE_S390X {
 				nodeQemuMonitorArgs = fmt.Sprintf("%s netdev_add tap,id=secondarynet%s,ifname=stap%s,script=no,downscript=no; device_add %s,netdev=secondarynet%s,mac=52:55:00:d1:56:%s;", nodeQemuMonitorArgs, netSuffix, netSuffix, qemuNetDevice, netSuffix, macSuffix)
 			} else { //devices like virtio-net-pci doesn't support hot-plug
-				nodeQemuArgs = fmt.Sprintf("%s -device %s,netdev=secondarynet%s,mac=52:55:00:d1:56:%s -netdev tap,id=secondarynet%s,ifname=stap%s,script=no,downscript=no", nodeQemuArgs, qemuNetDevice, netSuffix, macSuffix, netSuffix, netSuffix)
+				nodeQemuArgs = fmt.Sprintf("%s -device %s,netdev=secondarynet%s,mac=52:55:00:d1:56:%s,bus=pcie.0 -netdev tap,id=secondarynet%s,ifname=stap%s,script=no,downscript=no", nodeQemuArgs, qemuNetDevice, netSuffix, macSuffix, netSuffix, netSuffix)
 			}
 		}
 
@@ -661,7 +665,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 					CgroupPermissions: "mrw",
 				},
 			}
-			nodeQemuArgs = fmt.Sprintf("%s -device vfio-pci,host=%s", nodeQemuArgs, gpuAddress)
+			nodeQemuArgs = fmt.Sprintf("%s -device vfio-pci,host=%s%s", nodeQemuArgs, gpuAddress, pcieBus)
 		}
 
 		var vmArgsNvmeDisks []string
@@ -669,13 +673,13 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			for i, size := range nvmeDisks {
 				resource.MustParse(size)
 				disk := fmt.Sprintf("%s-%d.img", nvmeDiskImagePrefix, i)
-				nodeQemuArgs = fmt.Sprintf("%s -drive file=%s,format=raw,id=NVME%d,if=none -device nvme,drive=NVME%d,serial=nvme-%d", nodeQemuArgs, disk, i, i, i)
+				nodeQemuArgs = fmt.Sprintf("%s -drive file=%s,format=raw,id=NVME%d,if=none -device nvme,drive=NVME%d,serial=nvme-%d%s", nodeQemuArgs, disk, i, i, i, pcieBus)
 				vmArgsNvmeDisks = append(vmArgsNvmeDisks, fmt.Sprintf("--nvme-device-size %s", size))
 			}
 		}
 		var vmArgsSCSIDisks []string
 		if len(scsiDisks) > 0 {
-			nodeQemuArgs = fmt.Sprintf("%s -device virtio-scsi-pci,id=scsi0", nodeQemuArgs)
+			nodeQemuArgs = fmt.Sprintf("%s -device virtio-scsi-pci,id=scsi0%s", nodeQemuArgs, pcieBus)
 			for i, size := range scsiDisks {
 				resource.MustParse(size)
 				disk := fmt.Sprintf("%s-%d.img", scsiDiskImagePrefix, i)
@@ -685,7 +689,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		}
 
 		var vmArgsUSBDisks []string
-		const bus = " -device qemu-xhci,id=bus%d"
+		bus := " -device qemu-xhci,id=bus%d" + pcieBus
 		const drive = " -drive if=none,id=stick%d,format=raw,file=/usb-%d.img"
 		const dev = " -device usb-storage,bus=bus%d.0,drive=stick%d"
 		const usbSizefmt = " --usb-device-size %s"

--- a/cluster-up/cluster/k8s-1.35/provider.sh
+++ b/cluster-up/cluster/k8s-1.35/provider.sh
@@ -7,6 +7,7 @@ fi
 
 if [ "${KUBEVIRT_WITH_SRIOV}" == "true" ]; then
     export KUBEVIRT_WITH_MULTUS=true
+    export KUBEVIRT_NUM_NUMA_NODES=2
 fi
 
 # shellcheck disable=SC1090

--- a/cluster-up/cluster/k8s-1.36/provider.sh
+++ b/cluster-up/cluster/k8s-1.36/provider.sh
@@ -7,6 +7,7 @@ fi
 
 if [ "${KUBEVIRT_WITH_SRIOV}" == "true" ]; then
     export KUBEVIRT_WITH_MULTUS=true
+    export KUBEVIRT_NUM_NUMA_NODES=2
 fi
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Motivation: support NUMA-aware SR-IOV while keeping PCI topology stable and explicit.

Update the VM launch scripts to place the emulated SR-IOV path on a NUMA-aware bus
and preserve compatibility for non-NUMA runs.

This reduces implicit QEMU auto-placement and makes VM startup more deterministic across architectures.
- Route the SR-IOV path through the PCIe expander bus so bus selection is explicit instead of QEMU-chosen.
- Replace the previous implicit `if=virtio` `BLOCK_DEV` attachment with `if=none` + explicit arch-specific device wiring (`virtio-blk` on s390x, `virtio-blk-pci` on x86_64) to avoid implicit QEMU bus selection and keep topology deterministic.
- Pin x86_64 devices to `pcie.0` for predictable topology (boot/net/rng and audio where possible; `hda-duplex` remains intentionally unpinned).

```
pcie.0  (root complex)
├─ virtio-blk-pci (bootdisk)          [bus=pcie.0]
├─ virtio-blk-pci (extdisk, optional) [bus=pcie.0]
├─ virtio-net-pci (primary nic)       [bus=pcie.0]
├─ virtio-net-pci (secondary nic #1)  [bus=pcie.0]
├─ virtio-net-pci (secondary nic #2)  [bus=pcie.0]
├─ virtio-rng-pci                     [bus=pcie.0]
├─ intel-hda / AC97                   [bus=pcie.0]
└─ pxb-pcie (sriovpxb)                [bus=pcie.0, bus_nr=128, numa_node=0]
    └─ pcie-root-port (sriovrp)       [bus=sriovpxb]
        └─ igb (sriov nic)            [bus=sriovrp]
```

In the newer setup, igb becomes NUMA-pinned by placing it under 
a pxb-pcie bus that is explicitly tagged with `numa_node=<id>` (for example numa_node=0).
`sriovrp` attaches to that bus, and igb attaches to sriovrp, so the SR-IOV path inherits that NUMA locality.
`sriovrp` is the ID of a pcie-root-port device, so it acts as the root port in that virtual PCIe branch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
