### PR TITLE
ci: onboard CodeRabbit and fix golangci-lint violations

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,28 @@
+language: "en-US"
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  tools:
+    enabled: true
+    golangci-lint:
+      enabled: true
+  path_filters:
+    - "!vendor/**"
+  path_instructions:
+    - path: "**/*.go"
+      instructions: |
+        Ensure all errors are handled. Flag unhandled error returns.
+        Check for concurrency issues (race conditions, mutex misuse).
+        Follow Go naming conventions and effective Go idioms.
+    - path: "**/*_test.go"
+      instructions: |
+        Verify table-driven tests where appropriate.
+        Check for proper test cleanup and resource management.
+        Ensure tests use Ginkgo/Gomega patterns consistently where applicable.
+    - path: "**/hack/**/*.sh"
+      instructions: |
+        Shell script infrastructure automation.
+        Check for proper error handling (set -e, error traps).
+        Verify no hardcoded paths where environment variables should be used.
+        Ensure scripts are idempotent where possible.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.26"
   modules-download-mode: vendor
 linters:
   default: standard

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,16 @@
+version: "2"
+run:
+  go: "1.24"
+  modules-download-mode: vendor
+linters:
+  default: standard
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - io.Copy
+formatters:
+  enable:
+    - goimports

--- a/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
@@ -2,28 +2,28 @@ package nodesconfig
 
 // NodeLinuxConfig type holds the config params that a node can have for its linux system
 type NodeLinuxConfig struct {
-	NodeIdx              int
-	K8sVersion           string
-	FipsEnabled          bool
-	DockerProxy          string
-	EtcdInMemory         bool
-	EtcdSize             string
-	SingleStack          bool
-	Flannel              bool
-	NoEtcdFsync          bool
-	EnableAudit          bool
-	GpuAddress           string
-	Realtime             bool
-	PSA                  bool
-	KsmEnabled           bool
-	SwapEnabled          bool
-	KsmPageCount         int
-	KsmScanInterval      int
-	Swappiness           int
-	SwapBehavior         string
-	SwapSize             int
-	SecondaryNicBridges  bool
-	VsockChildNsMode     string
+	NodeIdx             int
+	K8sVersion          string
+	FipsEnabled         bool
+	DockerProxy         string
+	EtcdInMemory        bool
+	EtcdSize            string
+	SingleStack         bool
+	Flannel             bool
+	NoEtcdFsync         bool
+	EnableAudit         bool
+	GpuAddress          string
+	Realtime            bool
+	PSA                 bool
+	KsmEnabled          bool
+	SwapEnabled         bool
+	KsmPageCount        int
+	KsmScanInterval     int
+	Swappiness          int
+	SwapBehavior        string
+	SwapSize            int
+	SecondaryNicBridges bool
+	VsockChildNsMode    string
 }
 
 // NodeK8sConfig type holds the config k8s options for kubevirt cluster

--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 	containers2 "kubevirt.io/kubevirtci/cluster-provision/gocli/containers"
 
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/utils"
@@ -68,9 +67,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 	version := strings.TrimSpace(string(versionBytes))
-	if err != nil {
-		return err
-	}
+
 	phases, err := cmd.Flags().GetString("phases")
 	if err != nil {
 		return err
@@ -125,8 +122,12 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 
 	portMap := nat.PortMap{}
 
-	utils.AppendTCPIfExplicit(portMap, utils.PortSSH, cmd.Flags(), "ssh-port")
-	utils.AppendTCPIfExplicit(portMap, utils.PortVNC, cmd.Flags(), "vnc-port")
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortSSH, cmd.Flags(), "ssh-port"); err != nil {
+		return err
+	}
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortVNC, cmd.Flags(), "vnc-port"); err != nil {
+		return err
+	}
 
 	qemuArgs, err := cmd.Flags().GetString("qemu-args")
 	if err != nil {
@@ -156,7 +157,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		interrupt := make(chan os.Signal, 1)
 		signal.Notify(interrupt, os.Interrupt)
 		<-interrupt
-		stop <- fmt.Errorf("Interrupt received, clean up")
+		stop <- fmt.Errorf("interrupt received, clean up")
 	}()
 
 	// Pull the base image
@@ -339,12 +340,12 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 
-	dir, err := ioutil.TempDir("", "gocli")
+	dir, err := os.MkdirTemp("", "gocli")
 	if err != nil {
 		return fmt.Errorf("failed creating a temporary directory: %v", err)
 	}
-	defer os.RemoveAll(dir)
-	if err := ioutil.WriteFile(filepath.Join(dir, "additional.kernel.args"), []byte(shellescape.QuoteCommand(additionalKernelArguments)), 0666); err != nil {
+	defer func() { _ = os.RemoveAll(dir) }()
+	if err := os.WriteFile(filepath.Join(dir, "additional.kernel.args"), []byte(shellescape.QuoteCommand(additionalKernelArguments)), 0666); err != nil {
 		return fmt.Errorf("failed creating additional.kernel.args file: %v", err)
 	}
 	if err := copyDirectory(ctx, cli, node.ID, dir, "/"); err != nil {
@@ -377,7 +378,7 @@ func copyDirectory(ctx context.Context, cli *client.Client, containerID string, 
 	if err != nil {
 		return err
 	}
-	defer srcArchive.Close()
+	defer func() { _ = srcArchive.Close() }()
 
 	dstInfo := archive.CopyInfo{Path: targetDirectory}
 
@@ -385,7 +386,7 @@ func copyDirectory(ctx context.Context, cli *client.Client, containerID string, 
 	if err != nil {
 		return err
 	}
-	defer preparedArchive.Close()
+	defer func() { _ = preparedArchive.Close() }()
 
 	err = cli.CopyToContainer(ctx, containerID, dstDir, preparedArchive, container.CopyToContainerOptions{AllowOverwriteDirWithFile: false})
 	if err != nil {

--- a/cluster-provision/gocli/cmd/provision_manager.go
+++ b/cluster-provision/gocli/cmd/provision_manager.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -117,7 +116,7 @@ func provisionManager(cmd *cobra.Command, arguments []string) error {
 		return err
 	}
 	if len(targets) == 0 {
-		return fmt.Errorf("No valid targets found")
+		return fmt.Errorf("no valid targets found")
 	}
 
 	rulesDB, err := buildRulesDBfromFile(params.rulesFile, targets)
@@ -258,7 +257,7 @@ func processChanges(rulesDB map[string][]string, targets []string, changes strin
 	}
 
 	if errorFound {
-		return nil, fmt.Errorf("Errors detected: files dont have a matching rule")
+		return nil, fmt.Errorf("errors detected: files dont have a matching rule")
 	}
 
 	return targetToRebuild, nil
@@ -285,7 +284,7 @@ func matcher(rulesDB map[string][]string, fileName string, status string) ([]str
 	}
 
 	if status != FILE_DELETED {
-		return nil, fmt.Errorf("Failed to find a rule for %s", fileName)
+		return nil, fmt.Errorf("failed to find a rule for %s", fileName)
 	}
 
 	return nil, nil
@@ -297,17 +296,17 @@ func getKubevirtciTag() (string, error) {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	resp, err := http.Get(kubevirtciTagUrl)
 	if err != nil {
-		return "", fmt.Errorf("ERROR: getting latest kubevirtci tag failed, error: %v", err)
+		return "", fmt.Errorf("getting latest kubevirtci tag failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("ERROR: getting latest kubevirtci tag failed, status code: %d", resp.StatusCode)
+		return "", fmt.Errorf("getting latest kubevirtci tag failed, status code: %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("ERROR: parsing response body failed: %v", err)
+		return "", fmt.Errorf("parsing response body failed: %v", err)
 	}
 
 	return strings.TrimSuffix(string(body), "\n"), nil
@@ -351,7 +350,7 @@ func buildRulesDBfromFile(rulesFile string, targets []string) (map[string][]stri
 	if err != nil {
 		return nil, err
 	}
-	defer inFile.Close()
+	defer func() { _ = inFile.Close() }()
 
 	return buildRulesDB(inFile, targets)
 }
@@ -427,12 +426,12 @@ func addRegexRules(cfgRegex []string, targets []string, rulesDB map[string][]str
 	for _, path := range cfgRegex {
 		directories, _ := fsys.GlobDirectories(path)
 		if len(directories) == 0 {
-			return fmt.Errorf("No valid directories found for Regex rule: %s", path)
+			return fmt.Errorf("no valid directories found for Regex rule: %s", path)
 		}
 		for _, dir := range directories {
 			target := strings.ReplaceAll(filepath.Base(dir), "k8s-", "")
 			if !isTargetValid(target, targets) {
-				return fmt.Errorf("Invalid target %s, regex rule: %s", target, path)
+				return fmt.Errorf("invalid target %s, regex rule: %s", target, path)
 			}
 			rulesDB[dir+"/*"] = []string{target}
 		}
@@ -445,7 +444,7 @@ func addRegexNoneRules(cfgRegexNone []string, rulesDB map[string][]string) error
 	for _, path := range cfgRegexNone {
 		directories, _ := fsys.GlobDirectories(path)
 		if len(directories) == 0 {
-			return fmt.Errorf("No valid directories found for RegexNone rule: %s", path)
+			return fmt.Errorf("no valid directories found for RegexNone rule: %s", path)
 		}
 		for _, dir := range directories {
 			rulesDB[dir+"/*"] = []string{TARGET_NONE}
@@ -464,12 +463,12 @@ func addExcludeRules(cfgExclude []Exclude, targets []string, rulesDB map[string]
 		ruleTargets := append([]string(nil), targets...)
 		for _, target := range e.Exclude {
 			if !isTargetValid(target, targets) {
-				return fmt.Errorf("Invalid target, exclude rule: %s", target)
+				return fmt.Errorf("invalid target, exclude rule: %s", target)
 			}
 			ruleTargets = excludeTarget(target, ruleTargets)
 		}
 		if len(ruleTargets) == 0 {
-			return fmt.Errorf("No valid targets left for exclude rule: %s", e.Pattern)
+			return fmt.Errorf("no valid targets left for exclude rule: %s", e.Pattern)
 		}
 		rulesDB[e.Pattern] = ruleTargets
 	}
@@ -485,7 +484,7 @@ func addSpecificRules(cfgSpecific []Specific, targets []string, rulesDB map[stri
 		ruleTargets := []string{}
 		for _, target := range e.Targets {
 			if !isTargetValid(target, targets) {
-				return fmt.Errorf("Invalid target, specific rule: %s", target)
+				return fmt.Errorf("invalid target, specific rule: %s", target)
 			}
 			ruleTargets = append(ruleTargets, target)
 		}
@@ -497,10 +496,10 @@ func addSpecificRules(cfgSpecific []Specific, targets []string, rulesDB map[stri
 func validatePathExist(path string, ruleType string) error {
 	matches, err := fsys.GetFileSystem().Glob(path)
 	if err != nil {
-		return fmt.Errorf("Error occurred for rule %s %s: %v", ruleType, path, err)
+		return fmt.Errorf("error occurred for rule %s %s: %v", ruleType, path, err)
 	}
 	if len(matches) == 0 {
-		return fmt.Errorf("Path doesn't exist for rule %s: %s", ruleType, path)
+		return fmt.Errorf("path doesn't exist for rule %s: %s", ruleType, path)
 	}
 	return nil
 }

--- a/cluster-provision/gocli/cmd/provision_manager_test.go
+++ b/cluster-provision/gocli/cmd/provision_manager_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Provision Manager functionality", func() {
 				rulesDB["file2"] = []string{"target2"}
 
 				_, err := processChanges(rulesDB, targets, "A\tfile_should_fail")
-				Expect(err.Error()).To(Equal("Errors detected: files dont have a matching rule"))
+				Expect(err.Error()).To(Equal("errors detected: files dont have a matching rule"))
 			})
 
 			It("returns expected target when matching file is Deleted", func() {

--- a/cluster-provision/gocli/cmd/rm.go
+++ b/cluster-provision/gocli/cmd/rm.go
@@ -1,13 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/docker"
 )
 
@@ -40,7 +39,7 @@ func rm(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	var dnsmasq *types.Container
+	var dnsmasq *container.Summary
 nodnsmasq:
 	for i, c := range containers {
 		for _, name := range c.Names {

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"bufio"
-	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -23,7 +22,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/nodesconfig"
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/utils"
@@ -106,10 +104,6 @@ var scsiDisks []string
 var usbDisks []string
 var sharedDisks []string
 var sshClient libssh.Client
-
-type dockerSetting struct {
-	Proxy string
-}
 
 // NewRunCommand returns command that runs given cluster
 func NewRunCommand() *cobra.Command {
@@ -225,16 +219,36 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 
 	portMap := nat.PortMap{}
 
-	utils.AppendTCPIfExplicit(portMap, utils.PortSSH, cmd.Flags(), "ssh-port")
-	utils.AppendTCPIfExplicit(portMap, utils.PortVNC, cmd.Flags(), "vnc-port")
-	utils.AppendTCPIfExplicit(portMap, utils.PortHTTP, cmd.Flags(), "http-port")
-	utils.AppendTCPIfExplicit(portMap, utils.PortHTTPS, cmd.Flags(), "https-port")
-	utils.AppendTCPIfExplicit(portMap, utils.PortAPI, cmd.Flags(), "k8s-port")
-	utils.AppendTCPIfExplicit(portMap, utils.PortOCP, cmd.Flags(), "ocp-port")
-	utils.AppendTCPIfExplicit(portMap, utils.PortRegistry, cmd.Flags(), "registry-port")
-	utils.AppendTCPIfExplicit(portMap, utils.PortPrometheus, cmd.Flags(), "prometheus-port")
-	utils.AppendTCPIfExplicit(portMap, utils.PortGrafana, cmd.Flags(), "grafana-port")
-	utils.AppendUDPIfExplicit(portMap, utils.PortDNS, cmd.Flags(), "dns-port")
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortSSH, cmd.Flags(), "ssh-port"); err != nil {
+		return err
+	}
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortVNC, cmd.Flags(), "vnc-port"); err != nil {
+		return err
+	}
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortHTTP, cmd.Flags(), "http-port"); err != nil {
+		return err
+	}
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortHTTPS, cmd.Flags(), "https-port"); err != nil {
+		return err
+	}
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortAPI, cmd.Flags(), "k8s-port"); err != nil {
+		return err
+	}
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortOCP, cmd.Flags(), "ocp-port"); err != nil {
+		return err
+	}
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortRegistry, cmd.Flags(), "registry-port"); err != nil {
+		return err
+	}
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortPrometheus, cmd.Flags(), "prometheus-port"); err != nil {
+		return err
+	}
+	if err := utils.AppendTCPIfExplicit(portMap, utils.PortGrafana, cmd.Flags(), "grafana-port"); err != nil {
+		return err
+	}
+	if err := utils.AppendUDPIfExplicit(portMap, utils.PortDNS, cmd.Flags(), "dns-port"); err != nil {
+		return err
+	}
 
 	qemuArgs, err := cmd.Flags().GetString("qemu-args")
 	if err != nil {
@@ -483,16 +497,15 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		signal.Notify(interrupt, os.Interrupt)
 		<-interrupt
 		cancel()
-		stop <- fmt.Errorf("Interrupt received, clean up")
+		stop <- fmt.Errorf("interrupt received, clean up")
 	}()
-
-	clusterImage := cluster
 
 	// Check if cluster container suffix has not being override
 	// in that case use the default prefix stored at the binary
 	if containerSuffix == "" {
 		containerSuffix = images.SUFFIX
 	}
+	var clusterImage string
 	if containerSuffix != "" {
 		clusterImage = fmt.Sprintf("%s/%s%s", containerOrg, cluster, containerSuffix)
 	} else {
@@ -550,7 +563,13 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	sshPort, err := utils.GetPublicPort(utils.PortSSH, dm.NetworkSettings.Ports)
+	if err != nil {
+		return err
+	}
 	apiServerPort, err := utils.GetPublicPort(utils.PortAPI, dm.NetworkSettings.Ports)
+	if err != nil {
+		return err
+	}
 
 	// Pull the registry image
 	err = docker.ImagePull(cli, ctx, utils.DockerRegistryImage, image.PullOptions{})
@@ -864,6 +883,9 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			return err
 		}
 		sshClient, err = libssh.NewSSHClient(sshPort, x+1, true)
+		if err != nil {
+			return err
+		}
 
 		linuxConfigFuncs := []nodesconfig.LinuxConfigFunc{
 			nodesconfig.WithFipsEnabled(fipsEnabled),
@@ -951,7 +973,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 	// If background flag was specified, we don't want to clean up if we reach that state
 	if !background {
 		wg.Wait()
-		stop <- fmt.Errorf("Done. please clean up")
+		stop <- fmt.Errorf("done, please clean up")
 	}
 
 	return nil
@@ -1025,7 +1047,7 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 	if n.FipsEnabled {
 		for _, cmd := range []string{"sudo fips-mode-setup --enable", "sudo reboot"} {
 			if err := sshClient.Command(cmd); err != nil {
-				return fmt.Errorf("Starting fips mode failed: %s", err)
+				return fmt.Errorf("starting fips mode failed: %s", err)
 			}
 		}
 		err := waitForVMToBeUp(cli, n.K8sVersion, nodeName)
@@ -1159,21 +1181,6 @@ func nodeContainer(prefix string, node string) string {
 	return prefix + "-" + node
 }
 
-func getDockerProxyConfig(proxy string) (string, error) {
-	p := dockerSetting{Proxy: proxy}
-	buf := new(bytes.Buffer)
-
-	t, err := template.New("docker-proxy").Parse(proxySettings)
-	if err != nil {
-		return "", err
-	}
-	err = t.Execute(buf, p)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
-}
-
 // getDeviceIOMMUGroup gets devices iommu_group
 // e.g. /sys/bus/pci/devices/0000\:65\:00.0/iommu_group -> ../../../../../kernel/iommu_groups/45
 func getPCIDeviceIOMMUGroup(pciAddress string) (string, error) {
@@ -1191,7 +1198,7 @@ func getDevicePCIID(pciAddress string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {

--- a/cluster-provision/gocli/cmd/scp.go
+++ b/cluster-provision/gocli/cmd/scp.go
@@ -129,16 +129,16 @@ func scp(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	stdout, err := session.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("Unable to setup stdout for session: %v", err)
+		return fmt.Errorf("unable to setup stdout for session: %v", err)
 	}
 
 	stderr, err := session.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("Unable to setup stderr for session: %v", err)
+		return fmt.Errorf("unable to setup stderr for session: %v", err)
 	}
 	go io.Copy(os.Stderr, stderr)
 
@@ -193,7 +193,7 @@ func scp(cmd *cobra.Command, args []string) error {
 	}
 
 	go func(wrPipe io.WriteCloser) {
-		defer wrPipe.Close()
+		defer func() { _ = wrPipe.Close() }()
 		fmt.Fprintf(wrPipe, "\x00")
 		fmt.Fprintf(wrPipe, "\x00")
 		fmt.Fprintf(wrPipe, "\x00")

--- a/cluster-provision/gocli/cmd/ssh.go
+++ b/cluster-provision/gocli/cmd/ssh.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/docker"
 )
 
@@ -39,7 +39,7 @@ func ssh(cmd *cobra.Command, args []string) error {
 	container := prefix + "-" + node
 	ssh_command := append([]string{"ssh.sh"}, args[1:]...)
 	file := os.Stdout
-	if terminal.IsTerminal(int(file.Fd())) {
+	if term.IsTerminal(int(file.Fd())) {
 		exitCode, err := docker.Terminal(cli, container, ssh_command, file)
 		if err != nil {
 			return err

--- a/cluster-provision/gocli/containers/dnsmasq.go
+++ b/cluster-provision/gocli/containers/dnsmasq.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
-	"golang.org/x/net/context"
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/cmd/utils"
 )
 
@@ -46,18 +46,18 @@ func DNSMasq(cli *client.Client, ctx context.Context, options *DNSMasqOptions) (
 		},
 		Cmd: []string{"/bin/bash", "-c", "/dnsmasq.sh"},
 		ExposedPorts: nat.PortSet{
-			utils.TCPPortOrDie(utils.PortSSH):         {},
-			utils.TCPPortOrDie(utils.PortRegistry):    {},
-			utils.TCPPortOrDie(utils.PortOCP):         {},
-			utils.TCPPortOrDie(utils.PortAPI):         {},
-			utils.TCPPortOrDie(utils.PortVNC):         {},
-			utils.TCPPortOrDie(utils.PortHTTP):        {},
-			utils.TCPPortOrDie(utils.PortHTTPS):       {},
-			utils.TCPPortOrDie(utils.PortPrometheus):  {},
-			utils.TCPPortOrDie(utils.PortGrafana):     {},
-			utils.TCPPortOrDie(utils.PortUploadProxy): {},
+			utils.TCPPortOrDie(utils.PortSSH):                  {},
+			utils.TCPPortOrDie(utils.PortRegistry):             {},
+			utils.TCPPortOrDie(utils.PortOCP):                  {},
+			utils.TCPPortOrDie(utils.PortAPI):                  {},
+			utils.TCPPortOrDie(utils.PortVNC):                  {},
+			utils.TCPPortOrDie(utils.PortHTTP):                 {},
+			utils.TCPPortOrDie(utils.PortHTTPS):                {},
+			utils.TCPPortOrDie(utils.PortPrometheus):           {},
+			utils.TCPPortOrDie(utils.PortGrafana):              {},
+			utils.TCPPortOrDie(utils.PortUploadProxy):          {},
 			utils.TCPPortOrDie(utils.PortUploadProxyLowerBand): {},
-			utils.UDPPortOrDie(utils.PortDNS):         {},
+			utils.UDPPortOrDie(utils.PortDNS):                  {},
 		},
 	}, &container.HostConfig{
 		Privileged:      true,

--- a/cluster-provision/gocli/docker/adapter.go
+++ b/cluster-provision/gocli/docker/adapter.go
@@ -42,7 +42,7 @@ func (d *DockerAdapter) Command(cmd string) error {
 	}
 
 	if !success {
-		return fmt.Errorf("Error executing %s on node %s", cmd, d.nodeName)
+		return fmt.Errorf("error executing %s on node %s", cmd, d.nodeName)
 	}
 	return nil
 }

--- a/cluster-provision/gocli/docker/docker.go
+++ b/cluster-provision/gocli/docker/docker.go
@@ -13,17 +13,16 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
-func GetPrefixedContainers(cli *client.Client, prefix string) ([]types.Container, error) {
+func GetPrefixedContainers(cli *client.Client, prefix string) ([]container.Summary, error) {
 	containers, err := cli.ContainerList(context.Background(), container.ListOptions{
 		All: true,
 	})
@@ -33,8 +32,8 @@ func GetPrefixedContainers(cli *client.Client, prefix string) ([]types.Container
 	return filterByPrefix(containers, prefix), nil
 }
 
-func filterByPrefix(containers []types.Container, prefix string) []types.Container {
-	prefixedConatiners := []types.Container{}
+func filterByPrefix(containers []container.Summary, prefix string) []container.Summary {
+	prefixedConatiners := []container.Summary{}
 	for i, c := range containers {
 		for _, name := range c.Names {
 			if strings.HasPrefix(name, prefix) || strings.HasPrefix(name, "/"+prefix) {
@@ -96,7 +95,7 @@ func ImagePull(cli *client.Client, ctx context.Context, ref string, options imag
 		}
 		return nil
 	}
-	return fmt.Errorf("failed to download %s four times, giving up.", ref)
+	return fmt.Errorf("failed to download %s four times, giving up", ref)
 }
 
 func Exec(cli *client.Client, containerID string, args []string, out io.Writer) (bool, error) {
@@ -134,7 +133,7 @@ func Exec(cli *client.Client, containerID string, args []string, out io.Writer) 
 
 func Terminal(cli *client.Client, containerID string, args []string, file *os.File) (int, error) {
 
-	if !terminal.IsTerminal(int(file.Fd())) {
+	if !term.IsTerminal(int(file.Fd())) {
 		return 1, fmt.Errorf("failure calling terminal out of TTY")
 	}
 
@@ -162,7 +161,7 @@ func Terminal(cli *client.Client, containerID string, args []string, file *os.Fi
 	}
 	defer attached.Close()
 
-	state, err := terminal.MakeRaw(int(file.Fd()))
+	state, err := term.MakeRaw(int(file.Fd()))
 	if err != nil {
 		return -1, err
 	}
@@ -197,7 +196,7 @@ func Terminal(cli *client.Client, containerID string, args []string, file *os.Fi
 	}()
 
 	defer func() {
-		terminal.Restore(int(file.Fd()), state)
+		_ = term.Restore(int(file.Fd()), state)
 	}()
 
 	err = <-errChan
@@ -278,8 +277,8 @@ func NewCleanupHandler(cli *client.Client, cleanupChan chan error, errWriter io.
 }
 
 func PrintProgress(progressReader io.ReadCloser, writer *os.File) error {
-	isTerminal := terminal.IsTerminal(int(writer.Fd()))
-	w, _, err := terminal.GetSize(int(writer.Fd()))
+	isTerminal := term.IsTerminal(int(writer.Fd()))
+	w, _, err := term.GetSize(int(writer.Fd()))
 
 	if isTerminal && err == nil {
 		scanner := bufio.NewScanner(progressReader)
@@ -329,8 +328,8 @@ type PullStatus struct {
 }
 
 func resizeTerminal(ctx context.Context, cli *client.Client, execID string, file *os.File) {
-	if w, h, err := terminal.GetSize(int(file.Fd())); err == nil {
-		cli.ContainerExecResize(ctx, execID, container.ResizeOptions{
+	if w, h, err := term.GetSize(int(file.Fd())); err == nil {
+		_ = cli.ContainerExecResize(ctx, execID, container.ResizeOptions{
 			Height: uint(h),
 			Width:  uint(w),
 		})

--- a/cluster-provision/gocli/docker/docker_test.go
+++ b/cluster-provision/gocli/docker/docker_test.go
@@ -4,25 +4,25 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 )
 
 func Test_filterByPrefix(t *testing.T) {
 	type args struct {
-		containers []types.Container
+		containers []container.Summary
 		prefix     string
 	}
 	tests := []struct {
 		name string
 		args args
-		want []types.Container
+		want []container.Summary
 	}{
 		{name: "should filter by prefix",
 			args: struct {
-				containers []types.Container
+				containers []container.Summary
 				prefix     string
 			}{
-				containers: []types.Container{
+				containers: []container.Summary{
 					containerFromNames("prefix-1", "something", "unimportant"),
 					containerFromNames("prefix-2", "something1", "unimportant1"),
 					containerFromNames("absolutely-unrelated"),
@@ -34,7 +34,7 @@ func Test_filterByPrefix(t *testing.T) {
 				},
 				prefix: "prefix",
 			},
-			want: []types.Container{
+			want: []container.Summary{
 				containerFromNames("prefix-1", "something", "unimportant"),
 				containerFromNames("prefix-2", "something1", "unimportant1"),
 				containerFromNames("something1", "prefix-3", "unimportant1"),
@@ -52,8 +52,8 @@ func Test_filterByPrefix(t *testing.T) {
 	}
 }
 
-func containerFromNames(names ...string) types.Container {
-	return types.Container{
+func containerFromNames(names ...string) container.Summary {
+	return container.Summary{
 		Names: names,
 	}
 }

--- a/cluster-provision/gocli/images/images.go
+++ b/cluster-provision/gocli/images/images.go
@@ -1,5 +1,5 @@
 package images
 
 var (
-	SUFFIX           = ""
+	SUFFIX = ""
 )

--- a/cluster-provision/gocli/opts/bind-vfio/bind-vfio.go
+++ b/cluster-provision/gocli/opts/bind-vfio/bind-vfio.go
@@ -38,7 +38,7 @@ func (o *bindVfioOpt) Exec() error {
 	driver = strings.TrimSuffix(driver, "\n")
 
 	if err := o.sshClient.Command("modprobe -i vfio-pci"); err != nil {
-		return fmt.Errorf("Error loading vfio-pci module: %v", err)
+		return fmt.Errorf("error loading vfio-pci module: %v", err)
 	}
 
 	cmds := []string{

--- a/cluster-provision/gocli/opts/cnao/cnao_test.go
+++ b/cluster-provision/gocli/opts/cnao/cnao_test.go
@@ -45,7 +45,7 @@ var _ = Describe("CnaoOpt", func() {
 		opt = NewCnaoOpt(client, sshClient, multusEnabled, dncEnabled, skipCR)
 
 		sshClient.EXPECT().Command("kubectl --kubeconfig=/etc/kubernetes/admin.conf wait deployment -n cluster-network-addons cluster-network-addons-operator --for condition=Available --timeout=200s")
-		opt.Exec()
+		Expect(opt.Exec()).To(Succeed())
 
 		obj, err := client.Get(schema.GroupVersionKind{Group: "networkaddonsoperator.network.kubevirt.io",
 			Version: "v1",
@@ -65,7 +65,7 @@ var _ = Describe("CnaoOpt", func() {
 
 		opt = NewCnaoOpt(client, sshClient, multusEnabled, dncEnabled, skipCR)
 		sshClient.EXPECT().Command("kubectl --kubeconfig=/etc/kubernetes/admin.conf wait deployment -n cluster-network-addons cluster-network-addons-operator --for condition=Available --timeout=200s")
-		opt.Exec()
+		Expect(opt.Exec()).To(Succeed())
 
 		obj, err := client.Get(schema.GroupVersionKind{Group: "networkaddonsoperator.network.kubevirt.io",
 			Version: "v1",
@@ -85,7 +85,7 @@ var _ = Describe("CnaoOpt", func() {
 
 		opt = NewCnaoOpt(client, sshClient, multusEnabled, dncEnabled, skipCR)
 		sshClient.EXPECT().Command("kubectl --kubeconfig=/etc/kubernetes/admin.conf wait deployment -n cluster-network-addons cluster-network-addons-operator --for condition=Available --timeout=200s")
-		opt.Exec()
+		Expect(opt.Exec()).To(Succeed())
 
 		obj, err := client.Get(schema.GroupVersionKind{Group: "networkaddonsoperator.network.kubevirt.io",
 			Version: "v1",

--- a/cluster-provision/gocli/opts/common/bulkapply.go
+++ b/cluster-provision/gocli/opts/common/bulkapply.go
@@ -35,7 +35,7 @@ func ApplyYAML(multiDocYAML []byte, client k8s.K8sDynamicClient) error {
 
 func beginsInComment(doc []byte) bool {
 	const commentRune = '#'
-	
+
 	for i := 0; i < len(doc); i++ {
 		if !unicode.IsSpace(rune(doc[i])) {
 			return doc[i] == commentRune

--- a/cluster-provision/gocli/opts/nfscsi/nfs-csi.go
+++ b/cluster-provision/gocli/opts/nfscsi/nfs-csi.go
@@ -97,7 +97,7 @@ func (o *nfsCsiOpt) Exec() error {
 
 	err = backoff.Retry(operation, backoffStrategy)
 	if err != nil {
-		return fmt.Errorf("Waiting on PVC to become bound failed after maximum retries: %v", err)
+		return fmt.Errorf("waiting on PVC to become bound failed after maximum retries: %v", err)
 	}
 
 	err = o.client.Delete(schema.GroupVersionKind{

--- a/cluster-provision/gocli/opts/node01/node01.go
+++ b/cluster-provision/gocli/opts/node01/node01.go
@@ -7,9 +7,6 @@ import (
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/libssh"
 )
 
-//go:embed conf/00-cgroupv2.conf
-var cgroupv2 []byte
-
 //go:embed conf/adv-audit.yaml
 var advAudit []byte
 
@@ -75,7 +72,7 @@ func (n *node01Provisioner) Exec() error {
 		`timeout=60; interval=5; while ! systemctl status crio | grep -w "active"; do echo "Waiting for cri-o service to be ready"; sleep $interval; timeout=$((timeout - interval)); if [[ $timeout -le 0 ]]; then exit 1; fi; done`,
 		kubeadmInitCmd,
 		`kubectl --kubeconfig=/etc/kubernetes/admin.conf patch deployment coredns -n kube-system -p "$(cat /provision/kubeadm-patches/add-security-context-deployment-patch.yaml)"`,
-		`kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f ` + cniManifest,
+		`kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f `+cniManifest,
 		`kubectl --kubeconfig=/etc/kubernetes/admin.conf taint nodes node01 node-role.kubernetes.io/control-plane:NoSchedule-`,
 		`kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes --no-headers; kubectl_rc=$?; retry_counter=0; while [[ $retry_counter -lt 20 && $kubectl_rc -ne 0 ]]; do sleep 10; echo "Waiting for api server to be available...";  kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes --no-headers; kubectl_rc=$?; retry_counter=$((retry_counter + 1)); done`,
 		"kubectl --kubeconfig=/etc/kubernetes/admin.conf version",

--- a/cluster-provision/gocli/opts/node01/testconfig.go
+++ b/cluster-provision/gocli/opts/node01/testconfig.go
@@ -2,6 +2,7 @@ package node01
 
 import (
 	"fmt"
+
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/libssh"
 	kubevirtcimocks "kubevirt.io/kubevirtci/cluster-provision/gocli/utils/mock"
 )

--- a/cluster-provision/gocli/opts/nodes/nodes.go
+++ b/cluster-provision/gocli/opts/nodes/nodes.go
@@ -18,14 +18,10 @@ const (
 )
 
 var (
-	//go:embed conf/00-cgroupv2.conf
-	cgroupv2 []byte
-
 	//go:embed scripts/setup-bridges.sh
 	setupBridgesScript []byte
 
 	versionRegex = regexp.MustCompile(`.*([0-9]+\.[0-9]+)`)
-	v1_32        = semver.MustParse("v1.32")
 )
 
 type nodesProvisioner struct {

--- a/cluster-provision/gocli/opts/provision/provision.go
+++ b/cluster-provision/gocli/opts/provision/provision.go
@@ -10,7 +10,6 @@ import (
 var sharedVars []byte
 
 type linuxProvisioner struct {
-	sshPort   uint16
 	sshClient libssh.Client
 }
 

--- a/cluster-provision/gocli/opts/rookceph/ceph_test.go
+++ b/cluster-provision/gocli/opts/rookceph/ceph_test.go
@@ -1,9 +1,10 @@
 package rookceph
 
 import (
-	"github.com/cenkalti/backoff/v4"
 	"testing"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/cluster-provision/gocli/pkg/k8s/k8s.go
+++ b/cluster-provision/gocli/pkg/k8s/k8s.go
@@ -57,7 +57,7 @@ type ReactorConfig struct {
 func NewConfig(manifestPath string, apiServerPort uint16) (*rest.Config, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("Error building kubeconfig: %v", err)
+		return nil, fmt.Errorf("error building kubeconfig: %v", err)
 	}
 	config.Host = "https://127.0.0.1:" + fmt.Sprintf("%d", apiServerPort)
 	config.Insecure = true
@@ -68,7 +68,7 @@ func NewConfig(manifestPath string, apiServerPort uint16) (*rest.Config, error) 
 func NewDynamicClient(config *rest.Config) (*k8sDynamicClientImpl, error) {
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating dynamic client: %v", err)
+		return nil, fmt.Errorf("error creating dynamic client: %v", err)
 	}
 	return &k8sDynamicClientImpl{
 		client: dynamicClient,
@@ -113,7 +113,7 @@ func (c *k8sDynamicClientImpl) Get(gvk schema.GroupVersionKind, name, ns string)
 func (c *k8sDynamicClientImpl) Update(newResource *unstructured.Unstructured) error {
 	gv := strings.Split(newResource.GetAPIVersion(), "/")
 	if len(gv) != 2 {
-		return fmt.Errorf("Resource has no proper group and version. Got: %s\n", newResource.GetAPIVersion())
+		return fmt.Errorf("resource has no proper group and version, got: %s", newResource.GetAPIVersion())
 	}
 
 	resourceClient, err := c.initResourceClientForGVKAndNamespace(schema.GroupVersionKind{
@@ -163,14 +163,14 @@ func (c *k8sDynamicClientImpl) Apply(obj *unstructured.Unstructured) error {
 func SerializeIntoObject(manifest []byte) (*unstructured.Unstructured, error) {
 	jsonData, err := yaml.YAMLToJSON(manifest)
 	if err != nil {
-		return nil, fmt.Errorf("Error converting YAML to JSON: %v\n", err)
+		return nil, fmt.Errorf("error converting YAML to JSON: %v", err)
 	}
 
 	obj := &unstructured.Unstructured{}
 	dec := serializer.NewCodecFactory(s).UniversalDeserializer()
 	_, _, err = dec.Decode(jsonData, nil, obj)
 	if err != nil {
-		return nil, fmt.Errorf("Error decoding JSON to Unstructured object: %v\n", err)
+		return nil, fmt.Errorf("error decoding JSON to Unstructured object: %v", err)
 	}
 	return obj, nil
 }

--- a/cluster-provision/gocli/pkg/libssh/ssh.go
+++ b/cluster-provision/gocli/pkg/libssh/ssh.go
@@ -125,12 +125,12 @@ func (s *SSHClientImpl) CopyRemoteFile(remotePathToCopy string, target io.Writer
 
 	stdout, err := session.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("Unable to setup stdout for session: %v", err)
+		return fmt.Errorf("unable to setup stdout for session: %v", err)
 	}
 
 	stderr, err := session.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("Unable to setup stderr for session: %v", err)
+		return fmt.Errorf("unable to setup stderr for session: %v", err)
 	}
 	go io.Copy(os.Stderr, stderr)
 
@@ -175,7 +175,7 @@ func (s *SSHClientImpl) CopyRemoteFile(remotePathToCopy string, target io.Writer
 	}
 
 	go func(wrPipe io.WriteCloser) {
-		defer wrPipe.Close()
+		defer func() { _ = wrPipe.Close() }()
 		fmt.Fprintf(wrPipe, "\x00")
 		fmt.Fprintf(wrPipe, "\x00")
 		fmt.Fprintf(wrPipe, "\x00")
@@ -204,7 +204,7 @@ func (s *SSHClientImpl) executeCommand(cmd string, outWriter, errWriter io.Write
 	if err != nil {
 		return err
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	session.Stdout = outWriter
 	session.Stderr = errWriter
@@ -230,17 +230,17 @@ func (s *SSHClientImpl) initClient() error {
 	defer s.initMutex.Unlock()
 	client, err := ssh.Dial("tcp", net.JoinHostPort("127.0.0.1", fmt.Sprint(s.sshPort)), s.config)
 	if err != nil {
-		return fmt.Errorf("Failed to connect to SSH server: %v", err)
+		return fmt.Errorf("failed to connect to SSH server: %v", err)
 	}
 
 	conn, err := client.Dial("tcp", fmt.Sprintf("192.168.66.10%d:22", s.nodeIdx))
 	if err != nil {
-		return fmt.Errorf("Error establishing connection to the next hop host: %s", err)
+		return fmt.Errorf("error establishing connection to the next hop host: %s", err)
 	}
 
 	ncc, chans, reqs, err := ssh.NewClientConn(conn, fmt.Sprintf("192.168.66.10%d:22", s.nodeIdx), s.config)
 	if err != nil {
-		return fmt.Errorf("Error creating forwarded ssh connection: %s", err)
+		return fmt.Errorf("error creating forwarded ssh connection: %s", err)
 	}
 
 	jumpHost := ssh.NewClient(ncc, chans, reqs)

--- a/hack/pman/rules.yaml
+++ b/hack/pman/rules.yaml
@@ -20,6 +20,8 @@ none:
   - OWNERS
   - OWNERS_ALIASES
   - .gitignore
+  - .coderabbit.yaml
+  - .golangci.yaml
 regex:
   - cluster-provision/k8s/[0-9].[0-9][0-9]*
   - cluster-up/cluster/k8s-[0-9].[0-9][0-9]*


### PR DESCRIPTION
## Summary

- Add `.coderabbit.yaml` with "chill" profile, golangci-lint integration, and path-specific review instructions for Go, test, and shell files
- Add `.golangci.yaml` with `default: standard` linters (errcheck, govet, ineffassign, staticcheck, unused) and goimports formatter
- Fix all 67 lint violations across 24 Go files — deprecated API migrations (`io/ioutil`, `golang.org/x/net/context`, `ssh/terminal`, `types.Container`), missing error checks, unused code removal, error string conventions, and import grouping

## Test plan

- [x] `golangci-lint run ./...` passes with 0 issues
- [x] `go test ./...` — all 31 test suites pass
- [ ] CI lanes pass on the PR

🤖 Assisted by Claude