### PR TITLE
fix(cluster-provision): use correct qemu path for s390x

### DIFF
--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -218,7 +218,8 @@ fi
 
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
-  qemu_system_cmd="/usr/bin/qemu-kvm \
+  qemu_system_cmd="qemu-system-s390x \
+    -enable-kvm \
     -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
     -device virtio-blk,drive=drive1,bootindex=1 \
     ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -218,7 +218,8 @@ fi
 
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
-  qemu_system_cmd="/usr/bin/qemu-kvm \
+  qemu_system_cmd="qemu-system-s390x \
+    -enable-kvm \
     -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
     -device virtio-blk,drive=drive1,bootindex=1 \
     ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems fedora builds of QEMU for s390x don't provide the symlink /usr/bin/qemu-kvm -> /usr/bin/qemu-system-$arch unlike x86_64.

**Special notes for your reviewer**:

/cc @chandramerla @dhiller