### PR TITLE
chore(cluster-provision): remove legacy AC97 audio device

### DIFF
--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -262,7 +262,6 @@ else
     -serial pty \
     -machine q35,accel=kvm,kernel_irqchip=split \
     -device intel-iommu,intremap=on,caching-mode=on \
-    -device AC97,bus=pcie.0 \
     -device intel-hda,id=sound0,bus=pcie.0 -device hda-duplex,bus=sound0.0 \
     -device ich9-intel-hda,id=sound1,bus=pcie.0 -device hda-duplex,bus=sound1.0 \
     -uuid $(cat /proc/sys/kernel/random/uuid) \

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -262,7 +262,6 @@ else
     -serial pty \
     -machine q35,accel=kvm,kernel_irqchip=split \
     -device intel-iommu,intremap=on,caching-mode=on \
-    -device AC97,bus=pcie.0 \
     -device intel-hda,id=sound0,bus=pcie.0 -device hda-duplex,bus=sound0.0 \
     -device ich9-intel-hda,id=sound1,bus=pcie.0 -device hda-duplex,bus=sound1.0 \
     -uuid $(cat /proc/sys/kernel/random/uuid) \

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -88,11 +88,8 @@ EOF
 )
 
 // Required PCI ids are hardcoded in KubeVirt e2e tests:
-// - https://github.com/kubevirt/kubevirt/blob/720b695b/tests/vmi_hostdev_test.go#L112
+// - https://github.com/kubevirt/kubevirt/blob/39b1c5f9/tests/vmi_hostdev_test.go#L70-L79
 var soundcardPCIIDs = []string{
-	// Intel 82801AA AC97 Audio (aka -device AC97)
-	// Not enabled in CentOS builds of QEMU
-	"8086:2415",
 	// Intel HD Audio Controller (ich6) (aka -device intel-hda)
 	"8086:2668",
 	// Intel HD Audio Controller (ich9) (aka -device ich9-intel-hda)

--- a/cluster-provision/gocli/cmd/run_test.go
+++ b/cluster-provision/gocli/cmd/run_test.go
@@ -54,7 +54,6 @@ var _ = Describe("Node Provisioning", func() {
 			n := nodesconfig.NewNodeLinuxConfig(1, "k8s-1.30", linuxConfigFuncs)
 
 			etcdinmemory.AddExpectCalls(sshClient, "1G")
-			bindvfio.AddExpectCalls(sshClient, "8086:2415")
 			bindvfio.AddExpectCalls(sshClient, "8086:2668")
 			bindvfio.AddExpectCalls(sshClient, "8086:293e")
 			psa.AddExpectCalls(sshClient)


### PR DESCRIPTION
**What this PR does / why we need it**:

AC97 device is not enabled in CentOS builds of QEMU and KubeVirt tests have been updated to use the ICH9 device instead [\[1\]].

[\[1\]]: https://github.com/kubevirt/kubevirt/pull/18630

**Special notes for your reviewer**:

/cc @dhiller