### PR TITLE
cluster-provision: install crictl explicitly

### DIFF
--- a/cluster-provision/k8s/1.34/k8s_provision.sh
+++ b/cluster-provision/k8s/1.34/k8s_provision.sh
@@ -108,6 +108,7 @@ EOF
 
 # Install Kubernetes CNI.
 dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
+    cri-tools-${CRIO_VERSION}.0 \
     kubectl-${packages_version} \
     kubeadm-${packages_version} \
     kubelet-${packages_version} \

--- a/cluster-provision/k8s/1.35/k8s_provision.sh
+++ b/cluster-provision/k8s/1.35/k8s_provision.sh
@@ -116,6 +116,7 @@ EOF
 
 # Install Kubernetes CNI.
 dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
+    cri-tools-${CRIO_VERSION}.0 \
     kubectl-${packages_version} \
     kubeadm-${packages_version} \
     kubelet-${packages_version} \

--- a/cluster-provision/k8s/1.36/k8s_provision.sh
+++ b/cluster-provision/k8s/1.36/k8s_provision.sh
@@ -116,6 +116,7 @@ EOF
 
 # Install Kubernetes CNI.
 dnf install --skip-broken --nobest --nogpgcheck --disableexcludes=kubernetes -y \
+    cri-tools-${CRIO_VERSION}.0 \
     kubectl-${packages_version} \
     kubeadm-${packages_version} \
     kubelet-${packages_version} \


### PR DESCRIPTION
**What this PR does / why we need it**:

`crictl` is provided by the cri-tools package which was installed as a dependency of the kubeadm package.

Recent builds of the kubeadm package do not depend on it anymore so it needs to be installed explicitly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirtci/pull/1702

**Special notes for your reviewer**:

/cc @brianmcarey @dhiller