### PR TITLE
fix: kernel-modules-extra for CentOs Stream 10 compatibility

### DIFF
--- a/cluster-provision/k8s/1.34/provision.sh
+++ b/cluster-provision/k8s/1.34/provision.sh
@@ -29,6 +29,9 @@ fi
 
 # Install modules of the initrd kernel
 dnf install -y "kernel-modules-$(uname -r)"
+if [ "$release" == "centos10" ]; then
+  dnf install -y "kernel-modules-extra-$(uname -r)"
+fi
 
 # Resize root partition
 dnf install -y cloud-utils-growpart

--- a/cluster-provision/k8s/1.35/provision.sh
+++ b/cluster-provision/k8s/1.35/provision.sh
@@ -29,6 +29,9 @@ fi
 
 # Install modules of the initrd kernel
 dnf install -y "kernel-modules-$(uname -r)"
+if [ "$release" == "centos10" ]; then
+  dnf install -y "kernel-modules-extra-$(uname -r)"
+fi
 
 # Resize root partition
 dnf install -y cloud-utils-growpart

--- a/cluster-provision/k8s/1.36/provision.sh
+++ b/cluster-provision/k8s/1.36/provision.sh
@@ -29,6 +29,9 @@ fi
 
 # Install modules of the initrd kernel.
 dnf install -y "kernel-modules-$(uname -r)" "kernel-devel-$(uname -r)"
+if [ "$release" == "centos10" ]; then
+  dnf install -y "kernel-modules-extra-$(uname -r)"
+fi
 
 # Resize root partition
 dnf install -y cloud-utils-growpart


### PR DESCRIPTION
On CentOS Stream 10, br_netfilter was moved from the kernel-modules package to the kernel-modules-extra.

Assisted-by: IBM Bob

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
