### PR TITLE
centos10: Switch to using the fedora image from fedora registry as base container

### DIFF
--- a/cluster-provision/centos10/Dockerfile
+++ b/cluster-provision/centos10/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kubevirtci/fedora:42 AS base
+FROM registry.fedoraproject.org/fedora:44 AS base
 
 RUN dnf -y install jq iptables iproute dnsmasq qemu socat openssh-clients screen bind-utils tcpdump iputils libguestfs-tools-c && dnf clean all
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the same change that had already been made for CentOS 9.

See https://github.com/kubevirt/kubevirtci/pull/1593.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirtci/pull/1776

**Special notes for your reviewer**:

/cc @brianmcarey @dhiller 