### PR TITLE
fix: revert timeout and retry number changes

### DIFF
--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -58,7 +58,7 @@ n="$(printf "%02d" $(( 10#${NODE_NUM} )))"
 cat >/usr/local/bin/ssh.sh <<EOL
 #!/bin/bash
 set -e
-dockerize -wait tcp://192.168.66.1${n}:22 -timeout 120s &>/dev/null
+dockerize -wait tcp://192.168.66.1${n}:22 -timeout 300s &>/dev/null
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${VM_USER}@192.168.66.1${n} -i ${VM_USER_SSH_KEY} -p 22 -q \$@
 EOL
 chmod u+x /usr/local/bin/ssh.sh

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -58,7 +58,7 @@ n="$(printf "%02d" $(( 10#${NODE_NUM} )))"
 cat >/usr/local/bin/ssh.sh <<EOL
 #!/bin/bash
 set -e
-dockerize -wait tcp://192.168.66.1${n}:22 -timeout 120s &>/dev/null
+dockerize -wait tcp://192.168.66.1${n}:22 -timeout 300s &>/dev/null
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${VM_USER}@192.168.66.1${n} -i ${VM_USER_SSH_KEY} -p 22 -q \$@
 EOL
 chmod u+x /usr/local/bin/ssh.sh

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -1109,7 +1109,7 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 func waitForVMToBeUp(cli *client.Client, prefix string, nodeName string) error {
 	var err error
 	// Wait for the VM to be up
-	for x := 0; x < 5; x++ {
+	for x := 0; x < 10; x++ {
 		err = _cmd(cli, nodeContainer(prefix, nodeName), "ssh.sh echo VM is up", "waiting for node to come up")
 		if err == nil {
 			break


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

PR https://github.com/kubevirt/kubevirtci/pull/1767 reduced timeout and ssh.sh retry numbers, this change reverts them to the old values.

KubeVirtCI bump PR shows that the timeouts don't seem to suffice:
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18455/pull-kubevirt-e2e-k8s-1.34-sig-storage/2077725452146839552
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18455/pull-kubevirt-e2e-k8s-1.36-sig-storage/2077725444785836032
* https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18455/pull-kubevirt-e2e-k8s-1.36-sig-compute-serial/2077725446245453824/build-log.txt

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
