### PR TITLE
k8s: Install kernel-modules-extra on CentOS 10 for br_netfilter

### DIFF
--- a/cluster-provision/k8s/1.34/provision.sh
+++ b/cluster-provision/k8s/1.34/provision.sh
@@ -29,6 +29,9 @@ fi
 
 # Install modules of the initrd kernel
 dnf install -y "kernel-modules-$(uname -r)"
+if [ "$release" == "centos10" ]; then
+  dnf install -y "kernel-modules-extra-$(uname -r)"
+fi
 
 # Resize root partition
 dnf install -y cloud-utils-growpart

--- a/cluster-provision/k8s/1.35/provision.sh
+++ b/cluster-provision/k8s/1.35/provision.sh
@@ -29,6 +29,9 @@ fi
 
 # Install modules of the initrd kernel
 dnf install -y "kernel-modules-$(uname -r)"
+if [ "$release" == "centos10" ]; then
+  dnf install -y "kernel-modules-extra-$(uname -r)"
+fi
 
 # Resize root partition
 dnf install -y cloud-utils-growpart

--- a/cluster-provision/k8s/1.36/provision.sh
+++ b/cluster-provision/k8s/1.36/provision.sh
@@ -29,6 +29,9 @@ fi
 
 # Install modules of the initrd kernel.
 dnf install -y "kernel-modules-$(uname -r)" "kernel-devel-$(uname -r)"
+if [ "$release" == "centos10" ]; then
+  dnf install -y "kernel-modules-extra-$(uname -r)"
+fi
 
 # Resize root partition
 dnf install -y cloud-utils-growpart


### PR DESCRIPTION
## Summary

- The CentOS 10 kernel (`6.12.0-248.el10`) no longer ships `br_netfilter` in the base `kernel-modules` package, causing `modprobe br_netfilter` to fail during provisioning under `set -ex`
- Install `kernel-modules-extra` on CentOS 10 to provide the module, which is required for Kubernetes service routing (`net.bridge.bridge-nf-call-iptables`)
- Applied to all three k8s version directories (1.34, 1.35, 1.36)

Fixes: https://github.com/kubevirt/kubevirtci/issues/1769

## Test plan

- [ ] check-provision-k8s-1.34-centos10 passes
- [ ] check-provision-k8s-1.35-centos10 passes
- [ ] check-provision-k8s-1.36-centos10 passes