### PR TITLE
refactor: use -w flag and quote pwd expansions

### DIFF
--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -40,7 +40,7 @@ if [ ! -f alpine-make-vm-image ]; then
     chmod 755 alpine-make-vm-image
 fi
 
-podman run --rm -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v $(pwd):$(pwd):z alpine ash -c "cd $(pwd) &&
+podman run --rm -v /lib/modules:/lib/modules -v /dev:/dev --privileged -v "${PWD}":"${PWD}":z -w "${PWD}" alpine ash -c "
 ./alpine-make-vm-image \
     --image-format qcow2 \
     --image-size $IMAGE_SIZE \


### PR DESCRIPTION
Replace `cd $(pwd)` with podman's -w flag and properly quote all `${PWD} `expansions to handle paths with spaces safely.

Assisted-by: IBM Bob

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
