### PR TITLE
fix: use guestfish auto-inspect for centos10 s390x partition layout

### DIFF
--- a/cluster-provision/centos10/Dockerfile
+++ b/cluster-provision/centos10/Dockerfile
@@ -18,7 +18,7 @@ COPY scripts/download_box.sh /
 RUN  /download_box.sh https://cloud.centos.org/centos/10-stream/$BUILDARCH/images/CentOS-Stream-GenericCloud-10-$centos_version.$BUILDARCH.qcow2 && \
     # Access virtual machine disk images directly by using LIBGUESTFS_BACKEND=direct, instead of libvirt
     export LIBGUESTFS_BACKEND=direct && \
-    guestfish --ro --add box.qcow2 --mount /dev/sda2:/ ls /boot/ | grep -E '^vmlinuz-|^initramfs-' | xargs -I {} guestfish --ro --add box.qcow2 -i copy-out /boot/{} / ;
+    guestfish --ro --add box.qcow2 -i glob copy-out '/boot/vmlinuz-*' / : glob copy-out '/boot/initramfs-*' / ;
 
 
 FROM base AS nodecontainer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The CentOS 10 x86_64 cloud image has two partitions (sda1 = boot, sda2 = root), while the s390x image has only one (sda1 = root). The Dockerfile hardcodes `--mount /dev/sda2:/` which fails on s390x because sda2 does not exist. This causes `periodic-kubevirtci-bump-centos10-base-s390x` to fail every run since the job was introduced. The fix replaces `--mount /dev/sda2:/` with `-i` (auto-inspect) so guestfish detects and mounts the correct root partition regardless of disk layout. The second guestfish call on the same line already uses `-i`.

**Special notes for your reviewer**:

Verified locally by downloading both CentOS 10 qcow2 images (x86_64 and s390x) into a Fedora 42 container with libguestfs:
- Confirmed x86_64 has sda1 (1.0M) + sda2 (7.8G xfs), s390x has only sda1 (7.8G xfs)
- Reproduced the exact failure: `--mount /dev/sda2:/` on s390x gives "No such file or directory"
- Verified `-i` works on both architectures, successfully extracting vmlinuz and initramfs

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
