### PR TITLE
vm based providers: Place secondary NICs on NUMA buses

### DIFF
--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -192,6 +192,7 @@ fi
 
 numa_arg=""
 sriov_pxb_numa_arg=""
+secondary_nic_pxb_args=""
 if [ "${NUMA}" -gt 1 ]; then
     numa_mem_unit="${MEMORY//[[:digit:]]/}"
     numa_mem_value="${MEMORY//[!0-9]/}"
@@ -209,6 +210,10 @@ if [ "${NUMA}" -gt 1 ]; then
         node_first_cpu=$((node_last_cpu + 1))
     done
     sriov_pxb_numa_arg=",numa_node=0"
+    for node_id in $(seq 0 $((NUMA - 1))); do
+        # Leave enough room for the downstream buses allocated under each NUMA bridge.
+        secondary_nic_pxb_args+=" -device pxb-pcie,id=secondarypxb${node_id},bus=pcie.0,bus_nr=$((160 + (node_id * 32))),numa_node=${node_id}"
+    done
 fi
 
 if [ "$(uname -m)" == "s390x" ]; then
@@ -243,6 +248,7 @@ else
     -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n},bus=pcie.0 \
     -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
     -device pxb-pcie,id=sriovpxb,bus=pcie.0,bus_nr=128${sriov_pxb_numa_arg} \
+    ${secondary_nic_pxb_args} \
     -device pcie-root-port,id=sriovrp,slot=3,chassis=3,bus=sriovpxb \
     -device igb,id=igb0,bus=sriovrp,netdev=sriovnet0,mac=52:55:00:d1:57:${n} \
     -netdev tap,id=sriovnet0,ifname=tap-sriov${n},script=no,downscript=no \

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -192,6 +192,7 @@ fi
 
 numa_arg=""
 sriov_pxb_numa_arg=""
+secondary_nic_pxb_args=""
 if [ "${NUMA}" -gt 1 ]; then
     numa_mem_unit="${MEMORY//[[:digit:]]/}"
     numa_mem_value="${MEMORY//[!0-9]/}"
@@ -209,6 +210,10 @@ if [ "${NUMA}" -gt 1 ]; then
         node_first_cpu=$((node_last_cpu + 1))
     done
     sriov_pxb_numa_arg=",numa_node=0"
+    for node_id in $(seq 0 $((NUMA - 1))); do
+        # Leave enough room for the downstream buses allocated under each NUMA bridge.
+        secondary_nic_pxb_args+=" -device pxb-pcie,id=secondarypxb${node_id},bus=pcie.0,bus_nr=$((160 + (node_id * 32))),numa_node=${node_id}"
+    done
 fi
 
 if [ "$(uname -m)" == "s390x" ]; then
@@ -243,6 +248,7 @@ else
     -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n},bus=pcie.0 \
     -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
     -device pxb-pcie,id=sriovpxb,bus=pcie.0,bus_nr=128${sriov_pxb_numa_arg} \
+    ${secondary_nic_pxb_args} \
     -device pcie-root-port,id=sriovrp,slot=3,chassis=3,bus=sriovpxb \
     -device igb,id=igb0,bus=sriovrp,netdev=sriovnet0,mac=52:55:00:d1:57:${n} \
     -netdev tap,id=sriovnet0,ifname=tap-sriov${n},script=no,downscript=no \

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -84,6 +84,9 @@ EOF
 	scsiDiskImagePrefix = "/scsi"
 	QEMU_DEVICE_S390X   = "virtio-net-ccw"
 	QEMU_DEVICE_X86_64  = "virtio-net-pci"
+
+	secondaryNicRootPortBaseSlot  = 4
+	secondaryNicRootPortBaseChass = 10
 )
 
 var soundcardPCIIDs = []string{"8086:2668", "8086:2415"}
@@ -612,6 +615,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 	qemuArgs += " -serial pty"
 
 	var qemuNetDevice = getNetDeviceByArch()
+	numaNodes := int(numa)
 	pcieBus := ""
 	if qemuNetDevice != QEMU_DEVICE_S390X {
 		pcieBus = ",bus=pcie.0"
@@ -636,7 +640,27 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			if qemuNetDevice == QEMU_DEVICE_S390X {
 				nodeQemuMonitorArgs = fmt.Sprintf("%s netdev_add tap,id=secondarynet%s,ifname=stap%s,script=no,downscript=no; device_add %s,netdev=secondarynet%s,mac=52:55:00:d1:56:%s;", nodeQemuMonitorArgs, netSuffix, netSuffix, qemuNetDevice, netSuffix, macSuffix)
 			} else { //devices like virtio-net-pci doesn't support hot-plug
-				nodeQemuArgs = fmt.Sprintf("%s -device %s,netdev=secondarynet%s,mac=52:55:00:d1:56:%s,bus=pcie.0 -netdev tap,id=secondarynet%s,ifname=stap%s,script=no,downscript=no", nodeQemuArgs, qemuNetDevice, netSuffix, macSuffix, netSuffix, netSuffix)
+				rootPortArgs := ""
+				bus := "pcie.0"
+				if numaNodes > 1 {
+					numaNode := i % numaNodes
+					bus = fmt.Sprintf("secondaryrp%d", i)
+					slot := secondaryNicRootPortBaseSlot + i/numaNodes
+					rootPortArgs = fmt.Sprintf(" -device pcie-root-port,id=%s,slot=%d,chassis=%d,bus=secondarypxb%d",
+						bus,
+						slot,
+						secondaryNicRootPortBaseChass+i,
+						numaNode)
+				}
+				nodeQemuArgs = fmt.Sprintf("%s%s -device %s,netdev=secondarynet%s,mac=52:55:00:d1:56:%s,bus=%s -netdev tap,id=secondarynet%s,ifname=stap%s,script=no,downscript=no",
+					nodeQemuArgs,
+					rootPortArgs,
+					qemuNetDevice,
+					netSuffix,
+					macSuffix,
+					bus,
+					netSuffix,
+					netSuffix)
 			}
 		}
 


### PR DESCRIPTION
Create NUMA-aware secondary PCIe buses in vm.sh and route extra x86 secondary NICs
through per-NIC root ports when a VM has multiple NUMA nodes.

Tested on Centos9, but the same idea was tested at the past with Centos10.
Atm we use Centos9 all over beside on vGPU DRA.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
