### PR TITLE
fix: validate minimum memory size before fake VFIO setup

### DIFF
--- a/cluster-up/cluster/vfio-gpu/README.md
+++ b/cluster-up/cluster/vfio-gpu/README.md
@@ -39,12 +39,18 @@ Worker node packages: `make`, `gcc`, and matching kernel headers for the
 running worker-node kernel. These must be present in the provider image; the
 VFIO setup validates them before building the fake modules.
 
+Memory requirements: Some fake VFIO tests require at least **8G (8192M)** of
+memory allocated to the node VM. The default `KUBEVIRT_MEMORY_SIZE` (`5120M`)
+is insufficient — `make cluster-up` will **fail** with a fatal error if
+`KUBEVIRT_MEMORY_SIZE` is below this threshold when `KUBEVIRT_USE_FAKE_VFIO=true`.
+
 ## Cluster setup
 
 
 ```bash
 export KUBEVIRT_PROVIDER=k8s-1.36
 export KUBEVIRT_USE_FAKE_VFIO=true
+export KUBEVIRT_MEMORY_SIZE=8192M
 export FAKE_PCI_DEVICES=8
 export FAKE_IOMMU=true
 
@@ -104,6 +110,7 @@ cluster unless a Kind provider explicitly calls it.
 | Variable | Default | Purpose |
 | -------- | ------- | ------- |
 | `KUBEVIRT_USE_FAKE_VFIO` | `false` | Enables fake VFIO setup during `make cluster-up` for supported `k8s-*` providers |
+| `KUBEVIRT_MEMORY_SIZE` | `5120M` | Memory allocated to provider node VMs. Set to `>= 8192M` (or `8G`) for fake VFIO |
 | `FAKE_PCI_DEVICES` | `8` | Number of synthetic PCI devices to create inside each worker node |
 | `FAKE_IOMMU` | `true` | Load the fake IOMMU companion so fake devices can bind to `vfio-pci` |
 | `DRA_DRIVER_PROFILE` | `vfio-gpu` | DRA example driver profile installed by Helm |

--- a/cluster-up/cluster/vfio-gpu/config_vfio_cluster.sh
+++ b/cluster-up/cluster/vfio-gpu/config_vfio_cluster.sh
@@ -40,7 +40,23 @@ encode_vfio_assets() {
     tar -C "${SCRIPT_PATH}" -cz fake-iommu fake-pci setup-fake-pci-host.sh | base64 | tr -d '\n'
 }
 
+# Some fake VFIO tests require at least 8G of memory. Output a warning if the cluster was started with less.
+validate_memory() {
+    local mem_value mem_unit mem_in_mb
+    mem_value=$(echo "${KUBEVIRT_MEMORY_SIZE:-0}" | sed 's/[^0-9]//g')
+    mem_unit=$(echo "${KUBEVIRT_MEMORY_SIZE:-0}" | sed 's/[^a-zA-Z]//g' | tr '[:lower:]' '[:upper:]')
+    case "${mem_unit}" in
+        G|GI|GB|GIB) mem_in_mb=$((mem_value * 1024)) ;;
+        T|TI|TB|TIB) mem_in_mb=$((mem_value * 1024 * 1024)) ;;
+        *) mem_in_mb=${mem_value} ;;
+    esac
+    if [ "${mem_in_mb}" -lt 8192 ]; then
+        echo "WARNING: some tests with KUBEVIRT_USE_FAKE_VFIO=true require KUBEVIRT_MEMORY_SIZE >= 8G (8192M). Current value: ${KUBEVIRT_MEMORY_SIZE:-unset}" >&2
+    fi
+}
+
 validate_inputs() {
+    validate_memory
     if [ ! -d "${SCRIPT_PATH}/fake-iommu" ] || [ ! -d "${SCRIPT_PATH}/fake-pci" ]; then
         echo "FATAL: fake VFIO module sources not found under ${SCRIPT_PATH}" >&2
         exit 1

--- a/cluster-up/cluster/vfio-gpu/config_vfio_cluster.sh
+++ b/cluster-up/cluster/vfio-gpu/config_vfio_cluster.sh
@@ -40,7 +40,24 @@ encode_vfio_assets() {
     tar -C "${SCRIPT_PATH}" -cz fake-iommu fake-pci setup-fake-pci-host.sh | base64 | tr -d '\n'
 }
 
+# Some fake VFIO tests require at least 8G of memory. Fail early if the cluster was started with less.
+validate_memory() {
+    local mem_value mem_unit mem_in_mb
+    mem_value=$(echo "${KUBEVIRT_MEMORY_SIZE:-0}" | sed 's/[^0-9]//g')
+    mem_unit=$(echo "${KUBEVIRT_MEMORY_SIZE:-0}" | sed 's/[^a-zA-Z]//g' | tr '[:lower:]' '[:upper:]')
+    case "${mem_unit}" in
+        G|GI|GB|GIB) mem_in_mb=$((mem_value * 1024)) ;;
+        T|TI|TB|TIB) mem_in_mb=$((mem_value * 1024 * 1024)) ;;
+        *) mem_in_mb=${mem_value} ;;
+    esac
+    if [ "${mem_in_mb}" -lt 8192 ]; then
+        echo "FATAL: fake VFIO requires KUBEVIRT_MEMORY_SIZE >= 8G (8192M). Current value: ${KUBEVIRT_MEMORY_SIZE:-unset}" >&2
+        exit 1
+    fi
+}
+
 validate_inputs() {
+    validate_memory
     if [ ! -d "${SCRIPT_PATH}/fake-iommu" ] || [ ! -d "${SCRIPT_PATH}/fake-pci" ]; then
         echo "FATAL: fake VFIO module sources not found under ${SCRIPT_PATH}" >&2
         exit 1

--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -48,6 +48,7 @@ KUBEVIRT_KSM_ON=${KUBEVIRT_KSM_ON:-false}
 KUBVIRT_WITH_CNAO_SKIP_CONFIG=${KUBVIRT_WITH_CNAO_SKIP_CONFIG:-false}
 
 export KUBEVIRT_PROVIDER
+export KUBEVIRT_MEMORY_SIZE
 
 # If on a developer setup, expose ocp on 8443, so that the openshift web console can be used (the port is important because of auth redirects)
 # http and https ports are accessed by testing framework and should not be randomized


### PR DESCRIPTION
Add a validate_memory() check to config_vfio_cluster.sh that exits
if KUBEVIRT_MEMORY_SIZE is below the 8G (8192M) minimum required by
some fake VFIO tests. The check handles G, GB, and GiB suffixes,
normalising everything to MB for comparison.

Assisted-by: IBM Bob

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
