### PR TITLE
Enable HugePages Support for s390x Architecture

### DIFF
--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -98,6 +98,20 @@ type dockerSetting struct {
 	Proxy string
 }
 
+func defaultHugepages2M() uint {
+	if runtime.GOARCH == "s390x" {
+		return 0
+	}
+	return 64
+}
+
+func defaultHugepages1M() uint {
+	if runtime.GOARCH == "s390x" {
+		return 128
+	}
+	return 0
+}
+
 // NewRunCommand returns command that runs given cluster
 func NewRunCommand() *cobra.Command {
 
@@ -160,8 +174,10 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().StringArrayVar(&scsiDisks, "scsi", []string{}, "size of the emulate SCSI disk to pass to the node")
 	run.Flags().Bool("run-etcd-on-memory", false, "configure etcd to run on RAM memory, etcd data will not be persistent")
 	run.Flags().String("etcd-capacity", etcdinmemory.DefaultEtcdCapacity, "set etcd data mount size.\nthis flag takes affect only when 'run-etcd-on-memory' is specified")
-	run.Flags().Uint("hugepages-2m", 64, "number of hugepages of size 2M to allocate")
+	run.Flags().Uint("hugepages-2m", defaultHugepages2M(), "number of hugepages of size 2M to allocate")
 	run.Flags().Uint("hugepages-1g", 0, "number of hugepages of size 1Gi to allocate")
+	run.Flags().Uint("hugepages-1m", defaultHugepages1M(), "number of hugepages of size 1M to allocate")
+	run.Flags().Uint("hugepages-2g", 0, "number of hugepages of size 2G to allocate")
 	run.Flags().Bool("enable-realtime-scheduler", false, "configures the kernel to allow unlimited runtime for processes that require realtime scheduling")
 	run.Flags().Bool("enable-fips", false, "enables FIPS")
 	run.Flags().Bool("enable-psa", false, "Pod Security Admission")
@@ -334,6 +350,15 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 	hugepages1Gcount, err := cmd.Flags().GetUint("hugepages-1g")
+	if err != nil {
+		return err
+	}
+
+	hugepages1Mcount, err := cmd.Flags().GetUint("hugepages-1m")
+	if err != nil {
+		return err
+	}
+	hugepages2Gcount, err := cmd.Flags().GetUint("hugepages-2g")
 	if err != nil {
 		return err
 	}
@@ -745,6 +770,14 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 
 		if hugepages1Gcount > 0 {
 			kernelArgs += fmt.Sprintf(" hugepagesz=1G hugepages=%d", hugepages1Gcount)
+		}
+
+		if hugepages1Mcount > 0 {
+			kernelArgs += fmt.Sprintf(" hugepagesz=1M hugepages=%d", hugepages1Mcount)
+		}
+
+		if hugepages2Gcount > 0 {
+			kernelArgs += fmt.Sprintf(" hugepagesz=2G hugepages=%d", hugepages2Gcount)
 		}
 
 		if fipsEnabled {

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -194,6 +194,14 @@ function _add_common_params() {
         params=" --hugepages-1g $KUBEVIRT_HUGEPAGES_1G $params"
     fi
 
+    if [ -n "$KUBEVIRT_HUGEPAGES_1M" ]; then
+        params=" --hugepages-1m $KUBEVIRT_HUGEPAGES_1M $params"
+    fi
+
+    if [ -n "$KUBEVIRT_HUGEPAGES_2G" ]; then
+        params=" --hugepages-2g $KUBEVIRT_HUGEPAGES_2G $params"
+    fi
+
     if [ -n "$KUBEVIRT_REALTIME_SCHEDULER" ]; then
         params=" --enable-realtime-scheduler $params"
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds hugepages-1m and hugepages-2g flags for enabling s390x clusters to allocate 1Mi hugepages and 2Gi hugepages.

s390x supports 1Mi hugepages (not 2Mi like x86). The existing hugepages-2m and hugepages-1g flags only cover x86 hugepage sizes. This change adds the missing wiring for s390x.

**Changes:**

run.go: Added hugepages-1m (default 128) and hugepages-2g (default 0) flag definitions.

ephemeral-provider-common.sh: Added KUBEVIRT_HUGEPAGES_1M and KUBEVIRT_HUGEPAGES_2G environment variable passthrough.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Partially addresses kubevirt/kubevirt#18272

**Special notes for your reviewer**:

This PR is part of enabling hugepage support for s390x in kubevirt. The reference PR kubevirt/kubevirt#18272 fixes the memfd/hugetlbfs issues in kubevirt.



**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
