### PR TITLE
fix: replace hardcoded podman with ${CRI_BIN} in publish.sh

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -89,9 +89,9 @@ function push_node_base_image() {
   else
     TARGET_IMAGE="${TARGET_REPO}/centos${CENTOS_VERSION}:${KUBEVIRTCI_TAG}-${ARCH}"
   fi
-  podman tag ${TARGET_REPO}/centos${CENTOS_VERSION}-base:latest ${TARGET_IMAGE}
+  ${CRI_BIN} tag ${TARGET_REPO}/centos${CENTOS_VERSION}-base:latest ${TARGET_IMAGE}
   echo "INFO: push $TARGET_IMAGE"
-  podman push ${TARGET_IMAGE}
+  ${CRI_BIN} push ${TARGET_IMAGE}
 }
 
 function push_cluster_images() {
@@ -99,14 +99,14 @@ function push_cluster_images() {
     if [ $ARCH == "amd64" ]; then
       echo "INFO: push $i"
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
-      podman push "$TARGET_IMAGE"
+      ${CRI_BIN} push "$TARGET_IMAGE"
 
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
-      podman push "$TARGET_IMAGE"
+      ${CRI_BIN} push "$TARGET_IMAGE"
     elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
       echo "INFO: push $i slim"
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
-      podman push "$TARGET_IMAGE"
+      ${CRI_BIN} push "$TARGET_IMAGE"
     fi
   done
 
@@ -131,7 +131,7 @@ function push_gocli() {
   else
     TARGET_IMAGE="${TARGET_REPO}/gocli:${KUBEVIRTCI_TAG}-${ARCH}"
   fi
-  podman push "$TARGET_IMAGE"
+  ${CRI_BIN} push "$TARGET_IMAGE"
 }
 
 function publish_node_base_image() {
@@ -173,8 +173,8 @@ publish_manifest() {
       amend+=" --amend ${target_image_repo}/${image_name}:${image_tag}-${arch}"
     fi
   done
-  podman manifest create ${full_image_name} ${amend}
-  podman manifest push ${full_image_name} "docker://${full_image_name}"
+  ${CRI_BIN} manifest create ${full_image_name} ${amend}
+  ${CRI_BIN} manifest push ${full_image_name} "docker://${full_image_name}"
 
 }
 


### PR DESCRIPTION
All push, tag, and manifest operations were hardcoded to use podman, causing failures when the detected or user-specified CRI is docker. Replace every podman call with ${CRI_BIN} so the script consistently uses whichever runtime detect_cri.sh resolves.

Assisted-by: IBM Bob

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
