### PR TITLE
fix(cluster-provision): pin qemu runner to fedora 43

### DIFF
--- a/cluster-provision/centos10/Dockerfile
+++ b/cluster-provision/centos10/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:44 AS base
+FROM registry.fedoraproject.org/fedora:43 AS base
 
 RUN dnf -y install jq iptables iproute dnsmasq qemu socat openssh-clients screen bind-utils tcpdump iputils libguestfs-tools-c && dnf clean all
 

--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:44 AS base
+FROM registry.fedoraproject.org/fedora:43 AS base
 
 RUN dnf -y install jq iptables iproute dnsmasq qemu socat openssh-clients screen bind-utils tcpdump iputils libguestfs-tools-c && dnf clean all
 

--- a/cluster-provision/k8s/base-image
+++ b/cluster-provision/k8s/base-image
@@ -1,1 +1,1 @@
-quay.io/kubevirtci/centos9:2607211236-09226d87
+quay.io/kubevirtci/centos9:2607241400-4c030dd1

--- a/cluster-provision/k8s/base-image-centos10
+++ b/cluster-provision/k8s/base-image-centos10
@@ -1,1 +1,1 @@
-quay.io/kubevirtci/centos10:2607221053-1bcf61e4
+quay.io/kubevirtci/centos10:2607241400-4c030dd1


### PR DESCRIPTION
**What this PR does / why we need it**:

This helps to bring the user space (QEMU running in a Fedora container) closer to the kernel space (RHCOS 9) provided by CI nodes (bare-metal).

Sensible applications sush as QEMU encounter problems if the versions diverge too much.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1783