### PR TITLE
nfs-server: switch gocli to well maintained NFS image

### DIFF
--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -558,15 +558,19 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		if err != nil {
 			return err
 		}
-		// Pull the ganesha image
-		err = docker.ImagePull(cli, ctx, utils.NFSGaneshaImage, image.PullOptions{})
+		// Pull the nfs image
+		err = docker.ImagePull(cli, ctx, utils.NFSServerImage, image.PullOptions{})
 		if err != nil {
 			panic(err)
 		}
 
-		// Start the ganesha image
+		// Start the nfs container
 		nfsServer, err := cli.ContainerCreate(ctx, &container.Config{
-			Image: utils.NFSGaneshaImage,
+			Image: utils.NFSServerImage,
+			Env: []string{
+				"NFS_DIR=/data/nfs",
+				"NFS_OPTION=fsid=0,rw,sync,insecure,no_root_squash,no_subtree_check,nohide",
+			},
 		}, &container.HostConfig{
 			Mounts: []mount.Mount{
 				{
@@ -577,7 +581,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			},
 			Privileged:  true,
 			NetworkMode: container.NetworkMode("container:" + dnsmasq.ID),
-		}, nil, nil, prefix+"-nfs-ganesha")
+		}, nil, nil, prefix+"-nfs")
 		if err != nil {
 			return err
 		}

--- a/cluster-provision/gocli/cmd/utils/images.go
+++ b/cluster-provision/gocli/cmd/utils/images.go
@@ -1,8 +1,8 @@
 package utils
 
 const (
-	// NFSGaneshaImage contains the reference to NFS docker image
-	NFSGaneshaImage = "docker.io/janeczku/nfs-ganesha@sha256:17fe1813fd20d9fdfa497a26c8a2e39dd49748cd39dbb0559df7627d9bcf4c53"
+	// NFSServerImage contains the reference to NFS docker image
+	NFSServerImage = "quay.io/kubevirtci/gists-nfs-server:2.6.4"
 	// DockerRegistryImage contains the reference to docker registry docker image
 	DockerRegistryImage = "quay.io/libpod/registry:2.8.2"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the gocli docker-based NFS server from janeczku/nfs-ganesha to
gists-nfs-server:2.6.4 (mirrored to quay.io/kubevirtci), adding the
required NFS_DIR and NFS_OPTION env vars for export parity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1578 

**Special notes for your reviewer**:
Inspired by https://github.com/kubevirt/kubevirtci/pull/1673
CI failure - https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17905/pull-kubevirt-e2e-k8s-1.36-sig-storage/2064833210092621824

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
