### PR TITLE
WIP alpine-cloud-init: use linux-lts on amd64 for igbvf

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/configure.sh
@@ -19,6 +19,11 @@ sed -Ei \
 	-e 's/^[# ](unicode)=.*/\1=YES/' \
 	/etc/rc.conf
 
+step 'Enable igbvf kernel module when present'
+if ls /lib/modules/*/kernel/drivers/net/ethernet/intel/igbvf/igbvf.ko* >/dev/null 2>&1; then
+	echo "igbvf" > /etc/modules-load.d/igbvf.conf
+fi
+
 step 'Enable services'
 rc-update add qemu-guest-agent default
 rc-update add cloud-init default

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -15,6 +15,16 @@ if [ "$ARCHITECTURE" = "s390x" ]; then
    ALPINE_BRANCH="v3.20"
 fi
 
+# linux-virt on amd64 does not ship igbvf. Use linux-lts so SR-IOV VF
+# emulation backed by Intel 82576 can load the igbvf module in-guest.
+if [ "$ARCHITECTURE" = "amd64" ]; then
+   KERNEL_FLAVOR="lts"
+   # linux-lts on amd64 requires more space during initramfs creation than the
+   # old 200M image size, otherwise mkinitfs can fail with "No space left on
+   # device".
+   IMAGE_SIZE="512M"
+fi
+
 # arm64 uses UEFI boot which requires a separate 128M EFI partition,
 # so the image needs to be larger to fit both the EFI and root partitions.
 if [ "$ARCHITECTURE" = "arm64" ]; then


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Switch amd64 Alpine image builds to linux-lts because linux-virt does not ship igbvf, 
which is required for emulated Intel 82576 SR-IOV VF recognition. Also load igbvf at boot when present and increase amd64 image size to avoid mkinitfs running out of space during image creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
