### PR TITLE
gocli, istio: Bump to 1.30.2

### DIFF
--- a/cluster-provision/gocli/opts/istio/istio.go
+++ b/cluster-provision/gocli/opts/istio/istio.go
@@ -24,7 +24,7 @@ var istioWithCnao []byte
 //go:embed manifests/istio-operator.cr.yaml
 var istioNoCnao []byte
 
-const istioVersion = "1.26.4"
+const istioVersion = "1.30.2"
 
 type istioOpt struct {
 	cnaoEnabled bool

--- a/cluster-provision/k8s/1.34/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.34/extra-pre-pull-images
@@ -3,7 +3,7 @@ quay.io/calico/cni:v3.26.5
 quay.io/calico/kube-controllers:v3.26.5
 quay.io/calico/node:v3.26.5
 quay.io/cephcsi/cephcsi:v3.13.1
-quay.io/kubevirtci/install-cni:1.26.4
-quay.io/kubevirtci/pilot:1.26.4
-quay.io/kubevirtci/proxyv2:1.26.4
+quay.io/kubevirtci/install-cni:1.30.2
+quay.io/kubevirtci/pilot:1.30.2
+quay.io/kubevirtci/proxyv2:1.30.2
 gcr.io/k8s-staging-networking/kube-network-policies@sha256:8c1f03ed7368803ec906014e5d22d54bb0cbb836af18e59de238861b7a85fdda

--- a/cluster-provision/k8s/1.34/provision.sh
+++ b/cluster-provision/k8s/1.34/provision.sh
@@ -6,7 +6,7 @@ ARCH=$(uname -m)
 
 KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
 mkdir -p $KUBEVIRTCI_SHARED_DIR
-export ISTIO_VERSION=1.26.4
+export ISTIO_VERSION=1.30.2
 cat << EOF > $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
 #!/bin/bash
 set -ex

--- a/cluster-provision/k8s/1.35/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.35/extra-pre-pull-images
@@ -3,9 +3,9 @@ quay.io/calico/cni:v3.26.5
 quay.io/calico/kube-controllers:v3.26.5
 quay.io/calico/node:v3.26.5
 quay.io/cephcsi/cephcsi:v3.13.1
-quay.io/kubevirtci/install-cni:1.26.4
-quay.io/kubevirtci/pilot:1.26.4
-quay.io/kubevirtci/proxyv2:1.26.4
+quay.io/kubevirtci/install-cni:1.30.2
+quay.io/kubevirtci/pilot:1.30.2
+quay.io/kubevirtci/proxyv2:1.30.2
 gcr.io/k8s-staging-networking/kube-network-policies@sha256:bcbc2f6e57bb1689fffcaa968da1cf065ac0beed373e4f3b286a0e7dabe6e76d
 gcr.io/k8s-staging-networking/kube-network-policies@sha256:8c1f03ed7368803ec906014e5d22d54bb0cbb836af18e59de238861b7a85fdda
 ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:669b9d85524896308d9dbf4bb5f21f2635af27089d1209882e2d676597901d6d

--- a/cluster-provision/k8s/1.35/provision.sh
+++ b/cluster-provision/k8s/1.35/provision.sh
@@ -6,7 +6,7 @@ ARCH=$(uname -m)
 
 KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
 mkdir -p $KUBEVIRTCI_SHARED_DIR
-export ISTIO_VERSION=1.26.4
+export ISTIO_VERSION=1.30.2
 cat << EOF > $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
 #!/bin/bash
 set -ex

--- a/cluster-provision/k8s/1.36/extra-pre-pull-images
+++ b/cluster-provision/k8s/1.36/extra-pre-pull-images
@@ -3,9 +3,9 @@ quay.io/calico/cni:v3.26.5
 quay.io/calico/kube-controllers:v3.26.5
 quay.io/calico/node:v3.26.5
 quay.io/cephcsi/cephcsi:v3.13.1
-quay.io/kubevirtci/install-cni:1.26.4
-quay.io/kubevirtci/pilot:1.26.4
-quay.io/kubevirtci/proxyv2:1.26.4
+quay.io/kubevirtci/install-cni:1.30.2
+quay.io/kubevirtci/pilot:1.30.2
+quay.io/kubevirtci/proxyv2:1.30.2
 gcr.io/k8s-staging-networking/kube-network-policies@sha256:bcbc2f6e57bb1689fffcaa968da1cf065ac0beed373e4f3b286a0e7dabe6e76d
 gcr.io/k8s-staging-networking/kube-network-policies@sha256:8c1f03ed7368803ec906014e5d22d54bb0cbb836af18e59de238861b7a85fdda
 ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:669b9d85524896308d9dbf4bb5f21f2635af27089d1209882e2d676597901d6d

--- a/cluster-provision/k8s/1.36/provision.sh
+++ b/cluster-provision/k8s/1.36/provision.sh
@@ -6,7 +6,7 @@ ARCH=$(uname -m)
 
 KUBEVIRTCI_SHARED_DIR=/var/lib/kubevirtci
 mkdir -p $KUBEVIRTCI_SHARED_DIR
-export ISTIO_VERSION=1.26.4
+export ISTIO_VERSION=1.30.2
 cat << EOF > $KUBEVIRTCI_SHARED_DIR/shared_vars.sh
 #!/bin/bash
 set -ex

--- a/cluster-provision/k8s/base-image
+++ b/cluster-provision/k8s/base-image
@@ -1,1 +1,1 @@
-quay.io/kubevirtci/centos9:2607210400-a95861f5
+quay.io/kubevirtci/centos9:2607211236-09226d87

--- a/cluster-provision/k8s/base-image-centos10
+++ b/cluster-provision/k8s/base-image-centos10
@@ -1,1 +1,1 @@
-quay.io/kubevirtci/centos10:2607220400-5ace5d2a
+quay.io/kubevirtci/centos10:2607221053-1bcf61e4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Istio 1.26.x is EOL [1]. This PR bumps Istio to 1.30.2.

  Changes:
  - Bump istioctl version to 1.30.2 in the gocli Go constant and all k8s
    version provisioners (1.34, 1.35, 1.36)
  - Update pre-pull images (install-cni, pilot, proxyv2) to 1.30.2

[1] https://istio.io/latest/docs/releases/supported-releases/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
