### PR TITLE
feat: make target registry configurable via TARGET_REPO

### DIFF
--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -59,6 +59,10 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		// default to Centos Stream 9
 		centosVersion = "9"
 	}
+	imageRepo := os.Getenv("TARGET_REPO")
+	if imageRepo == "" {
+		imageRepo = "quay.io/kubevirtci"
+	}
 
 	centosScriptsPath := filepath.Join(packagePath, "..", "..", fmt.Sprintf("centos%s", centosVersion), "scripts")
 
@@ -74,7 +78,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	if strings.Contains(phases, "linux") {
-		base = fmt.Sprintf("quay.io/kubevirtci/centos%s", centosVersion)
+		base = fmt.Sprintf("%s/centos%s", imageRepo, centosVersion)
 	} else {
 		k8sPath := fmt.Sprintf("%s/../", packagePath)
 		// Select base-image file based on PROVISION_CENTOS_VERSION
@@ -98,7 +102,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		name = fmt.Sprintf("%s-%s", name, containerSuffix)
 	}
 	prefix := fmt.Sprintf("k8s-%s-provision", name)
-	target := fmt.Sprintf("quay.io/kubevirtci/k8s-%s", name)
+	target := fmt.Sprintf("%s/k8s-%s", imageRepo, name)
 	scripts := filepath.Join(packagePath)
 
 	if phases == "linux" {

--- a/cluster-provision/gocli/cmd/provision.go
+++ b/cluster-provision/gocli/cmd/provision.go
@@ -46,6 +46,7 @@ func NewProvisionCommand() *cobra.Command {
 	provision.Flags().String("container-suffix", "", "use additional suffix for the provisioned container image")
 	provision.Flags().String("phases", "linux,k8s", "phases to run, possible values: linux,k8s linux k8s")
 	provision.Flags().StringArray("additional-persistent-kernel-arguments", []string{}, "additional persistent kernel arguments applied after provision")
+	provision.Flags().String("image-repo", "quay.io/kubevirtci", "the registry to publish the images to")
 
 	return provision
 }
@@ -63,6 +64,10 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		baseName := strings.TrimSpace(string(baseBytes))
 		centosVersion = strings.TrimPrefix(baseName, "centos")
 	}
+	imageRepo, err := cmd.Flags().GetString("image-repo")
+	if err != nil {
+		return err
+	}
 
 	centosScriptsPath := filepath.Join(packagePath, "..", "..", fmt.Sprintf("centos%s", centosVersion), "scripts")
 
@@ -78,7 +83,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	if strings.Contains(phases, "linux") {
-		base = fmt.Sprintf("quay.io/kubevirtci/centos%s", centosVersion)
+		base = fmt.Sprintf("%s/centos%s", imageRepo, centosVersion)
 	} else {
 		k8sPath := fmt.Sprintf("%s/../", packagePath)
 		// Select base-image file based on PROVISION_CENTOS_VERSION
@@ -102,7 +107,7 @@ func provisionCluster(cmd *cobra.Command, args []string) (retErr error) {
 		name = fmt.Sprintf("%s-%s", name, containerSuffix)
 	}
 	prefix := fmt.Sprintf("k8s-%s-provision", name)
-	target := fmt.Sprintf("quay.io/kubevirtci/k8s-%s", name)
+	target := fmt.Sprintf("%s/k8s-%s", imageRepo, name)
 	scripts := filepath.Join(packagePath)
 
 	if phases == "linux" {

--- a/publish.sh
+++ b/publish.sh
@@ -16,7 +16,8 @@ PHASES=${PHASES:-k8s}
 
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET_REPO="quay.io/kubevirtci"
+export TARGET_REPO="${TARGET_REPO:-quay.io/kubevirtci}"
+SOURCE_REPO="quay.io/kubevirtci"
 TARGET_KUBEVIRT_REPO="quay.io/kubevirt"
 TARGET_GIT_REMOTE="https://kubevirt-bot@github.com/kubevirt/kubevirtci.git"
 
@@ -34,7 +35,7 @@ function run_provision_manager() {
       return
   fi
 
-  json_result=$(${CRI_BIN} run --rm -v $(pwd):/workdir:Z quay.io/kubevirtci/gocli provision-manager)
+  json_result=$(${CRI_BIN} run --rm -v $(pwd):/workdir:Z ${TARGET_REPO}/gocli provision-manager)
   echo "INFO: Provision manager results: $json_result"
 
   while IFS=":" read key value; do
@@ -50,7 +51,7 @@ function run_provision_manager() {
 }
 
 function build_gocli() {
-  (cd cluster-provision/gocli && make container)
+  (cd cluster-provision/gocli && make container KUBEVIRTCI_IMAGE_REPO="${TARGET_REPO}")
   if [ $ARCH == "amd64" ]; then
     ${CRI_BIN} tag ${TARGET_REPO}/gocli ${TARGET_REPO}/gocli:${KUBEVIRTCI_TAG}
   else
@@ -114,12 +115,12 @@ function push_cluster_images() {
   for i in ${IMAGES_TO_RETAG[@]}; do
     if [ $ARCH == "amd64" ]; then
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG)"
-      skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
+      skopeo copy "docker://${SOURCE_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim)"
-      skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
+      skopeo copy "docker://${SOURCE_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
     elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim-$ARCH)"
-      skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim-${ARCH}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
+      skopeo copy "docker://${SOURCE_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim-${ARCH}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
     fi
   done
 }

--- a/publish.sh
+++ b/publish.sh
@@ -16,7 +16,11 @@ PHASES=${PHASES:-k8s}
 
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET_REPO="quay.io/kubevirtci"
+# TARGET_REPO is the destination for this publication. SOURCE_REPO is the
+# canonical repository holding images from the previous release; unchanged
+# providers are copied from it into TARGET_REPO under the new tag.
+TARGET_REPO="${TARGET_REPO:-quay.io/kubevirtci}"
+SOURCE_REPO="quay.io/kubevirtci"
 TARGET_KUBEVIRT_REPO="quay.io/kubevirt"
 TARGET_GIT_REMOTE="https://kubevirt-bot@github.com/kubevirt/kubevirtci.git"
 
@@ -34,7 +38,7 @@ function run_provision_manager() {
       return
   fi
 
-  json_result=$(${CRI_BIN} run --rm -v $(pwd):/workdir:Z quay.io/kubevirtci/gocli provision-manager)
+  json_result=$(${CRI_BIN} run --rm -v $(pwd):/workdir:Z ${TARGET_REPO}/gocli provision-manager)
   echo "INFO: Provision manager results: $json_result"
 
   while IFS=":" read key value; do
@@ -50,7 +54,7 @@ function run_provision_manager() {
 }
 
 function build_gocli() {
-  (cd cluster-provision/gocli && make container)
+  (cd cluster-provision/gocli && make container KUBEVIRTCI_IMAGE_REPO="${TARGET_REPO}")
   if [ $ARCH == "amd64" ]; then
     ${CRI_BIN} tag ${TARGET_REPO}/gocli ${TARGET_REPO}/gocli:${KUBEVIRTCI_TAG}
   fi
@@ -71,14 +75,14 @@ function build_clusters() {
   for i in "${IMAGES_TO_BUILD[@]}"; do
     if [ $ARCH == "amd64" ]; then
       echo "INFO: building $i"
-      cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i
+      cluster-provision/gocli/build/cli provision --phases k8s --image-repo ${TARGET_REPO} cluster-provision/k8s/$i
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}
 
-      cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i --slim
+      cluster-provision/gocli/build/cli provision --phases k8s --image-repo ${TARGET_REPO} cluster-provision/k8s/$i --slim
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim
     elif [[ "$ARCH" == "s390x" ]]; then
       echo "INFO: building $i slim"
-      cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i --slim
+      cluster-provision/gocli/build/cli provision --phases k8s --image-repo ${TARGET_REPO} cluster-provision/k8s/$i --slim
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}
     fi
   done
@@ -115,12 +119,12 @@ function push_cluster_images() {
   for i in ${IMAGES_TO_RETAG[@]}; do
     if [ $ARCH == "amd64" ]; then
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG)"
-      skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
+      skopeo copy "docker://${SOURCE_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim)"
-      skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
+      skopeo copy "docker://${SOURCE_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
     elif [[ "$ARCH" == "s390x" ]]; then
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim-$ARCH)"
-      skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim-${ARCH}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
+      skopeo copy "docker://${SOURCE_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim-${ARCH}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
     fi
   done
 }


### PR DESCRIPTION
TARGET_REPO was hardcoded to quay.io/kubevirtci in publish.sh,
silently overwriting any user-exported value. Similarly,
provision.go hardcoded the commit target as
quay.io/kubevirtci/k8s-<version>.

Assisted-by: IBM Bob

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
