### PR TITLE
feat: build s390x slim images for all k8s provider versions

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -74,7 +74,7 @@ function build_clusters() {
 
       cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i --slim
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim
-    elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
+    elif [[ "$ARCH" == "s390x" ]]; then
       echo "INFO: building $i slim"
       cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i --slim
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}
@@ -103,7 +103,7 @@ function push_cluster_images() {
 
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
       podman push "$TARGET_IMAGE"
-    elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
+    elif [[ "$ARCH" == "s390x" ]]; then
       echo "INFO: push $i slim"
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
       podman push "$TARGET_IMAGE"
@@ -117,7 +117,7 @@ function push_cluster_images() {
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
-    elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
+    elif [[ "$ARCH" == "s390x" ]]; then
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim-$ARCH)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim-${ARCH}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
     fi
@@ -163,7 +163,7 @@ publish_manifest() {
   local image_tag="${2:?}"
   local target_image_repo="${3:-$TARGET_REPO}"
   local full_image_name="${target_image_repo}/${image_name}:${image_tag}"
-  if [[ "$image_name" != "centos9" && "$image_name" != "centos10" && "$image_name" != "gocli" && ! ( "$image_name" == "k8s-1.34" && "$image_tag" =~ "slim" ) ]]; then
+  if [[ "$image_name" != "centos9" && "$image_name" != "centos10" && "$image_name" != "gocli" && ! ( "$image_name" == k8s-* && "$image_tag" == *slim* ) ]]; then
     unset 'cur_archs[1]'
   fi
   for arch in ${cur_archs[*]};do

--- a/publish.sh
+++ b/publish.sh
@@ -76,7 +76,7 @@ function build_clusters() {
 
       cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i --slim
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim
-    elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
+    elif [[ "$ARCH" == "s390x" ]]; then
       echo "INFO: building $i slim"
       cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i --slim
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}
@@ -104,7 +104,7 @@ function push_cluster_images() {
 
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
       ${CRI_BIN} push "$TARGET_IMAGE"
-    elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
+    elif [[ "$ARCH" == "s390x" ]]; then
       echo "INFO: push $i slim"
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
       ${CRI_BIN} push "$TARGET_IMAGE"
@@ -118,7 +118,7 @@ function push_cluster_images() {
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
-    elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
+    elif [[ "$ARCH" == "s390x" ]]; then
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim-$ARCH)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim-${ARCH}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
     fi
@@ -166,7 +166,7 @@ publish_manifest() {
   local image_tag="${2:?}"
   local target_image_repo="${3:-$TARGET_REPO}"
   local full_image_name="${target_image_repo}/${image_name}:${image_tag}"
-  if [[ "$image_name" != "centos9" && "$image_name" != "centos10" && ! ( "$image_name" == "k8s-1.34" && "$image_tag" =~ "slim" ) ]]; then
+  if [[ "$image_name" != "centos9" && "$image_name" != "centos10" && ! ( "$image_name" == k8s-* && "$image_tag" == *slim* ) ]]; then
     unset 'cur_archs[1]'
   fi
   for arch in ${cur_archs[*]};do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Remove the hardcoded k8s-1.34 version gate for s390x in publish.sh so all k8s provider versions get s390x slim images built and published, matching the amd64 behavior. Currently, every k8s version bump requires a manual PR to update the hardcoded version (1.30 -> 1.31 -> 1.34). This change removes that maintenance overhead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

A follow-up project-infra PR can add check-provision jobs for k8s-1.35-s390x and k8s-1.36-s390x. I am happy to work on those PR's as well. 

Update : Raised PR for the same (https://github.com/kubevirt/project-infra/pull/5174)

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
