### PR TITLE
emulated SR-IOV: label SR-IOV namespaces as privileged

### DIFF
--- a/cluster-up/cluster/k8s-1.35/sriov-components/sriov_components.sh
+++ b/cluster-up/cluster/k8s-1.35/sriov-components/sriov_components.sh
@@ -126,6 +126,11 @@ function sriov_components::deploy() {
 
 function sriov_components::deploy_dra() {
   _kubectl create namespace "$SRIOV_DRA_NAMESPACE"
+  _kubectl label namespace "$SRIOV_DRA_NAMESPACE" \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/warn=privileged \
+    pod-security.kubernetes.io/audit=privileged
+
   _kubectl apply -f "$SRIOV_DRA_MANIFEST"
 
   return 0
@@ -193,6 +198,12 @@ function _format_json_array() {
 }
 
 function _deploy_sriov_components() {
+  _kubectl create namespace sriov
+  _kubectl label namespace sriov \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/warn=privileged \
+    pod-security.kubernetes.io/audit=privileged
+
   _kubectl kustomize "$CUSTOM_MANIFESTS" >"$SRIOV_COMPONENTS_MANIFEST"
 
   echo "Deploying SRIOV components:"

--- a/cluster-up/cluster/k8s-1.36/sriov-components/sriov_components.sh
+++ b/cluster-up/cluster/k8s-1.36/sriov-components/sriov_components.sh
@@ -126,6 +126,11 @@ function sriov_components::deploy() {
 
 function sriov_components::deploy_dra() {
   _kubectl create namespace "$SRIOV_DRA_NAMESPACE"
+  _kubectl label namespace "$SRIOV_DRA_NAMESPACE" \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/warn=privileged \
+    pod-security.kubernetes.io/audit=privileged
+
   _kubectl apply -f "$SRIOV_DRA_MANIFEST"
 
   return 0
@@ -193,6 +198,12 @@ function _format_json_array() {
 }
 
 function _deploy_sriov_components() {
+  _kubectl create namespace sriov
+  _kubectl label namespace sriov \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/warn=privileged \
+    pod-security.kubernetes.io/audit=privileged
+
   _kubectl kustomize "$CUSTOM_MANIFESTS" >"$SRIOV_COMPONENTS_MANIFEST"
 
   echo "Deploying SRIOV components:"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Apply Pod Security Admission privileged labels to SR-IOV namespaces before 
deploying manifests so components can run under restricted cluster (PSA enabled).
Without this, the DP / DRA pods fails to schedule with PSA enable, because they are privileged.

```
sriov          52s         Warning   FailedCreate              daemonset/kube-sriov-cni-ds                        (combined from similar events): Error creating: pods "kube-sriov-cni-ds-m4zds" is forbidden: violates PodSecurity "restricted:latest": privileged (container "kube-sriov-cni" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "kube-sriov-cni" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "kube-sriov-cni" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "cnibin" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "kube-sriov-cni" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "kube-sriov-cni" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
