### PR TITLE
k8s: Enable cpuManagerPolicy static in kubelet drop-in config

### DIFF
--- a/cluster-provision/gocli/opts/node01/node01.go
+++ b/cluster-provision/gocli/opts/node01/node01.go
@@ -3,6 +3,7 @@ package node01
 import (
 	_ "embed"
 	"fmt"
+	"runtime"
 
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/libssh"
 )
@@ -68,6 +69,16 @@ func (n *node01Provisioner) Exec() error {
 
 	if n.secondaryNicBridges {
 		cmds = append(cmds, string(setupBridgesScript))
+	}
+
+	if runtime.GOARCH != "s390x" {
+		cmds = append(cmds, `cat >> /etc/kubernetes/kubelet.conf.d/50-kubevirt.conf <<'EOF'
+cpuManagerPolicy: static
+kubeReserved:
+  cpu: 500m
+systemReserved:
+  cpu: 500m
+EOF`)
 	}
 
 	cmds = append(cmds,

--- a/cluster-provision/gocli/opts/node01/testconfig.go
+++ b/cluster-provision/gocli/opts/node01/testconfig.go
@@ -2,6 +2,8 @@ package node01
 
 import (
 	"fmt"
+	"runtime"
+
 	"kubevirt.io/kubevirtci/cluster-provision/gocli/pkg/libssh"
 	kubevirtcimocks "kubevirt.io/kubevirtci/cluster-provision/gocli/utils/mock"
 )
@@ -11,6 +13,17 @@ func AddExpectCalls(sshClient *kubevirtcimocks.MockSSHClient) {
 		fmt.Sprintf(`if [ -f /home/%s/enable_audit ]; then echo '%s' | tee /etc/kubernetes/audit/adv-audit.yaml > /dev/null; fi`, libssh.GetSSHUser(), string(advAudit)),
 		`timeout=30; interval=5; while ! hostnamectl | grep Transient; do echo "Waiting for dhclient to set the hostname from dnsmasq"; sleep $interval; timeout=$((timeout - interval)); [ $timeout -le 0 ] && exit 1; done`,
 		"swapoff -a",
+	}
+	if runtime.GOARCH != "s390x" {
+		cmds = append(cmds, `cat >> /etc/kubernetes/kubelet.conf.d/50-kubevirt.conf <<'EOF'
+cpuManagerPolicy: static
+kubeReserved:
+  cpu: 500m
+systemReserved:
+  cpu: 500m
+EOF`)
+	}
+	cmds = append(cmds,
 		"until ip address show dev eth0 | grep global | grep inet6; do sleep 1; done",
 		`timeout=60; interval=5; while ! systemctl status crio | grep -w "active"; do echo "Waiting for cri-o service to be ready"; sleep $interval; timeout=$((timeout - interval)); if [[ $timeout -le 0 ]]; then exit 1; fi; done`,
 		`kubeadm init --config /etc/kubernetes/kubeadm.conf -v5`,
@@ -22,7 +35,7 @@ func AddExpectCalls(sshClient *kubevirtcimocks.MockSSHClient) {
 		`kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f /provision/local-volume.yaml`,
 		"mkdir -p /var/lib/rook",
 		"chcon -t container_file_t /var/lib/rook",
-	}
+	)
 	for _, cmd := range cmds {
 		sshClient.EXPECT().Command(cmd)
 	}


### PR DESCRIPTION
## Summary

- Enable `cpuManagerPolicy: static` in the kubelet drop-in config (`50-kubevirt.conf`) during base image provisioning for k8s 1.34, 1.35, and 1.36
- Add required `kubeReserved` and `systemReserved` CPU reservations (500m each) to match the existing gocli worker node configuration

## Problem

On single-node clusters where the control-plane node also has the `worker` role, CPUManager was not enabled. The gocli provisioner only sets `--cpu-manager-policy=static` during the worker node join path (`nodes.go`), which the control-plane node never executes. This was previously handled by the `configure_cpu_manager` shell function removed in #1289.

The KubeVirt functional test suite's `SynchronizedBeforeSuite` enables the CPUManager feature gate and then waits for all schedulable nodes to have the `cpumanager=true` label, causing a 360-second timeout on single-node clusters.

## Fix

Add `cpuManagerPolicy: static` and CPU reservations directly to the kubelet drop-in config file that is written during base image provisioning. This ensures CPUManager is configured on all nodes regardless of their role, including control-plane+worker nodes in single-node clusters.

Supersedes: #1649

Fixes: https://github.com/kubevirt/kubevirtci/issues/1648
