### PR TITLE
k8s, sriov: Move igb udev rule to k8s phase

### DIFF
--- a/cluster-provision/k8s/1.35/k8s_provision.sh
+++ b/cluster-provision/k8s/1.35/k8s_provision.sh
@@ -49,6 +49,12 @@ else
   exit 1
 fi
 
+function create_sriov_udev_rule() {
+    cat > /etc/udev/rules.d/99-kubevirtci-sriov-net.rules <<'EOF'
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="igb", NAME="sriov0"
+EOF
+}
+
 function pull_container_retry() {
     retry=0
     maxRetries=5
@@ -90,6 +96,8 @@ registries = ['registry:5000']
 [registries.block]
 registries = []
 EOF
+
+create_sriov_udev_rule
 
 packages_version=$(getKubernetesClosestStableVersion)
 major_version=$(echo $packages_version | cut -d "." -f 2)

--- a/cluster-provision/k8s/1.35/provision.sh
+++ b/cluster-provision/k8s/1.35/provision.sh
@@ -98,9 +98,6 @@ else
 fi 
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
-cat > /etc/udev/rules.d/99-kubevirtci-sriov-net.rules <<'EOF'
-ACTION=="add", SUBSYSTEM=="net", DRIVERS=="igb", NAME="sriov0"
-EOF
 
 # envsubst pkg is not available by default in s390x Architecture, so explicitly installing it as part of gettext
 dnf install -y gettext

--- a/cluster-provision/k8s/1.36/k8s_provision.sh
+++ b/cluster-provision/k8s/1.36/k8s_provision.sh
@@ -49,6 +49,12 @@ else
   exit 1
 fi
 
+function create_sriov_udev_rule() {
+    cat > /etc/udev/rules.d/99-kubevirtci-sriov-net.rules <<'EOF'
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="igb", NAME="sriov0"
+EOF
+}
+
 function pull_container_retry() {
     retry=0
     maxRetries=5
@@ -90,6 +96,8 @@ registries = ['registry:5000']
 [registries.block]
 registries = []
 EOF
+
+create_sriov_udev_rule
 
 packages_version=$(getKubernetesClosestStableVersion)
 major_version=$(echo $packages_version | cut -d "." -f 2)

--- a/cluster-provision/k8s/1.36/provision.sh
+++ b/cluster-provision/k8s/1.36/provision.sh
@@ -98,9 +98,6 @@ else
 fi 
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
-cat > /etc/udev/rules.d/99-kubevirtci-sriov-net.rules <<'EOF'
-ACTION=="add", SUBSYSTEM=="net", DRIVERS=="igb", NAME="sriov0"
-EOF
 
 # NetworkManager-config-server sets no-auto-default=* which prevents auto-DHCP
 # on unconfigured interfaces. CentOS 9 has ifcfg-eth0 from cloud-init but


### PR DESCRIPTION
We do not currently create new base images, 
so placing the igb rename rule in provision.sh does not help the published images.
Move it to the k8s phase instead, which still runs during publish.

The node is shut down after provisioning, so the rule is applied on the next boot during cluster-up.
It will be activated only on the worker nodes where the igb device exists, otherwise will just do nothing.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
