### PR TITLE
Support Topology Manager and reservedSystemCPUs settings 

### DIFF
--- a/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
@@ -2,28 +2,29 @@ package nodesconfig
 
 // NodeLinuxConfig type holds the config params that a node can have for its linux system
 type NodeLinuxConfig struct {
-	NodeIdx             int
-	K8sVersion          string
-	FipsEnabled         bool
-	DockerProxy         string
-	EtcdInMemory        bool
-	EtcdSize            string
-	SingleStack         bool
-	Flannel             bool
-	NoEtcdFsync         bool
-	EnableAudit         bool
-	GpuAddress          string
-	Realtime            bool
-	PSA                 bool
-	KsmEnabled          bool
-	SwapEnabled         bool
-	KsmPageCount        int
-	KsmScanInterval     int
-	Swappiness          int
-	SwapBehavior        string
-	SwapSize            int
-	SecondaryNicBridges bool
-	VsockChildNsMode    string
+	NodeIdx               int
+	K8sVersion            string
+	FipsEnabled           bool
+	DockerProxy           string
+	EtcdInMemory          bool
+	EtcdSize              string
+	SingleStack           bool
+	Flannel               bool
+	NoEtcdFsync           bool
+	EnableAudit           bool
+	GpuAddress            string
+	Realtime              bool
+	PSA                   bool
+	KsmEnabled            bool
+	SwapEnabled           bool
+	KsmPageCount          int
+	KsmScanInterval       int
+	Swappiness            int
+	SwapBehavior          string
+	SwapSize              int
+	SecondaryNicBridges   bool
+	VsockChildNsMode      string
+	TopologyManagerPolicy string
 }
 
 // NodeK8sConfig type holds the config k8s options for kubevirt cluster

--- a/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/nodeconfig.go
@@ -25,6 +25,7 @@ type NodeLinuxConfig struct {
 	SecondaryNicBridges   bool
 	VsockChildNsMode      string
 	TopologyManagerPolicy string
+	ReservedSystemCPUs    string
 }
 
 // NodeK8sConfig type holds the config k8s options for kubevirt cluster

--- a/cluster-provision/gocli/cmd/nodesconfig/opts.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/opts.go
@@ -142,6 +142,12 @@ func WithVsockChildNsMode(mode string) LinuxConfigFunc {
 	}
 }
 
+func WithTopologyManagerPolicy(policy string) LinuxConfigFunc {
+	return func(n *NodeLinuxConfig) {
+		n.TopologyManagerPolicy = policy
+	}
+}
+
 func WithCeph(ceph bool) K8sConfigFunc {
 	return func(n *NodeK8sConfig) {
 		n.Ceph = ceph

--- a/cluster-provision/gocli/cmd/nodesconfig/opts.go
+++ b/cluster-provision/gocli/cmd/nodesconfig/opts.go
@@ -148,6 +148,12 @@ func WithTopologyManagerPolicy(policy string) LinuxConfigFunc {
 	}
 }
 
+func WithReservedSystemCPUs(cpuset string) LinuxConfigFunc {
+	return func(n *NodeLinuxConfig) {
+		n.ReservedSystemCPUs = cpuset
+	}
+}
+
 func WithCeph(ceph bool) K8sConfigFunc {
 	return func(n *NodeK8sConfig) {
 		n.Ceph = ceph

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -180,6 +180,7 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().StringArrayVar(&sharedDisks, "shared-block-device", []string{}, "size of block device to share between all nodes")
 	run.Flags().Bool("deploy-network-resources-injector", false, "deploys Network Resources Injector")
 	run.Flags().String("vsock-child-ns-mode", "", "vsock child namespace mode (global or local)")
+	run.Flags().String("topology-manager-policy", "", "kubelet topology manager policy (e.g. single-numa-node)")
 
 	return run
 }
@@ -275,6 +276,11 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	secondaryNicBridges, err := cmd.Flags().GetBool("enable-secondary-nic-bridges")
+	if err != nil {
+		return err
+	}
+
+	topologyManagerPolicy, err := cmd.Flags().GetString("topology-manager-policy")
 	if err != nil {
 		return err
 	}
@@ -908,6 +914,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			nodesconfig.WithSwapSize(int(swapSize)),
 			nodesconfig.WithSecondaryNicBridges(secondaryNicBridges),
 			nodesconfig.WithVsockChildNsMode(vsockChildNsMode),
+			nodesconfig.WithTopologyManagerPolicy(topologyManagerPolicy),
 		}
 
 		n := nodesconfig.NewNodeLinuxConfig(x+1, prefix, linuxConfigFuncs)
@@ -1107,7 +1114,7 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 			bindVfioOpt := bindvfio.NewBindVfioOpt(sshClient, gpuDeviceID)
 			opts = append(opts, bindVfioOpt)
 		}
-		n := nodesprovision.NewNodesProvisioner(n.K8sVersion, sshClient, n.SingleStack, n.SecondaryNicBridges)
+		n := nodesprovision.NewNodesProvisioner(n.K8sVersion, sshClient, n.SingleStack, n.SecondaryNicBridges, n.TopologyManagerPolicy)
 		opts = append(opts, n)
 	}
 

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -181,6 +181,7 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().Bool("deploy-network-resources-injector", false, "deploys Network Resources Injector")
 	run.Flags().String("vsock-child-ns-mode", "", "vsock child namespace mode (global or local)")
 	run.Flags().String("topology-manager-policy", "", "kubelet topology manager policy (e.g. single-numa-node)")
+	run.Flags().String("reserved-system-cpus", "", "kubelet reserved system cpuset (e.g. 4 or 4-5)")
 
 	return run
 }
@@ -281,6 +282,10 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	topologyManagerPolicy, err := cmd.Flags().GetString("topology-manager-policy")
+	if err != nil {
+		return err
+	}
+	reservedSystemCPUs, err := cmd.Flags().GetString("reserved-system-cpus")
 	if err != nil {
 		return err
 	}
@@ -915,6 +920,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			nodesconfig.WithSecondaryNicBridges(secondaryNicBridges),
 			nodesconfig.WithVsockChildNsMode(vsockChildNsMode),
 			nodesconfig.WithTopologyManagerPolicy(topologyManagerPolicy),
+			nodesconfig.WithReservedSystemCPUs(reservedSystemCPUs),
 		}
 
 		n := nodesconfig.NewNodeLinuxConfig(x+1, prefix, linuxConfigFuncs)
@@ -1114,7 +1120,7 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 			bindVfioOpt := bindvfio.NewBindVfioOpt(sshClient, gpuDeviceID)
 			opts = append(opts, bindVfioOpt)
 		}
-		n := nodesprovision.NewNodesProvisioner(n.K8sVersion, sshClient, n.SingleStack, n.SecondaryNicBridges, n.TopologyManagerPolicy)
+		n := nodesprovision.NewNodesProvisioner(n.K8sVersion, sshClient, n.SingleStack, n.SecondaryNicBridges, n.TopologyManagerPolicy, n.ReservedSystemCPUs)
 		opts = append(opts, n)
 	}
 

--- a/cluster-provision/gocli/opts/nodes/nodes.go
+++ b/cluster-provision/gocli/opts/nodes/nodes.go
@@ -31,9 +31,10 @@ type nodesProvisioner struct {
 	version               *semver.Version
 	secondaryNicBridges   bool
 	topologyManagerPolicy string
+	reservedSystemCPUs    string
 }
 
-func NewNodesProvisioner(k8sVersion string, sc libssh.Client, singleStack, secondaryNicBridges bool, topologyManagerPolicy string) *nodesProvisioner {
+func NewNodesProvisioner(k8sVersion string, sc libssh.Client, singleStack, secondaryNicBridges bool, topologyManagerPolicy, reservedSystemCPUs string) *nodesProvisioner {
 	submatches := versionRegex.FindStringSubmatch(k8sVersion)
 	if len(submatches) != 2 {
 		logrus.Infof("not a parseable semver contained in %q. Trying the %q environment variable", k8sVersion, kubevirtProviderEnv)
@@ -57,6 +58,7 @@ func NewNodesProvisioner(k8sVersion string, sc libssh.Client, singleStack, secon
 		version:               version,
 		secondaryNicBridges:   secondaryNicBridges,
 		topologyManagerPolicy: topologyManagerPolicy,
+		reservedSystemCPUs:    reservedSystemCPUs,
 	}
 }
 
@@ -73,6 +75,7 @@ func (n *nodesProvisioner) Exec() error {
 
 	kubeletCpuManagerArgs := " --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m"
 	kubeletTopologyManagerArgs := ""
+	kubeletReservedSystemCPUsArgs := ""
 	if runtime.GOARCH == "s390x" {
 		// CPU Manager and related features are not yet supported on s390x.
 		kubeletCpuManagerArgs = ""
@@ -80,11 +83,14 @@ func (n *nodesProvisioner) Exec() error {
 		if n.topologyManagerPolicy != "" {
 			kubeletTopologyManagerArgs = " --topology-manager-policy=" + n.topologyManagerPolicy
 		}
+		if n.reservedSystemCPUs != "" {
+			kubeletReservedSystemCPUsArgs = " --reserved-cpus=" + n.reservedSystemCPUs
+		}
 	}
 	cmds := []string{
 		"source /var/lib/kubevirtci/shared_vars.sh",
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
-		`echo "KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --fail-swap-on=false ` + nodeIP + " " + n.featureGatesFlag() + kubeletCpuManagerArgs + kubeletTopologyManagerArgs + `" | tee /etc/sysconfig/kubelet > /dev/null`,
+		`echo "KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --fail-swap-on=false ` + nodeIP + " " + n.featureGatesFlag() + kubeletCpuManagerArgs + kubeletTopologyManagerArgs + kubeletReservedSystemCPUsArgs + `" | tee /etc/sysconfig/kubelet > /dev/null`,
 		"systemctl daemon-reload &&  service kubelet restart",
 		"swapoff -a",
 	}

--- a/cluster-provision/gocli/opts/nodes/nodes.go
+++ b/cluster-provision/gocli/opts/nodes/nodes.go
@@ -25,14 +25,15 @@ var (
 )
 
 type nodesProvisioner struct {
-	k8sVersion          string
-	sshClient           libssh.Client
-	singleStack         bool
-	version             *semver.Version
-	secondaryNicBridges bool
+	k8sVersion            string
+	sshClient             libssh.Client
+	singleStack           bool
+	version               *semver.Version
+	secondaryNicBridges   bool
+	topologyManagerPolicy string
 }
 
-func NewNodesProvisioner(k8sVersion string, sc libssh.Client, singleStack, secondaryNicBridges bool) *nodesProvisioner {
+func NewNodesProvisioner(k8sVersion string, sc libssh.Client, singleStack, secondaryNicBridges bool, topologyManagerPolicy string) *nodesProvisioner {
 	submatches := versionRegex.FindStringSubmatch(k8sVersion)
 	if len(submatches) != 2 {
 		logrus.Infof("not a parseable semver contained in %q. Trying the %q environment variable", k8sVersion, kubevirtProviderEnv)
@@ -50,11 +51,12 @@ func NewNodesProvisioner(k8sVersion string, sc libssh.Client, singleStack, secon
 		logrus.Fatalf("not a parseable semver contained in %q", k8sVersion)
 	}
 	return &nodesProvisioner{
-		sshClient:           sc,
-		singleStack:         singleStack,
-		k8sVersion:          k8sVersion,
-		version:             version,
-		secondaryNicBridges: secondaryNicBridges,
+		sshClient:             sc,
+		singleStack:           singleStack,
+		k8sVersion:            k8sVersion,
+		version:               version,
+		secondaryNicBridges:   secondaryNicBridges,
+		topologyManagerPolicy: topologyManagerPolicy,
 	}
 }
 
@@ -70,14 +72,19 @@ func (n *nodesProvisioner) Exec() error {
 	}
 
 	kubeletCpuManagerArgs := " --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m"
+	kubeletTopologyManagerArgs := ""
 	if runtime.GOARCH == "s390x" {
-		// CPU Manager feature is not yet supported on s390x.
+		// CPU Manager and related features are not yet supported on s390x.
 		kubeletCpuManagerArgs = ""
+	} else {
+		if n.topologyManagerPolicy != "" {
+			kubeletTopologyManagerArgs = " --topology-manager-policy=" + n.topologyManagerPolicy
+		}
 	}
 	cmds := []string{
 		"source /var/lib/kubevirtci/shared_vars.sh",
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
-		`echo "KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --fail-swap-on=false ` + nodeIP + " " + n.featureGatesFlag() + kubeletCpuManagerArgs + `" | tee /etc/sysconfig/kubelet > /dev/null`,
+		`echo "KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --fail-swap-on=false ` + nodeIP + " " + n.featureGatesFlag() + kubeletCpuManagerArgs + kubeletTopologyManagerArgs + `" | tee /etc/sysconfig/kubelet > /dev/null`,
 		"systemctl daemon-reload &&  service kubelet restart",
 		"swapoff -a",
 	}

--- a/cluster-provision/gocli/opts/nodes/nodes_test.go
+++ b/cluster-provision/gocli/opts/nodes/nodes_test.go
@@ -26,7 +26,7 @@ var _ = Describe("nodes", func() {
 		BeforeEach(func() {
 			mockCtrl = gomock.NewController(GinkgoT())
 			sshClient = kubevirtcimocks.NewMockSSHClient(mockCtrl)
-			opt = NewNodesProvisioner("k8s-1.32", sshClient, false, false, "")
+			opt = NewNodesProvisioner("k8s-1.32", sshClient, false, false, "", "")
 			AddExpectCalls(sshClient)
 		})
 
@@ -42,7 +42,7 @@ var _ = Describe("nodes", func() {
 
 	DescribeTable("calling featureGateFlag",
 		func(k8sVersion, expectedValue string) {
-			np := NewNodesProvisioner(k8sVersion, nil, false, false, "")
+			np := NewNodesProvisioner(k8sVersion, nil, false, false, "", "")
 			Expect(np.featureGatesFlag()).To(BeEquivalentTo(expectedValue))
 		},
 		Entry("should not add new fg if 1.32", "k8s-1.32", "--feature-gates=NodeSwap=true"),
@@ -62,7 +62,7 @@ var _ = Describe("nodes", func() {
 					}
 				})
 
-				np := NewNodesProvisioner("name-with-no-version", nil, false, false, "")
+				np := NewNodesProvisioner("name-with-no-version", nil, false, false, "", "")
 				Expect(np.featureGatesFlag()).To(BeEquivalentTo(expectedValue))
 			},
 			Entry("should not add new fg if 1.32", "k8s-1.32", "--feature-gates=NodeSwap=true"),

--- a/cluster-provision/gocli/opts/nodes/nodes_test.go
+++ b/cluster-provision/gocli/opts/nodes/nodes_test.go
@@ -26,7 +26,7 @@ var _ = Describe("nodes", func() {
 		BeforeEach(func() {
 			mockCtrl = gomock.NewController(GinkgoT())
 			sshClient = kubevirtcimocks.NewMockSSHClient(mockCtrl)
-			opt = NewNodesProvisioner("k8s-1.32", sshClient, false, false)
+			opt = NewNodesProvisioner("k8s-1.32", sshClient, false, false, "")
 			AddExpectCalls(sshClient)
 		})
 
@@ -42,7 +42,7 @@ var _ = Describe("nodes", func() {
 
 	DescribeTable("calling featureGateFlag",
 		func(k8sVersion, expectedValue string) {
-			np := NewNodesProvisioner(k8sVersion, nil, false, false)
+			np := NewNodesProvisioner(k8sVersion, nil, false, false, "")
 			Expect(np.featureGatesFlag()).To(BeEquivalentTo(expectedValue))
 		},
 		Entry("should not add new fg if 1.32", "k8s-1.32", "--feature-gates=NodeSwap=true"),
@@ -62,7 +62,7 @@ var _ = Describe("nodes", func() {
 					}
 				})
 
-				np := NewNodesProvisioner("name-with-no-version", nil, false, false)
+				np := NewNodesProvisioner("name-with-no-version", nil, false, false, "")
 				Expect(np.featureGatesFlag()).To(BeEquivalentTo(expectedValue))
 			},
 			Entry("should not add new fg if 1.32", "k8s-1.32", "--feature-gates=NodeSwap=true"),

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -270,6 +270,10 @@ function _add_common_params() {
         params=" --deploy-network-resources-injector $params"
     fi
 
+    if [ -n "$KUBEVIRT_TOPOLOGY_MANAGER_POLICY" ]; then
+        params=" --topology-manager-policy=$KUBEVIRT_TOPOLOGY_MANAGER_POLICY $params"
+    fi
+
     echo $params
 }
 

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -274,6 +274,10 @@ function _add_common_params() {
         params=" --topology-manager-policy=$KUBEVIRT_TOPOLOGY_MANAGER_POLICY $params"
     fi
 
+    if [ -n "$KUBEVIRT_RESERVED_SYSTEM_CPUS" ]; then
+        params=" --reserved-system-cpus=$KUBEVIRT_RESERVED_SYSTEM_CPUS $params"
+    fi
+
     echo $params
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Allow to enable Topology Manager, and to set `reservedSystemCPUs`.
Required for advanced CPU topology settings.

Usage example
```
export KUBEVIRT_RESERVED_SYSTEM_CPUS=5
export KUBEVIRT_TOPOLOGY_MANAGER_POLICY=single-numa-node
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
