### PR TITLE
fix(cluster-provision): switch qemu runner to CentOS

### DIFF
--- a/cluster-provision/centos10/Dockerfile
+++ b/cluster-provision/centos10/Dockerfile
@@ -1,30 +1,39 @@
-FROM registry.fedoraproject.org/fedora:44 AS base
+FROM quay.io/centos/centos:stream9 AS base
 
-RUN dnf -y install jq iptables iproute dnsmasq qemu socat openssh-clients screen bind-utils tcpdump iputils libguestfs-tools-c && dnf clean all
+RUN dnf -y install epel-release
 
+RUN dnf -y install \
+    bind-utils \
+    dnsmasq \
+    guestfs-tools \
+    jq \
+    iproute \
+    iptables \
+    iputils \
+    openssh-clients \
+    screen \
+    socat \
+    tcpdump \
+    qemu-kvm-core && \
+    dnf clean all
 
 FROM base AS imageartifactdownload
 
-ARG BUILDARCH
-
-ARG centos_version
+ARG BUILDARCH=x86_64
+ARG CENTOS_VERSION
 
 WORKDIR /
 
-RUN echo "Centos10 version $centos_version"
-
-COPY scripts/download_box.sh /
-
-RUN  /download_box.sh https://cloud.centos.org/centos/10-stream/$BUILDARCH/images/CentOS-Stream-GenericCloud-10-$centos_version.$BUILDARCH.qcow2 && \
+RUN echo "CentOS Stream 10 version $CENTOS_VERSION" && \
+    curl --fail-with-body --retry 2 -LR -o box.qcow2 https://cloud.centos.org/centos/10-stream/$BUILDARCH/images/CentOS-Stream-GenericCloud-10-$CENTOS_VERSION.$BUILDARCH.qcow2 && \
     # Access virtual machine disk images directly by using LIBGUESTFS_BACKEND=direct, instead of libvirt
     export LIBGUESTFS_BACKEND=direct && \
     guestfish --ro --add box.qcow2 --mount /dev/sda2:/ ls /boot/ | grep -E '^vmlinuz-|^initramfs-' | xargs -I {} guestfish --ro --add box.qcow2 -i copy-out /boot/{} / ;
 
-
 FROM base AS nodecontainer
 
 ARG BUILDARCH
-       
+
 WORKDIR /
 
 COPY vagrant.key /vagrant.key

--- a/cluster-provision/centos10/build.sh
+++ b/cluster-provision/centos10/build.sh
@@ -1,7 +1,12 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-centos_version="$(cat $DIR/version | tr -d '\n')"
+CENTOS_VERSION="$(cat $DIR/version)"
 
-docker build --build-arg BUILDARCH=$(uname -m) --build-arg centos_version=$centos_version . -t quay.io/kubevirtci/centos10
+source "${DIR}/../../hack/detect_cri.sh"
+export CRI_BIN=${CRI_BIN:-$(detect_cri)}
+
+${CRI_BIN} build --build-arg BUILDARCH=$(uname -m) --build-arg CENTOS_VERSION=$CENTOS_VERSION . -t quay.io/kubevirtci/centos10

--- a/cluster-provision/centos10/scripts/download_box.sh
+++ b/cluster-provision/centos10/scripts/download_box.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-set -o pipefail
-
-curl -L --fail $1 -o box.qcow2

--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -224,8 +224,7 @@ fi
 
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
-  qemu_system_cmd="qemu-system-s390x \
-    -enable-kvm \
+  qemu_system_cmd="/usr/libexec/qemu-kvm \
     -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
     -device virtio-blk,drive=drive1,bootindex=1 \
     ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \
@@ -246,8 +245,7 @@ if [ "$(uname -m)" == "s390x" ]; then
     ${QEMU_ARGS}"
 else
   #Docs: https://www.qemu.org/docs/master/system/invocation.html
-  qemu_system_cmd="qemu-system-x86_64 \
-    -enable-kvm \
+  qemu_system_cmd="/usr/libexec/qemu-kvm \
     -drive format=qcow2,file=${next},if=none,id=bootdisk,cache=unsafe ${block_dev_drive_arg} \
     -device virtio-blk-pci,drive=bootdisk,bus=pcie.0 \
     ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk,bus=pcie.0} \
@@ -269,7 +267,8 @@ else
     ${SERIAL_ARG} \
     -machine q35,accel=kvm,kernel_irqchip=split \
     -device intel-iommu,intremap=on,caching-mode=on \
-    -device intel-hda,bus=pcie.0 -device hda-duplex -device AC97,bus=pcie.0 \
+    -device intel-hda,id=sound0,bus=pcie.0 -device hda-duplex,bus=sound0.0 \
+    -device ich9-intel-hda,id=sound1,bus=pcie.0 -device hda-duplex,bus=sound1.0 \
     -uuid $(cat /proc/sys/kernel/random/uuid) \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
     ${QEMU_ARGS}"

--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -1,30 +1,39 @@
-FROM registry.fedoraproject.org/fedora:44 AS base
+FROM quay.io/centos/centos:stream9 AS base
 
-RUN dnf -y install jq iptables iproute dnsmasq qemu socat openssh-clients screen bind-utils tcpdump iputils libguestfs-tools-c && dnf clean all
+RUN dnf -y install epel-release
 
+RUN dnf -y install \
+    bind-utils \
+    dnsmasq \
+    guestfs-tools \
+    jq \
+    iproute \
+    iptables \
+    iputils \
+    openssh-clients \
+    screen \
+    socat \
+    tcpdump \
+    qemu-kvm-core && \
+    dnf clean all
 
 FROM base AS imageartifactdownload
 
-ARG BUILDARCH
-
-ARG centos_version
+ARG BUILDARCH=x86_64
+ARG CENTOS_VERSION
 
 WORKDIR /
 
-RUN echo "Centos9 version $centos_version"
-
-COPY scripts/download_box.sh /
-
-RUN  /download_box.sh https://cloud.centos.org/centos/9-stream/$BUILDARCH/images/CentOS-Stream-GenericCloud-9-$centos_version.$BUILDARCH.qcow2 && \
+RUN echo "CentOS Stream 9 version $CENTOS_VERSION" && \
+    curl --fail-with-body --retry 2 -LR -o box.qcow2 https://cloud.centos.org/centos/9-stream/$BUILDARCH/images/CentOS-Stream-GenericCloud-9-$CENTOS_VERSION.$BUILDARCH.qcow2 && \
     # Access virtual machine disk images directly by using LIBGUESTFS_BACKEND=direct, instead of libvirt
     export LIBGUESTFS_BACKEND=direct && \
-    guestfish --ro --add box.qcow2 --mount /dev/sda1:/ ls /boot/ | grep -E '^vmlinuz-|^initramfs-' | xargs -I {} guestfish --ro --add box.qcow2 -i copy-out /boot/{} / ; 
-
+    guestfish --ro --add box.qcow2 --mount /dev/sda1:/ ls /boot/ | grep -E '^vmlinuz-|^initramfs-' | xargs -I {} guestfish --ro --add box.qcow2 -i copy-out /boot/{} / ;
 
 FROM base AS nodecontainer
 
 ARG BUILDARCH
-       
+
 WORKDIR /
 
 COPY vagrant.key /vagrant.key

--- a/cluster-provision/centos9/build.sh
+++ b/cluster-provision/centos9/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-centos_version="$(cat $DIR/version | tr -d '\n')"
+CENTOS_VERSION="$(cat $DIR/version)"
 
 source "${DIR}/../../hack/detect_cri.sh"
 export CRI_BIN=${CRI_BIN:-$(detect_cri)}
 
-${CRI_BIN} build --build-arg BUILDARCH=$(uname -m) --build-arg centos_version=$centos_version . -t quay.io/kubevirtci/centos9
+${CRI_BIN} build --build-arg BUILDARCH=$(uname -m) --build-arg CENTOS_VERSION=$CENTOS_VERSION . -t quay.io/kubevirtci/centos9

--- a/cluster-provision/centos9/scripts/download_box.sh
+++ b/cluster-provision/centos9/scripts/download_box.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-set -o pipefail
-
-curl -L --fail $1 -o box.qcow2

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -224,8 +224,7 @@ fi
 
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
-  qemu_system_cmd="qemu-system-s390x \
-    -enable-kvm \
+  qemu_system_cmd="/usr/libexec/qemu-kvm \
     -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
     -device virtio-blk,drive=drive1,bootindex=1 \
     ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \
@@ -246,8 +245,7 @@ if [ "$(uname -m)" == "s390x" ]; then
     ${QEMU_ARGS}"
 else
   #Docs: https://www.qemu.org/docs/master/system/invocation.html
-  qemu_system_cmd="qemu-system-x86_64 \
-    -enable-kvm \
+  qemu_system_cmd="/usr/libexec/qemu-kvm \
     -drive format=qcow2,file=${next},if=none,id=bootdisk,cache=unsafe ${block_dev_drive_arg} \
     -device virtio-blk-pci,drive=bootdisk,bus=pcie.0 \
     ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk,bus=pcie.0} \
@@ -269,7 +267,8 @@ else
     ${SERIAL_ARG} \
     -machine q35,accel=kvm,kernel_irqchip=split \
     -device intel-iommu,intremap=on,caching-mode=on \
-    -device intel-hda,bus=pcie.0 -device hda-duplex -device AC97,bus=pcie.0 \
+    -device intel-hda,id=sound0,bus=pcie.0 -device hda-duplex,bus=sound0.0 \
+    -device ich9-intel-hda,id=sound1,bus=pcie.0 -device hda-duplex,bus=sound1.0 \
     -uuid $(cat /proc/sys/kernel/random/uuid) \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
     ${QEMU_ARGS}"

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -89,7 +89,15 @@ EOF
 	secondaryNicRootPortBaseChass = 10
 )
 
-var soundcardPCIIDs = []string{"8086:2668", "8086:2415"}
+var soundcardPCIIDs = []string{
+	// Intel 82801AA AC97 Audio (aka -device AC97)
+	// Not enabled in CentOS builds of QEMU
+	//"8086:2415",
+	// Intel HD Audio Controller (ich6) (aka -device intel-hda)
+	"8086:2668",
+	// Intel HD Audio Controller (ich9) (aka -device ich9-intel-hda)
+	"8086:293e",
+}
 var cli *client.Client
 var nvmeDisks []string
 var scsiDisks []string

--- a/cluster-provision/gocli/cmd/run_test.go
+++ b/cluster-provision/gocli/cmd/run_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Node Provisioning", func() {
 
 			etcdinmemory.AddExpectCalls(sshClient, "1G")
 			bindvfio.AddExpectCalls(sshClient, "8086:2668")
-			bindvfio.AddExpectCalls(sshClient, "8086:2415")
+			bindvfio.AddExpectCalls(sshClient, "8086:293e")
 			psa.AddExpectCalls(sshClient)
 			node01.AddExpectCalls(sshClient)
 

--- a/cluster-provision/k8s/base-image
+++ b/cluster-provision/k8s/base-image
@@ -1,1 +1,1 @@
-quay.io/kubevirtci/centos9:2607211236-09226d87
+quay.io/kubevirtci/centos9:2607251400-4c030dd1

--- a/cluster-provision/k8s/base-image-centos10
+++ b/cluster-provision/k8s/base-image-centos10
@@ -1,1 +1,1 @@
-quay.io/kubevirtci/centos10:2607221053-1bcf61e4
+quay.io/kubevirtci/centos10:2607251400-4c030dd1


### PR DESCRIPTION
**What this PR does / why we need it**:

This helps to bring the user space (QEMU running in a container) closer to the kernel space (RHCOS 9) provided by CI nodes (bare-metal).

Sensible applications sush as QEMU encounter problems if the versions diverge too much.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1783