### PR TITLE
feat: capture VM serial console output for CI debugging

### DIFF
--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -58,7 +58,7 @@ n="$(printf "%02d" $(( 10#${NODE_NUM} )))"
 cat >/usr/local/bin/ssh.sh <<EOL
 #!/bin/bash
 set -e
-dockerize -wait tcp://192.168.66.1${n}:22 -timeout 300s &>/dev/null
+dockerize -wait tcp://192.168.66.1${n}:22 -timeout 120s &>/dev/null
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${VM_USER}@192.168.66.1${n} -i ${VM_USER_SSH_KEY} -p 22 -q \$@
 EOL
 chmod u+x /usr/local/bin/ssh.sh
@@ -216,6 +216,12 @@ if [ "${NUMA}" -gt 1 ]; then
     done
 fi
 
+if [ -n "${PROW_JOB_ID:-}" ] || [ "${CI:-}" = "true" ]; then
+  SERIAL_ARG="-serial file:/dev/stderr"
+else
+  SERIAL_ARG="-serial pty"
+fi
+
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
   qemu_system_cmd="qemu-system-s390x \
@@ -233,7 +239,7 @@ if [ "$(uname -m)" == "s390x" ]; then
     -cpu host \
     -m ${MEMORY} \
     -smp ${CPU} ${numa_arg} \
-    -serial pty \
+    ${SERIAL_ARG} \
     -machine s390-ccw-virtio,accel=kvm \
     -uuid $(cat /proc/sys/kernel/random/uuid) \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
@@ -260,7 +266,7 @@ else
     -cpu host,migratable=no,+invtsc \
     -m ${MEMORY} \
     -smp ${CPU} ${numa_arg} \
-    -serial pty \
+    ${SERIAL_ARG} \
     -machine q35,accel=kvm,kernel_irqchip=split \
     -device intel-iommu,intremap=on,caching-mode=on \
     -device intel-hda,bus=pcie.0 -device hda-duplex -device AC97,bus=pcie.0 \

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -58,7 +58,7 @@ n="$(printf "%02d" $(( 10#${NODE_NUM} )))"
 cat >/usr/local/bin/ssh.sh <<EOL
 #!/bin/bash
 set -e
-dockerize -wait tcp://192.168.66.1${n}:22 -timeout 300s &>/dev/null
+dockerize -wait tcp://192.168.66.1${n}:22 -timeout 120s &>/dev/null
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${VM_USER}@192.168.66.1${n} -i ${VM_USER_SSH_KEY} -p 22 -q \$@
 EOL
 chmod u+x /usr/local/bin/ssh.sh
@@ -216,6 +216,12 @@ if [ "${NUMA}" -gt 1 ]; then
     done
 fi
 
+if [ -n "${PROW_JOB_ID:-}" ] || [ "${CI:-}" = "true" ]; then
+  SERIAL_ARG="-serial file:/dev/stderr"
+else
+  SERIAL_ARG="-serial pty"
+fi
+
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
   qemu_system_cmd="qemu-system-s390x \
@@ -233,7 +239,7 @@ if [ "$(uname -m)" == "s390x" ]; then
     -cpu host \
     -m ${MEMORY} \
     -smp ${CPU} ${numa_arg} \
-    -serial pty \
+    ${SERIAL_ARG} \
     -machine s390-ccw-virtio,accel=kvm \
     -uuid $(cat /proc/sys/kernel/random/uuid) \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
@@ -260,7 +266,7 @@ else
     -cpu host,migratable=no,+invtsc \
     -m ${MEMORY} \
     -smp ${CPU} ${numa_arg} \
-    -serial pty \
+    ${SERIAL_ARG} \
     -machine q35,accel=kvm,kernel_irqchip=split \
     -device intel-iommu,intremap=on,caching-mode=on \
     -device intel-hda,bus=pcie.0 -device hda-duplex -device AC97,bus=pcie.0 \

--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -209,9 +209,9 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 	}
 	node, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: base,
-		Env: []string{
+		Env: append([]string{
 			fmt.Sprintf("NODE_NUM=%s", nodeNum),
-		},
+		}, utils.ForwardEnv("PROW_JOB_ID", "CI")...),
 		Volumes: map[string]struct{}{
 			"/var/run/disk":     {},
 			"/var/lib/registry": {},

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -787,9 +787,9 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 
 		vmContainerConfig := &container.Config{
 			Image: clusterImage,
-			Env: []string{
+			Env: append([]string{
 				fmt.Sprintf("NODE_NUM=%s", nodeNum),
-			},
+			}, utils.ForwardEnv("PROW_JOB_ID", "CI")...),
 			Cmd: []string{"/bin/bash", "-c", fmt.Sprintf("/vm.sh -n /var/run/disk/disk.qcow2 --memory %s --cpu %s --numa %s %s %s %s %s %s %s",
 				memory,
 				strconv.Itoa(int(cpu)),
@@ -1113,7 +1113,7 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 func waitForVMToBeUp(cli *client.Client, prefix string, nodeName string) error {
 	var err error
 	// Wait for the VM to be up
-	for x := 0; x < 10; x++ {
+	for x := 0; x < 5; x++ {
 		err = _cmd(cli, nodeContainer(prefix, nodeName), "ssh.sh echo VM is up", "waiting for node to come up")
 		if err == nil {
 			break

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -610,10 +610,6 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 		volumes <- sharedVolume.Name
 	}
 
-	// Add serial pty so we can do stuff like 'screen /dev/pts0' to access
-	// the VM console from the container without ssh
-	qemuArgs += " -serial pty"
-
 	var qemuNetDevice = getNetDeviceByArch()
 	numaNodes := int(numa)
 	pcieBus := ""

--- a/cluster-provision/gocli/cmd/utils/utils.go
+++ b/cluster-provision/gocli/cmd/utils/utils.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/docker/go-connections/nat"
@@ -15,6 +17,17 @@ func AppendTCPIfExplicit(ports nat.PortMap, exposedPort int, flagSet *pflag.Flag
 // AppendUDPIfExplicit append UDP port to the portMap if the port flag exists
 func AppendUDPIfExplicit(ports nat.PortMap, exposedPort int, flagSet *pflag.FlagSet, flagName string) error {
 	return appendIfExplicit(ports, exposedPort, flagSet, flagName, UDPPortOrDie)
+}
+
+// ForwardEnv returns KEY=VALUE strings for env vars that are set in the current process.
+func ForwardEnv(names ...string) []string {
+	var result []string
+	for _, name := range names {
+		if val, ok := os.LookupEnv(name); ok {
+			result = append(result, fmt.Sprintf("%s=%s", name, val))
+		}
+	}
+	return result
 }
 
 func appendIfExplicit(ports nat.PortMap, exposedPort int, flagSet *pflag.FlagSet, flagName string, portFn func(port int) nat.Port) error {


### PR DESCRIPTION
## Summary

- Fix QEMU `-serial pty` boot hang that blocked CentOS 9 Stream image bumps since April 2026
- Use `-serial file:/dev/stderr` in CI (captures console output in build logs), keep `-serial pty` for local dev
- Forward `PROW_JOB_ID` and `CI` env vars into VM containers so `vm.sh` can detect CI
- Remove hardcoded `-serial pty` from `run.go` — vm.sh now manages the serial backend, eliminating duplicate serial ports
- Reduce `dockerize` SSH timeout from 300s to 120s and SSH retries from 10 to 5 (~10 min total instead of ~50 min)

Fixes: kubevirt/project-infra#5098 , kubevirt/kubevirtci#1770

## Root cause

When `-serial pty` is used and nobody reads from the PTY (always the case in CI), the QEMU PTY backend can stall guest execution under CPU contention. This is a [known class of QEMU bugs](https://bugzilla.redhat.com/show_bug.cgi?id=1455451). The kernel jump from `5.14.0-691` to `5.14.0-721` (~30 releases) produces more boot messages on `console=ttyS0`, crossing the threshold that triggers the stall.

With `-serial pty`: ~60% failure rate. With `-serial file:/dev/stderr`: 0% failures across 10+ runs.

Additionally, `run.go` hardcoded `-serial pty` in QEMU_ARGS, which created a second unread PTY serial port (COM2) alongside vm.sh's own serial backend — doubling the exposure to the bug.

See https://github.com/kubevirt/project-infra/issues/5098 for full investigation.

## Changes

- `cluster-provision/centos9/scripts/vm.sh`: conditional serial backend (CI vs local), 120s dockerize timeout
- `cluster-provision/centos10/scripts/vm.sh`: same
- `cluster-provision/gocli/cmd/utils/utils.go`: new `ForwardEnv()` helper
- `cluster-provision/gocli/cmd/provision.go`: forward `PROW_JOB_ID`/`CI` to VM containers
- `cluster-provision/gocli/cmd/run.go`: forward `PROW_JOB_ID`/`CI` to VM containers, reduce SSH retries from 10 to 5, remove hardcoded `-serial pty` (vm.sh handles it)

## Test plan

- [x] `check-provision-centos-base` passes with CentOS 9 compose `20260706.0`
- [x] 10+ consecutive successful boots confirm the serial backend fix
- [ ] Confirm `-serial null` also boots reliably (proves PTY backend is the cause independent of output)

## Related issues

- https://github.com/kubevirt/project-infra/issues/5098 — root cause investigation
- #1769 — CentOS 10 `br_netfilter` missing (unrelated, pre-existing)
- #1770 — s390x SSH timeout during check-cluster-up (partially addressed by removing duplicate serial port)

/kind bug

🤖 Assisted by Claude