### PR TITLE
emulated SR-IOV: Adapt to enable running DRA in parallel mode

### DIFF
--- a/cluster-up/cluster/k8s-1.35/config_sriov_cluster.sh
+++ b/cluster-up/cluster/k8s-1.35/config_sriov_cluster.sh
@@ -20,7 +20,7 @@ SRIOVDP_RESOURCE_PREFIX="kubevirt.io"
 SRIOVDP_RESOURCE_NAME="sriov_net"
 VFS_DRIVER="vfio-pci"
 VFS_DRIVER_KMODULE="vfio_pci"
-VFS_COUNT="${VFS_COUNT:-6}"
+VFS_COUNT="${VFS_COUNT:-7}"
 KUBEVIRT_USE_DRA=${KUBEVIRT_USE_DRA:-false}
 
 # Source SR-IOV components deployment functions

--- a/cluster-up/cluster/k8s-1.35/provider.sh
+++ b/cluster-up/cluster/k8s-1.35/provider.sh
@@ -6,7 +6,9 @@ if [ "${KUBEVIRT_CGROUPV2}" == "false" ]; then
 fi
 
 if [ "${KUBEVIRT_WITH_SRIOV}" == "true" ]; then
-    export KUBEVIRT_WITH_MULTUS=true
+    if [ "${KUBEVIRT_WITH_CNAO}" != "true" ]; then
+        export KUBEVIRT_WITH_MULTUS=true
+    fi
     export KUBEVIRT_NUM_NUMA_NODES=2
 fi
 

--- a/cluster-up/cluster/k8s-1.35/sriov-node/configure_vfs.sh
+++ b/cluster-up/cluster/k8s-1.35/sriov-node/configure_vfs.sh
@@ -76,7 +76,7 @@ function ensure_driver_is_loaded() {
 
 DRIVER="${DRIVER:-vfio-pci}"
 DRIVER_KMODULE="${DRIVER_KMODULE:-vfio_pci}"
-VFS_COUNT=${VFS_COUNT:-6}
+VFS_COUNT=${VFS_COUNT:-7}
 
 [ $((VFS_COUNT)) -lt 1 ] && echo "INFO: VFS_COUNT is lower then 1, nothing to do..." && exit 0
 

--- a/cluster-up/cluster/k8s-1.36/config_sriov_cluster.sh
+++ b/cluster-up/cluster/k8s-1.36/config_sriov_cluster.sh
@@ -20,7 +20,7 @@ SRIOVDP_RESOURCE_PREFIX="kubevirt.io"
 SRIOVDP_RESOURCE_NAME="sriov_net"
 VFS_DRIVER="vfio-pci"
 VFS_DRIVER_KMODULE="vfio_pci"
-VFS_COUNT="${VFS_COUNT:-6}"
+VFS_COUNT="${VFS_COUNT:-7}"
 KUBEVIRT_USE_DRA=${KUBEVIRT_USE_DRA:-false}
 
 # Source SR-IOV components deployment functions

--- a/cluster-up/cluster/k8s-1.36/provider.sh
+++ b/cluster-up/cluster/k8s-1.36/provider.sh
@@ -6,7 +6,9 @@ if [ "${KUBEVIRT_CGROUPV2}" == "false" ]; then
 fi
 
 if [ "${KUBEVIRT_WITH_SRIOV}" == "true" ]; then
-    export KUBEVIRT_WITH_MULTUS=true
+    if [ "${KUBEVIRT_WITH_CNAO}" != "true" ]; then
+        export KUBEVIRT_WITH_MULTUS=true
+    fi
     export KUBEVIRT_NUM_NUMA_NODES=2
 fi
 

--- a/cluster-up/cluster/k8s-1.36/sriov-node/configure_vfs.sh
+++ b/cluster-up/cluster/k8s-1.36/sriov-node/configure_vfs.sh
@@ -76,7 +76,7 @@ function ensure_driver_is_loaded() {
 
 DRIVER="${DRIVER:-vfio-pci}"
 DRIVER_KMODULE="${DRIVER_KMODULE:-vfio_pci}"
-VFS_COUNT=${VFS_COUNT:-6}
+VFS_COUNT=${VFS_COUNT:-7}
 
 [ $((VFS_COUNT)) -lt 1 ] && echo "INFO: VFS_COUNT is lower then 1, nothing to do..." && exit 0
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Do the changes required to run emulated SR-IOV, with DRA, in parallel mode,
folded into k8s-1.36.

1. Increase VFs to maximum 7,
it will allow to run 3 tests that have 2 VMs each + one that has one VM at the same time.
lucky we have only 3 tests that need 2 VMs, and igb supports max 7.
Default parallel is 4 processes, so it fits perfect.
It means we can't overcome this limit, but it is fine as not required to do more than that, maybe even less.
EDIT - there are new findings about max required, they will be handled on kubevirt side,
max VF is 7 anyhow.

2. Don't auto deploy standalone multus when CNAO + SRIOV are enabled.
If it is already enabled it will override the CNAO one, else just use the CNAO one,
but don't add it extra implicitly.
It allows the tests to keep their multus logic, without implicit suprises.

Takes around 8 minutes for 12 tests locally,
instead 20-30m for 13 tests (running) + 15-30 build and deploy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
None
```
