### PR TITLE
fix(cluster-provision): switch qemu runner to Fedora 43

### DIFF
--- a/cluster-provision/centos10/Dockerfile
+++ b/cluster-provision/centos10/Dockerfile
@@ -1,6 +1,4 @@
-FROM quay.io/centos/centos:stream9 AS base
-
-RUN dnf -y install epel-release
+FROM registry.fedoraproject.org/fedora:43 AS base
 
 RUN dnf -y install \
     bind-utils \

--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -58,7 +58,7 @@ n="$(printf "%02d" $(( 10#${NODE_NUM} )))"
 cat >/usr/local/bin/ssh.sh <<EOL
 #!/bin/bash
 set -e
-dockerize -wait tcp://192.168.66.1${n}:22 -timeout 300s &>/dev/null
+dockerize -wait tcp://192.168.66.1${n}:22 -timeout 120s &>/dev/null
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${VM_USER}@192.168.66.1${n} -i ${VM_USER_SSH_KEY} -p 22 -q \$@
 EOL
 chmod u+x /usr/local/bin/ssh.sh
@@ -216,15 +216,9 @@ if [ "${NUMA}" -gt 1 ]; then
     done
 fi
 
-if [ -n "${PROW_JOB_ID:-}" ] || [ "${CI:-}" = "true" ]; then
-  SERIAL_ARG="-serial file:/dev/stderr"
-else
-  SERIAL_ARG="-serial pty"
-fi
-
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
-  qemu_system_cmd="/usr/libexec/qemu-kvm \
+  qemu_system_cmd="/usr/bin/qemu-kvm \
     -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
     -device virtio-blk,drive=drive1,bootindex=1 \
     ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \
@@ -238,14 +232,14 @@ if [ "$(uname -m)" == "s390x" ]; then
     -cpu host \
     -m ${MEMORY} \
     -smp ${CPU} ${numa_arg} \
-    ${SERIAL_ARG} \
+    -serial pty \
     -machine s390-ccw-virtio,accel=kvm \
     -uuid $(cat /proc/sys/kernel/random/uuid) \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
     ${QEMU_ARGS}"
 else
   #Docs: https://www.qemu.org/docs/master/system/invocation.html
-  qemu_system_cmd="/usr/libexec/qemu-kvm \
+  qemu_system_cmd="/usr/bin/qemu-kvm \
     -drive format=qcow2,file=${next},if=none,id=bootdisk,cache=unsafe ${block_dev_drive_arg} \
     -device virtio-blk-pci,drive=bootdisk,bus=pcie.0 \
     ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk,bus=pcie.0} \
@@ -264,9 +258,10 @@ else
     -cpu host,migratable=no,+invtsc \
     -m ${MEMORY} \
     -smp ${CPU} ${numa_arg} \
-    ${SERIAL_ARG} \
+    -serial pty \
     -machine q35,accel=kvm,kernel_irqchip=split \
     -device intel-iommu,intremap=on,caching-mode=on \
+    -device AC97,bus=pcie.0 \
     -device intel-hda,id=sound0,bus=pcie.0 -device hda-duplex,bus=sound0.0 \
     -device ich9-intel-hda,id=sound1,bus=pcie.0 -device hda-duplex,bus=sound1.0 \
     -uuid $(cat /proc/sys/kernel/random/uuid) \

--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -1,6 +1,4 @@
-FROM quay.io/centos/centos:stream9 AS base
-
-RUN dnf -y install epel-release
+FROM registry.fedoraproject.org/fedora:43 AS base
 
 RUN dnf -y install \
     bind-utils \

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -58,7 +58,7 @@ n="$(printf "%02d" $(( 10#${NODE_NUM} )))"
 cat >/usr/local/bin/ssh.sh <<EOL
 #!/bin/bash
 set -e
-dockerize -wait tcp://192.168.66.1${n}:22 -timeout 300s &>/dev/null
+dockerize -wait tcp://192.168.66.1${n}:22 -timeout 120s &>/dev/null
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${VM_USER}@192.168.66.1${n} -i ${VM_USER_SSH_KEY} -p 22 -q \$@
 EOL
 chmod u+x /usr/local/bin/ssh.sh
@@ -216,15 +216,9 @@ if [ "${NUMA}" -gt 1 ]; then
     done
 fi
 
-if [ -n "${PROW_JOB_ID:-}" ] || [ "${CI:-}" = "true" ]; then
-  SERIAL_ARG="-serial file:/dev/stderr"
-else
-  SERIAL_ARG="-serial pty"
-fi
-
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
-  qemu_system_cmd="/usr/libexec/qemu-kvm \
+  qemu_system_cmd="/usr/bin/qemu-kvm \
     -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
     -device virtio-blk,drive=drive1,bootindex=1 \
     ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \
@@ -238,14 +232,14 @@ if [ "$(uname -m)" == "s390x" ]; then
     -cpu host \
     -m ${MEMORY} \
     -smp ${CPU} ${numa_arg} \
-    ${SERIAL_ARG} \
+    -serial pty \
     -machine s390-ccw-virtio,accel=kvm \
     -uuid $(cat /proc/sys/kernel/random/uuid) \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
     ${QEMU_ARGS}"
 else
   #Docs: https://www.qemu.org/docs/master/system/invocation.html
-  qemu_system_cmd="/usr/libexec/qemu-kvm \
+  qemu_system_cmd="/usr/bin/qemu-kvm \
     -drive format=qcow2,file=${next},if=none,id=bootdisk,cache=unsafe ${block_dev_drive_arg} \
     -device virtio-blk-pci,drive=bootdisk,bus=pcie.0 \
     ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk,bus=pcie.0} \
@@ -264,9 +258,10 @@ else
     -cpu host,migratable=no,+invtsc \
     -m ${MEMORY} \
     -smp ${CPU} ${numa_arg} \
-    ${SERIAL_ARG} \
+    -serial pty \
     -machine q35,accel=kvm,kernel_irqchip=split \
     -device intel-iommu,intremap=on,caching-mode=on \
+    -device AC97,bus=pcie.0 \
     -device intel-hda,id=sound0,bus=pcie.0 -device hda-duplex,bus=sound0.0 \
     -device ich9-intel-hda,id=sound1,bus=pcie.0 -device hda-duplex,bus=sound1.0 \
     -uuid $(cat /proc/sys/kernel/random/uuid) \

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -89,10 +89,12 @@ EOF
 	secondaryNicRootPortBaseChass = 10
 )
 
+// Required PCI ids are hardcoded in KubeVirt e2e tests:
+// - https://github.com/kubevirt/kubevirt/blob/720b695b/tests/vmi_hostdev_test.go#L112
 var soundcardPCIIDs = []string{
 	// Intel 82801AA AC97 Audio (aka -device AC97)
 	// Not enabled in CentOS builds of QEMU
-	//"8086:2415",
+	"8086:2415",
 	// Intel HD Audio Controller (ich6) (aka -device intel-hda)
 	"8086:2668",
 	// Intel HD Audio Controller (ich9) (aka -device ich9-intel-hda)
@@ -1117,7 +1119,7 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 func waitForVMToBeUp(cli *client.Client, prefix string, nodeName string) error {
 	logContainerDiagnostics(cli, prefix, nodeName, "pre-ssh")
 	var err error
-	for x := 0; x < 10; x++ {
+	for x := 0; x < 5; x++ {
 		err = _cmd(cli, nodeContainer(prefix, nodeName), "ssh.sh echo VM is up", "waiting for node to come up")
 		if err == nil {
 			break

--- a/cluster-provision/gocli/cmd/run_test.go
+++ b/cluster-provision/gocli/cmd/run_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Node Provisioning", func() {
 			n := nodesconfig.NewNodeLinuxConfig(1, "k8s-1.30", linuxConfigFuncs)
 
 			etcdinmemory.AddExpectCalls(sshClient, "1G")
+			bindvfio.AddExpectCalls(sshClient, "8086:2415")
 			bindvfio.AddExpectCalls(sshClient, "8086:2668")
 			bindvfio.AddExpectCalls(sshClient, "8086:293e")
 			psa.AddExpectCalls(sshClient)

--- a/cluster-provision/k8s/base-image
+++ b/cluster-provision/k8s/base-image
@@ -1,1 +1,1 @@
-quay.io/kubevirtci/centos9:2607280400-d9d21bba
+quay.io/kubevirtci/centos9:2607281400-d9d21bba

--- a/cluster-provision/k8s/base-image-centos10
+++ b/cluster-provision/k8s/base-image-centos10
@@ -1,1 +1,1 @@
-quay.io/kubevirtci/centos10:2607251400-4c030dd1
+quay.io/kubevirtci/centos10:2607281400-d9d21bba


### PR DESCRIPTION
**What this PR does / why we need it**:

This change upgrades QEMU from qemu-kvm-10.1.0-22.el9 [[1]] to the version qemu-10.1.5-1.fc43 [[2]] which includes a fix which might be required for proper SR-IOV support with emulated IGB devices [[3]].

[1]: https://kojihub.stream.centos.org/koji/buildinfo?buildID=116389
[2]: https://koji.fedoraproject.org/koji/buildinfo?buildID=2965689
[3]: https://gitlab.com/qemu-project/qemu/-/commit/c3ae83117dfb198eae7f8afe8609e69674732cdb

Audio device AC97 is also restored because it is required by KubeVirt e2e tests [[4]]. The additional ICH 9 sound card is preserved so that it will be easier to transition KubeVirt e2e tests to use the latter.

[4]: https://github.com/kubevirt/kubevirt/blob/720b695b/tests/vmi_hostdev_test.go#L112

It also reverts a few changes which were made during previous investigation of the issue and are not relevant anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1783

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl