### PR TITLE
feat(gocli): log resource diagnostics on SSH retry failures

### DIFF
--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -1107,6 +1107,7 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 }
 
 func waitForVMToBeUp(cli *client.Client, prefix string, nodeName string) error {
+	logContainerDiagnostics(cli, prefix, nodeName, "pre-ssh")
 	var err error
 	for x := 0; x < 10; x++ {
 		err = _cmd(cli, nodeContainer(prefix, nodeName), "ssh.sh echo VM is up", "waiting for node to come up")
@@ -1114,7 +1115,7 @@ func waitForVMToBeUp(cli *client.Client, prefix string, nodeName string) error {
 			break
 		}
 		logrus.WithError(err).Warningf("Could not establish a ssh connection to the VM, retrying ...")
-		logContainerDiagnostics(cli, prefix, nodeName, x+1)
+		logContainerDiagnostics(cli, prefix, nodeName, fmt.Sprintf("retry-%d", x+1))
 		time.Sleep(1 * time.Second)
 	}
 
@@ -1122,11 +1123,12 @@ func waitForVMToBeUp(cli *client.Client, prefix string, nodeName string) error {
 		return fmt.Errorf("could not establish a connection to the node after a generous timeout: %v", err)
 	}
 
+	logContainerDiagnostics(cli, prefix, nodeName, "ssh-ok")
 	return nil
 }
 
-func logContainerDiagnostics(cli *client.Client, prefix string, nodeName string, attempt int) {
-	diagCmd := `echo "=== resource snapshot (attempt %d) ===" && date -Iseconds && ` +
+func logContainerDiagnostics(cli *client.Client, prefix string, nodeName string, phase string) {
+	diagCmd := `echo "=== resource snapshot (%s, %s) ===" && date -Iseconds && ` +
 		`echo "--- loadavg ---" && cat /proc/loadavg && ` +
 		`echo "--- memory ---" && free -m && ` +
 		`echo "--- psi cpu ---" && (cat /proc/pressure/cpu 2>/dev/null || echo "PSI unavailable") && ` +
@@ -1135,7 +1137,7 @@ func logContainerDiagnostics(cli *client.Client, prefix string, nodeName string,
 		`echo "--- top cpu consumers ---" && ps -eo pid,pcpu,pmem,comm --sort=-pcpu 2>/dev/null | head -10 && ` +
 		`echo "--- qemu process ---" && (ps aux 2>/dev/null | grep qemu-system | grep -v grep || echo "QEMU NOT RUNNING") && ` +
 		`echo "--- oom kills ---" && (dmesg 2>/dev/null | grep -i -E 'oom|killed|out.of.memory' | tail -5 || true)`
-	cmd := fmt.Sprintf(diagCmd, attempt)
+	cmd := fmt.Sprintf(diagCmd, nodeName, phase)
 	docker.Exec(cli, nodeContainer(prefix, nodeName), []string{"/bin/bash", "-c", cmd}, os.Stderr)
 }
 

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -1108,13 +1108,13 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 
 func waitForVMToBeUp(cli *client.Client, prefix string, nodeName string) error {
 	var err error
-	// Wait for the VM to be up
 	for x := 0; x < 10; x++ {
 		err = _cmd(cli, nodeContainer(prefix, nodeName), "ssh.sh echo VM is up", "waiting for node to come up")
 		if err == nil {
 			break
 		}
 		logrus.WithError(err).Warningf("Could not establish a ssh connection to the VM, retrying ...")
+		logContainerDiagnostics(cli, prefix, nodeName, x+1)
 		time.Sleep(1 * time.Second)
 	}
 
@@ -1123,6 +1123,20 @@ func waitForVMToBeUp(cli *client.Client, prefix string, nodeName string) error {
 	}
 
 	return nil
+}
+
+func logContainerDiagnostics(cli *client.Client, prefix string, nodeName string, attempt int) {
+	diagCmd := `echo "=== resource snapshot (attempt %d) ===" && date -Iseconds && ` +
+		`echo "--- loadavg ---" && cat /proc/loadavg && ` +
+		`echo "--- memory ---" && free -m && ` +
+		`echo "--- psi cpu ---" && (cat /proc/pressure/cpu 2>/dev/null || echo "PSI unavailable") && ` +
+		`echo "--- psi memory ---" && (cat /proc/pressure/memory 2>/dev/null || echo "PSI unavailable") && ` +
+		`echo "--- psi io ---" && (cat /proc/pressure/io 2>/dev/null || echo "PSI unavailable") && ` +
+		`echo "--- top cpu consumers ---" && ps -eo pid,pcpu,pmem,comm --sort=-pcpu 2>/dev/null | head -10 && ` +
+		`echo "--- qemu process ---" && (ps aux 2>/dev/null | grep qemu-system | grep -v grep || echo "QEMU NOT RUNNING") && ` +
+		`echo "--- oom kills ---" && (dmesg 2>/dev/null | grep -i -E 'oom|killed|out.of.memory' | tail -5 || true)`
+	cmd := fmt.Sprintf(diagCmd, attempt)
+	docker.Exec(cli, nodeContainer(prefix, nodeName), []string{"/bin/bash", "-c", cmd}, os.Stderr)
 }
 
 func nodeNameFromIndex(x int) string {


### PR DESCRIPTION
## Summary

- Log host resource snapshots at three points during `waitForVMToBeUp`: before SSH attempts (`pre-ssh`), on each SSH retry failure (`retry-N`), and after successful connection (`ssh-ok`)
- Captures: load average, memory, PSI pressure (cpu/memory/io), top CPU consumers, QEMU process state, OOM kills
- Output goes to stderr on every VM boot — the `pre-ssh` and `ssh-ok` snapshots bracket the SSH window so we can compare resource state between passing and failing runs

## Context

The persistent SSH timeout failures tracked in #1783 always show node01 booting fine while node02 never sends a DHCPDISCOVER. The leading hypothesis is resource contention: node02's QEMU starts after node01 is fully provisioned (running a full k8s cluster), starving node02 of CPU during boot.

We currently have zero diagnostic data from inside the failure window. This change gives us per-phase resource snapshots so the next batch of failures (~3-11% of runs) reveals whether contention is the cause. The `pre-ssh` and `ssh-ok` baselines from passing runs also help establish what "normal" resource pressure looks like, making it easier to spot anomalies in failing runs.

### What the diagnostics show

On each phase (pre-ssh, retry-N, ssh-ok), the build log will contain:

```
=== resource snapshot (node01, pre-ssh) ===
2026-07-22T12:00:00+00:00
--- loadavg ---
12.34 8.56 4.23 3/456 7890
--- memory ---
              total        used        free      shared  buff/cache   available
Mem:          64000       58000        2000         500        4000        5500
--- psi cpu ---
some avg10=45.23 avg60=32.10 avg300=18.50 total=12345678
full avg10=12.34 avg60=8.50 avg300=4.20 total=3456789
--- psi memory ---
...
--- psi io ---
...
--- top cpu consumers ---
  PID %CPU %MEM COMMAND
 1234 85.0 12.3 qemu-system-x86
  567 45.0  8.1 kubelet
...
--- qemu process ---
root  1234  85.0  12.3 ... qemu-system-x86_64 ...
--- oom kills ---
(empty = no OOM kills)
```

PSI `some avg10 > 25%` = meaningful contention; `> 50%` = severe.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./cmd/...` passes
- [ ] Diagnostic output appears in Prow build log on next SSH timeout failure
- [ ] `pre-ssh` and `ssh-ok` baselines appear in passing runs

🤖 Assisted by Claude