### PR TITLE
k8s, sriov: Rename PF interface to sriov0

### DIFF
--- a/cluster-provision/k8s/1.35/provision.sh
+++ b/cluster-provision/k8s/1.35/provision.sh
@@ -98,6 +98,9 @@ else
 fi 
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
+cat > /etc/udev/rules.d/99-kubevirtci-sriov-net.rules <<'EOF'
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="igb", NAME="sriov0"
+EOF
 
 # envsubst pkg is not available by default in s390x Architecture, so explicitly installing it as part of gettext
 dnf install -y gettext

--- a/cluster-provision/k8s/1.36/provision.sh
+++ b/cluster-provision/k8s/1.36/provision.sh
@@ -98,6 +98,9 @@ else
 fi 
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
+cat > /etc/udev/rules.d/99-kubevirtci-sriov-net.rules <<'EOF'
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="igb", NAME="sriov0"
+EOF
 
 # NetworkManager-config-server sets no-auto-default=* which prevents auto-DHCP
 # on unconfigured interfaces. CentOS 9 has ifcfg-eth0 from cloud-init but

--- a/cluster-up/cluster/k8s-1.35/config_sriov_cluster.sh
+++ b/cluster-up/cluster/k8s-1.35/config_sriov_cluster.sh
@@ -98,7 +98,7 @@ done
 
 echo ""
 # Collect PF names from all nodes
-PFS_IN_USE="eth1"  # Our SR-IOV interface
+PFS_IN_USE="sriov0"  # Our SR-IOV interface
 
 if [[ "$KUBEVIRT_USE_DRA" != "true" ]]; then
   echo ""

--- a/cluster-up/cluster/k8s-1.36/config_sriov_cluster.sh
+++ b/cluster-up/cluster/k8s-1.36/config_sriov_cluster.sh
@@ -98,7 +98,7 @@ done
 
 echo ""
 # Collect PF names from all nodes
-PFS_IN_USE="eth1"  # Our SR-IOV interface
+PFS_IN_USE="sriov0"  # Our SR-IOV interface
 
 if [[ "$KUBEVIRT_USE_DRA" != "true" ]]; then
   echo ""


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Bake a udev rule into the k8s node images so the SR-IOV igb device gets a
stable name that does not depend on ethN probe order.
This lets the SR-IOV cluster setup target a fixed PF name instead of inferring one from the number of secondary NICs (atm it was even hardcoded, which didn't allow to use `KUBEVIRT_NUM_SECONDARY_NICS` with `KUBEVIRT_WITH_SRIOV`).

It is also safer in case of secondary interfaces reorder, the igb will have an orthogonal name.
`KUBEVIRT_NUM_SECONDARY_NICS` with `KUBEVIRT_WITH_SRIOV` is now supported,
and the tests that use ethN, won't use the igb by mistake in case of reorder.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
