### PR TITLE
ppc64le: add ppc64le architecture support (VEP-265)

### DIFF
--- a/cluster-provision/centos10/Dockerfile
+++ b/cluster-provision/centos10/Dockerfile
@@ -40,10 +40,12 @@ RUN chmod 700 vagrant.key
 
 ENV DOCKERIZE_VERSION=v0.8.0
 
-RUN if test "$BUILDARCH" != "s390x"; then \
-      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
-    else \
+RUN if test "$BUILDARCH" = "s390x"; then \
       curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-s390x-$DOCKERIZE_VERSION.tar.gz; \
+    elif test "$BUILDARCH" = "ppc64le"; then \
+      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-ppc64le-$DOCKERIZE_VERSION.tar.gz; \
+    else \
+      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
     fi && \
     tar -xzvf dockerize-linux-$BUILDARCH.tar.gz && \
     rm dockerize-linux-$BUILDARCH.tar.gz && \

--- a/cluster-provision/centos10/Dockerfile
+++ b/cluster-provision/centos10/Dockerfile
@@ -43,11 +43,14 @@ RUN chmod 700 vagrant.key
 
 ENV DOCKERIZE_VERSION=v0.8.0
 
-RUN if test "$BUILDARCH" != "s390x"; then \
-      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
-    else \
-      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-s390x-$DOCKERIZE_VERSION.tar.gz; \
-    fi && \
+RUN case "$BUILDARCH" in \
+      s390x) \
+        curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-s390x-$DOCKERIZE_VERSION.tar.gz ;; \
+      ppc64le) \
+        curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-ppc64le-$DOCKERIZE_VERSION.tar.gz ;; \
+      *) \
+        curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz ;; \
+    esac && \
     tar -xzvf dockerize-linux-$BUILDARCH.tar.gz && \
     rm dockerize-linux-$BUILDARCH.tar.gz && \
     chmod u+x dockerize && \

--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -238,6 +238,27 @@ if [ "$(uname -m)" == "s390x" ]; then
     -uuid $(cat /proc/sys/kernel/random/uuid) \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
     ${QEMU_ARGS}"
+elif [ "$(uname -m)" == "ppc64le" ]; then
+  qemu_system_cmd="qemu-system-ppc64 \
+    -enable-kvm \
+    -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
+    -device virtio-blk-pci,drive=drive1,bootindex=1 \
+    ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk} \
+    -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n} \
+    -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
+    -device virtio-rng-pci \
+    -initrd /initrd.img \
+    -kernel /vmlinuz \
+    -append \"$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
+    -vnc :${n} \
+    -cpu host \
+    -m ${MEMORY} \
+    -smp ${CPU} ${numa_arg} \
+    -serial pty \
+    -machine pseries,accel=kvm \
+    -uuid $(cat /proc/sys/kernel/random/uuid) \
+    -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
+    ${QEMU_ARGS}"
 else
   #Docs: https://www.qemu.org/docs/master/system/invocation.html
   qemu_system_cmd="/usr/bin/qemu-kvm \

--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -217,58 +217,83 @@ if [ "${host_arch}" != "s390x" ] && [ "${NUMA}" != 0 ]; then
     done
 fi
 
-if [ "${host_arch}" == "s390x" ]; then
-  # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
-  qemu_system_cmd="qemu-system-s390x \
-    -enable-kvm \
-    -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
-    -device virtio-blk,drive=drive1,bootindex=1 \
-    ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \
-    -device virtio-net-ccw,netdev=network0,mac=52:55:00:d1:55:${n} \
-    -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
-    -device virtio-rng \
-    -initrd /initrd.img \
-    -kernel /vmlinuz \
-    -append \"$(cat /kernel.s390x.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
-    -vnc :${n} \
-    -cpu host \
-    -m ${MEMORY} \
-    -smp ${CPU} \
-    -serial pty \
-    -machine s390-ccw-virtio,accel=kvm \
-    -uuid $(cat /proc/sys/kernel/random/uuid) \
-    -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
-    ${QEMU_ARGS}"
-else
-  #Docs: https://www.qemu.org/docs/master/system/invocation.html
-  qemu_system_cmd="/usr/bin/qemu-kvm \
-    -drive format=qcow2,file=${next},if=none,id=bootdisk,cache=unsafe ${block_dev_drive_arg} \
-    -device virtio-blk-pci,drive=bootdisk,bus=pcie.0 \
-    ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk,bus=pcie.0} \
-    -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n},bus=pcie.0 \
-    -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
-    -device pxb-pcie,id=sriovpxb,bus=pcie.0,bus_nr=128${sriov_pxb_numa_arg} \
-    ${secondary_nic_pxb_args} \
-    -device pcie-root-port,id=sriovrp,slot=3,chassis=3,bus=sriovpxb \
-    -device igb,id=igb0,bus=sriovrp,netdev=sriovnet0,mac=52:55:00:d1:57:${n} \
-    -netdev tap,id=sriovnet0,ifname=tap-sriov${n},script=no,downscript=no \
-    -device virtio-rng-pci,bus=pcie.0 \
-    -initrd /initrd.img \
-    -kernel /vmlinuz \
-    -append \"$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
-    -vnc :${n} \
-    -cpu host,migratable=no,+invtsc \
-    -m ${MEMORY} \
-    -smp ${CPU} ${numa_arg} \
-    -serial pty \
-    -machine q35,accel=kvm,kernel_irqchip=split \
-    -device intel-iommu,intremap=on,caching-mode=on \
-    -device intel-hda,id=sound0,bus=pcie.0 -device hda-duplex,bus=sound0.0 \
-    -device ich9-intel-hda,id=sound1,bus=pcie.0 -device hda-duplex,bus=sound1.0 \
-    -uuid $(cat /proc/sys/kernel/random/uuid) \
-    -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
-    ${QEMU_ARGS}"
-fi
+case "$(uname -m)" in
+  s390x)
+    # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
+    qemu_system_cmd="qemu-system-s390x \
+      -enable-kvm \
+      -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
+      -device virtio-blk,drive=drive1,bootindex=1 \
+      ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \
+      -device virtio-net-ccw,netdev=network0,mac=52:55:00:d1:55:${n} \
+      -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
+      -device virtio-rng \
+      -initrd /initrd.img \
+      -kernel /vmlinuz \
+      -append \"$(cat /kernel.s390x.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
+      -vnc :${n} \
+      -cpu host \
+      -m ${MEMORY} \
+      -smp ${CPU} ${numa_arg} \
+      -serial pty \
+      -machine s390-ccw-virtio,accel=kvm \
+      -uuid $(cat /proc/sys/kernel/random/uuid) \
+      -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
+      ${QEMU_ARGS}"
+    ;;
+  ppc64le)
+    qemu_system_cmd="qemu-system-ppc64 \
+      -enable-kvm \
+      -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
+      -device virtio-blk-pci,drive=drive1,bootindex=1 \
+      ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk} \
+      -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n} \
+      -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
+      -device virtio-rng-pci \
+      -initrd /initrd.img \
+      -kernel /vmlinuz \
+      -append \"$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
+      -vnc :${n} \
+      -cpu host \
+      -m ${MEMORY} \
+      -smp ${CPU} ${numa_arg} \
+      -serial pty \
+      -machine pseries,accel=kvm \
+      -uuid $(cat /proc/sys/kernel/random/uuid) \
+      -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
+      ${QEMU_ARGS}"
+    ;;
+  *)
+    #Docs: https://www.qemu.org/docs/master/system/invocation.html
+    qemu_system_cmd="/usr/bin/qemu-kvm \
+      -drive format=qcow2,file=${next},if=none,id=bootdisk,cache=unsafe ${block_dev_drive_arg} \
+      -device virtio-blk-pci,drive=bootdisk,bus=pcie.0 \
+      ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk,bus=pcie.0} \
+      -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n},bus=pcie.0 \
+      -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
+      -device pxb-pcie,id=sriovpxb,bus=pcie.0,bus_nr=128${sriov_pxb_numa_arg} \
+      ${secondary_nic_pxb_args} \
+      -device pcie-root-port,id=sriovrp,slot=3,chassis=3,bus=sriovpxb \
+      -device igb,id=igb0,bus=sriovrp,netdev=sriovnet0,mac=52:55:00:d1:57:${n} \
+      -netdev tap,id=sriovnet0,ifname=tap-sriov${n},script=no,downscript=no \
+      -device virtio-rng-pci,bus=pcie.0 \
+      -initrd /initrd.img \
+      -kernel /vmlinuz \
+      -append \"$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
+      -vnc :${n} \
+      -cpu host,migratable=no,+invtsc \
+      -m ${MEMORY} \
+      -smp ${CPU} ${numa_arg} \
+      -serial pty \
+      -machine q35,accel=kvm,kernel_irqchip=split \
+      -device intel-iommu,intremap=on,caching-mode=on \
+      -device intel-hda,id=sound0,bus=pcie.0 -device hda-duplex,bus=sound0.0 \
+      -device ich9-intel-hda,id=sound1,bus=pcie.0 -device hda-duplex,bus=sound1.0 \
+      -uuid $(cat /proc/sys/kernel/random/uuid) \
+      -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
+      ${QEMU_ARGS}"
+    ;;
+esac
 
 PID=0
 eval "nohup $qemu_system_cmd &"

--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -40,10 +40,12 @@ RUN chmod 700 vagrant.key
 
 ENV DOCKERIZE_VERSION=v0.8.0
 
-RUN if test "$BUILDARCH" != "s390x"; then \
-      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
-    else \
+RUN if test "$BUILDARCH" = "s390x"; then \
       curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-s390x-$DOCKERIZE_VERSION.tar.gz; \
+    elif test "$BUILDARCH" = "ppc64le"; then \
+      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-ppc64le-$DOCKERIZE_VERSION.tar.gz; \
+    else \
+      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
     fi && \
     tar -xzvf dockerize-linux-$BUILDARCH.tar.gz && \
     rm dockerize-linux-$BUILDARCH.tar.gz && \

--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -43,11 +43,14 @@ RUN chmod 700 vagrant.key
 
 ENV DOCKERIZE_VERSION=v0.8.0
 
-RUN if test "$BUILDARCH" != "s390x"; then \
-      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
-    else \
-      curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-s390x-$DOCKERIZE_VERSION.tar.gz; \
-    fi && \
+RUN case "$BUILDARCH" in \
+      s390x) \
+        curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-s390x-$DOCKERIZE_VERSION.tar.gz ;; \
+      ppc64le) \
+        curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-ppc64le-$DOCKERIZE_VERSION.tar.gz ;; \
+      *) \
+        curl -L -o dockerize-linux-$BUILDARCH.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz ;; \
+    esac && \
     tar -xzvf dockerize-linux-$BUILDARCH.tar.gz && \
     rm dockerize-linux-$BUILDARCH.tar.gz && \
     chmod u+x dockerize && \

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -238,6 +238,27 @@ if [ "$(uname -m)" == "s390x" ]; then
     -uuid $(cat /proc/sys/kernel/random/uuid) \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
     ${QEMU_ARGS}"
+elif [ "$(uname -m)" == "ppc64le" ]; then
+  qemu_system_cmd="qemu-system-ppc64 \
+    -enable-kvm \
+    -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
+    -device virtio-blk-pci,drive=drive1,bootindex=1 \
+    ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk} \
+    -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n} \
+    -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
+    -device virtio-rng-pci \
+    -initrd /initrd.img \
+    -kernel /vmlinuz \
+    -append \"$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
+    -vnc :${n} \
+    -cpu host \
+    -m ${MEMORY} \
+    -smp ${CPU} ${numa_arg} \
+    -serial pty \
+    -machine pseries,accel=kvm \
+    -uuid $(cat /proc/sys/kernel/random/uuid) \
+    -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
+    ${QEMU_ARGS}"
 else
   #Docs: https://www.qemu.org/docs/master/system/invocation.html
   qemu_system_cmd="/usr/bin/qemu-kvm \

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -217,58 +217,83 @@ if [ "${host_arch}" != "s390x" ] && [ "${NUMA}" != 0 ]; then
     done
 fi
 
-if [ "${host_arch}" == "s390x" ]; then
-  # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
-  qemu_system_cmd="qemu-system-s390x \
-    -enable-kvm \
-    -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
-    -device virtio-blk,drive=drive1,bootindex=1 \
-    ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \
-    -device virtio-net-ccw,netdev=network0,mac=52:55:00:d1:55:${n} \
-    -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
-    -device virtio-rng \
-    -initrd /initrd.img \
-    -kernel /vmlinuz \
-    -append \"$(cat /kernel.s390x.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
-    -vnc :${n} \
-    -cpu host \
-    -m ${MEMORY} \
-    -smp ${CPU} \
-    -serial pty \
-    -machine s390-ccw-virtio,accel=kvm \
-    -uuid $(cat /proc/sys/kernel/random/uuid) \
-    -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
-    ${QEMU_ARGS}"
-else
-  #Docs: https://www.qemu.org/docs/master/system/invocation.html
-  qemu_system_cmd="/usr/bin/qemu-kvm \
-    -drive format=qcow2,file=${next},if=none,id=bootdisk,cache=unsafe ${block_dev_drive_arg} \
-    -device virtio-blk-pci,drive=bootdisk,bus=pcie.0 \
-    ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk,bus=pcie.0} \
-    -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n},bus=pcie.0 \
-    -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
-    -device pxb-pcie,id=sriovpxb,bus=pcie.0,bus_nr=128${sriov_pxb_numa_arg} \
-    ${secondary_nic_pxb_args} \
-    -device pcie-root-port,id=sriovrp,slot=3,chassis=3,bus=sriovpxb \
-    -device igb,id=igb0,bus=sriovrp,netdev=sriovnet0,mac=52:55:00:d1:57:${n} \
-    -netdev tap,id=sriovnet0,ifname=tap-sriov${n},script=no,downscript=no \
-    -device virtio-rng-pci,bus=pcie.0 \
-    -initrd /initrd.img \
-    -kernel /vmlinuz \
-    -append \"$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
-    -vnc :${n} \
-    -cpu host,migratable=no,+invtsc \
-    -m ${MEMORY} \
-    -smp ${CPU} ${numa_arg} \
-    -serial pty \
-    -machine q35,accel=kvm,kernel_irqchip=split \
-    -device intel-iommu,intremap=on,caching-mode=on \
-    -device intel-hda,id=sound0,bus=pcie.0 -device hda-duplex,bus=sound0.0 \
-    -device ich9-intel-hda,id=sound1,bus=pcie.0 -device hda-duplex,bus=sound1.0 \
-    -uuid $(cat /proc/sys/kernel/random/uuid) \
-    -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
-    ${QEMU_ARGS}"
-fi
+case "$(uname -m)" in
+  s390x)
+    # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
+    qemu_system_cmd="qemu-system-s390x \
+      -enable-kvm \
+      -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
+      -device virtio-blk,drive=drive1,bootindex=1 \
+      ${BLOCK_DEV:+ -device virtio-blk,drive=extdisk} \
+      -device virtio-net-ccw,netdev=network0,mac=52:55:00:d1:55:${n} \
+      -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
+      -device virtio-rng \
+      -initrd /initrd.img \
+      -kernel /vmlinuz \
+      -append \"$(cat /kernel.s390x.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
+      -vnc :${n} \
+      -cpu host \
+      -m ${MEMORY} \
+      -smp ${CPU} ${numa_arg} \
+      -serial pty \
+      -machine s390-ccw-virtio,accel=kvm \
+      -uuid $(cat /proc/sys/kernel/random/uuid) \
+      -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
+      ${QEMU_ARGS}"
+    ;;
+  ppc64le)
+    qemu_system_cmd="qemu-system-ppc64 \
+      -enable-kvm \
+      -drive format=qcow2,file=${next},if=none,cache=unsafe,id=drive1 ${block_dev_drive_arg} \
+      -device virtio-blk-pci,drive=drive1,bootindex=1 \
+      ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk} \
+      -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n} \
+      -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
+      -device virtio-rng-pci \
+      -initrd /initrd.img \
+      -kernel /vmlinuz \
+      -append \"$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
+      -vnc :${n} \
+      -cpu host \
+      -m ${MEMORY} \
+      -smp ${CPU} ${numa_arg} \
+      -serial pty \
+      -machine pseries,accel=kvm \
+      -uuid $(cat /proc/sys/kernel/random/uuid) \
+      -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
+      ${QEMU_ARGS}"
+    ;;
+  *)
+    #Docs: https://www.qemu.org/docs/master/system/invocation.html
+    qemu_system_cmd="/usr/bin/qemu-kvm \
+      -drive format=qcow2,file=${next},if=none,id=bootdisk,cache=unsafe ${block_dev_drive_arg} \
+      -device virtio-blk-pci,drive=bootdisk,bus=pcie.0 \
+      ${BLOCK_DEV:+ -device virtio-blk-pci,drive=extdisk,bus=pcie.0} \
+      -device virtio-net-pci,netdev=network0,mac=52:55:00:d1:55:${n},bus=pcie.0 \
+      -netdev tap,id=network0,ifname=tap${n},script=no,downscript=no \
+      -device pxb-pcie,id=sriovpxb,bus=pcie.0,bus_nr=128${sriov_pxb_numa_arg} \
+      ${secondary_nic_pxb_args} \
+      -device pcie-root-port,id=sriovrp,slot=3,chassis=3,bus=sriovpxb \
+      -device igb,id=igb0,bus=sriovrp,netdev=sriovnet0,mac=52:55:00:d1:57:${n} \
+      -netdev tap,id=sriovnet0,ifname=tap-sriov${n},script=no,downscript=no \
+      -device virtio-rng-pci,bus=pcie.0 \
+      -initrd /initrd.img \
+      -kernel /vmlinuz \
+      -append \"$(cat /kernel.args) $(cat /additional.kernel.args) ${KERNEL_ARGS}\" \
+      -vnc :${n} \
+      -cpu host,migratable=no,+invtsc \
+      -m ${MEMORY} \
+      -smp ${CPU} ${numa_arg} \
+      -serial pty \
+      -machine q35,accel=kvm,kernel_irqchip=split \
+      -device intel-iommu,intremap=on,caching-mode=on \
+      -device intel-hda,id=sound0,bus=pcie.0 -device hda-duplex,bus=sound0.0 \
+      -device ich9-intel-hda,id=sound1,bus=pcie.0 -device hda-duplex,bus=sound1.0 \
+      -uuid $(cat /proc/sys/kernel/random/uuid) \
+      -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
+      ${QEMU_ARGS}"
+    ;;
+esac
 
 PID=0
 eval "nohup $qemu_system_cmd &"

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -82,6 +82,7 @@ EOF
 	scsiDiskImagePrefix = "/scsi"
 	QEMU_DEVICE_S390X   = "virtio-net-ccw"
 	QEMU_DEVICE_X86_64  = "virtio-net-pci"
+	QEMU_DEVICE_PPC64LE = "virtio-net-pci"
 
 	secondaryNicRootPortBaseSlot  = 4
 	secondaryNicRootPortBaseChass = 10
@@ -1083,8 +1084,8 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 		opts = append(opts, realtimeOpt)
 	}
 
-	// sound cards are not supported on s390x.
-	if runtime.GOARCH != "s390x" {
+	// sound cards are not supported on s390x or ppc64le.
+	if runtime.GOARCH != "s390x" && runtime.GOARCH != "ppc64le" {
 		for _, s := range soundcardPCIIDs {
 			// move the VM sound cards to a vfio-pci driver to prepare for assignment
 			bvfio := bindvfio.NewBindVfioOpt(sshClient, s)
@@ -1231,9 +1232,12 @@ func getDevicePCIID(pciAddress string) (string, error) {
 }
 
 func getNetDeviceByArch() string {
-	if runtime.GOARCH == "s390x" {
+	switch runtime.GOARCH {
+	case "s390x":
 		return QEMU_DEVICE_S390X
-	} else {
+	case "ppc64le":
+		return QEMU_DEVICE_PPC64LE
+	default:
 		return QEMU_DEVICE_X86_64
 	}
 }

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -82,6 +82,7 @@ EOF
 	scsiDiskImagePrefix = "/scsi"
 	QEMU_DEVICE_S390X   = "virtio-net-ccw"
 	QEMU_DEVICE_X86_64  = "virtio-net-pci"
+	QEMU_DEVICE_PPC64LE = "virtio-net-pci"
 
 	secondaryNicRootPortBaseSlot  = 4
 	secondaryNicRootPortBaseChass = 10
@@ -1083,8 +1084,8 @@ func provisionNode(sshClient libssh.Client, n *nodesconfig.NodeLinuxConfig) erro
 		opts = append(opts, realtimeOpt)
 	}
 
-	// sound cards are not supported on s390x.
-	if runtime.GOARCH != "s390x" {
+	// sound cards are not supported on s390x or ppc64le.
+	if runtime.GOARCH != "s390x" && runtime.GOARCH != "ppc64le" {
 		for _, s := range soundcardPCIIDs {
 			// move the VM sound cards to a vfio-pci driver to prepare for assignment
 			bvfio := bindvfio.NewBindVfioOpt(sshClient, s)
@@ -1223,9 +1224,12 @@ func getDevicePCIID(pciAddress string) (string, error) {
 }
 
 func getNetDeviceByArch() string {
-	if runtime.GOARCH == "s390x" {
+	switch runtime.GOARCH {
+	case "s390x":
 		return QEMU_DEVICE_S390X
-	} else {
+	case "ppc64le":
+		return QEMU_DEVICE_PPC64LE
+	default:
 		return QEMU_DEVICE_X86_64
 	}
 }

--- a/cluster-provision/gocli/opts/nodes/nodes.go
+++ b/cluster-provision/gocli/opts/nodes/nodes.go
@@ -76,8 +76,8 @@ func (n *nodesProvisioner) Exec() error {
 	kubeletCpuManagerArgs := " --cpu-manager-policy=static --kube-reserved=cpu=500m --system-reserved=cpu=500m"
 	kubeletTopologyManagerArgs := ""
 	kubeletReservedSystemCPUsArgs := ""
-	if runtime.GOARCH == "s390x" {
-		// CPU Manager and related features are not yet supported on s390x.
+	if runtime.GOARCH == "s390x" || runtime.GOARCH == "ppc64le" {
+		// CPU Manager and related features are not yet supported on s390x or ppc64le.
 		kubeletCpuManagerArgs = ""
 	} else {
 		if n.topologyManagerPolicy != "" {

--- a/cluster-provision/images/kubevirt-testing/kernel-boot-container/Dockerfile.ppc64le-guestless-kernel
+++ b/cluster-provision/images/kubevirt-testing/kernel-boot-container/Dockerfile.ppc64le-guestless-kernel
@@ -1,0 +1,4 @@
+FROM scratch
+# Kernel built using http://www.linux-kvm.org/page/KVM-unit-tests
+ARG KERNEL_URL=https://storage.googleapis.com/builddeps/ppc64le/ppc64le-guestless-kernel.bin
+ADD --chmod=755 ${KERNEL_URL} /boot/kernel

--- a/cluster-provision/images/vm-image-builder/README.md
+++ b/cluster-provision/images/vm-image-builder/README.md
@@ -29,6 +29,9 @@ To cross build for the Arm64 image on AMD64 machines, the following RPM needs to
 To cross build for the s390x image on AMD64 machines, the following RPM needs to be installed:
 - qemu-system-s390x
 
+To cross build for the ppc64le image on AMD64 machines, the following RPM needs to be installed:
+- qemu-system-ppc64
+
 ## Quickstart: Build and publish an existing containerdisk
 
 Choose one of the configuration directories in this folder which you want to
@@ -56,7 +59,13 @@ To build for s390x, you need to set the following environment
 variable.
 ```
 export ARCHITECTURE=s390x
-``` 
+```
+
+To build for ppc64le, you need to set the following environment
+variable.
+```
+export ARCHITECTURE=ppc64le
+```
 
 To build the Virtual Machine without console output, only need to set the
 environment variable `CONSOLE`. This is useful when the build script is
@@ -72,11 +81,12 @@ instructions are distributed between the following three files:
 
 ```
 $ ls -l example/
-cloud-config    # cloud-init configuration for virt-customize
-image-url       # download URL of the base image
-image-url-arm64 # download URL of the base image for Arm64
-image-url-s390x # download URL of the base image for s390x
-os-variant      # operating system variant (for example fedora32)
+  cloud-config      # cloud-init configuration for virt-customize
+  image-url         # download URL of the base image
+  image-url-arm64   # download URL of the base image for Arm64
+  image-url-s390x   # download URL of the base image for s390x
+  image-url-ppc64le # download URL of the base image for ppc64le
+  os-variant        # operating system variant (for example fedora32)
 ```
 
 To create a completely new containerdisk, best copy the `example` folder and
@@ -102,8 +112,8 @@ $ virtctl console testvm1
 ```
 
 ### Build and publish multi-arch images
-The multi-arch publish does not support building alpine-cloud-init because the [alpine-make-vm-image](https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image) project does not support building Arm64 and s390x images.
-The `publish-multiarch-containerdisk.sh` script now supports building Arm64, AMD64 and s390x images.
+The multi-arch publish does not support building alpine-cloud-init because the [alpine-make-vm-image](https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image) project does not support building Arm64, s390x and ppc64le images natively on non-native hardware.
+The `publish-multiarch-containerdisk.sh` script now supports building Arm64, AMD64, s390x and ppc64le images.
 The script primarily performs the following tasks:
 1. Use `create-containerdisk.sh` to build images.
 2. Upload the resulting images to a specific registry.
@@ -125,9 +135,9 @@ The script primarily performs the following tasks:
 ./ publish-multiarch-containerdisk.sh example myregistry registry_org
 
 # The script will do following things:
-# 1. Build the Arm64,AMD64 and s390x example image.
+# 1. Build the Arm64, AMD64, s390x and ppc64le example image.
 # 2. Generate a tag based on the current time.
-# 3. Push the registry_org/myregistry/example:tag-arm64,registry_org/myregistry/example:tag-amd64 and registry_org/myregistry/example:tag-s390x
+# 3. Push the registry_org/myregistry/example:tag-arm64, registry_org/myregistry/example:tag-amd64, registry_org/myregistry/example:tag-s390x and registry_org/myregistry/example:tag-ppc64le
 # 4. Generate a multi-arch manifest for the image, registry_org/myregistry/example:tag.
 ```
 
@@ -164,7 +174,7 @@ Prerequisites: see the [Prerequisites](#prerequisites) section above.
 
 ### 3. Publish to quay.io (kubevirtci)
 
-Build and push for all architectures (amd64, arm64, s390x):
+Build and push for all architectures (amd64, arm64, s390x, ppc64le):
 
 ```bash
 cd cluster-provision/images/vm-image-builder
@@ -208,6 +218,12 @@ oci_pull(
     digest = "sha256:<new-s390x-digest>",
     image = "quay.io/kubevirtci/fedora-with-test-tooling",
 )
+
+oci_pull(
+    name = "fedora_with_test_tooling_ppc64le",
+    digest = "sha256:<new-ppc64le-digest>",
+    image = "quay.io/kubevirtci/fedora-with-test-tooling",
+)
 ```
 
 ### 6. Verify
@@ -232,7 +248,7 @@ create-containerdisk.sh
         │
         ▼
 publish-multiarch-containerdisk.sh
-  ├─ builds amd64, arm64, s390x
+  ├─ builds amd64, arm64, s390x, ppc64le
   ├─ pushes per-arch images
   └─ pushes multi-arch manifest
         │

--- a/cluster-provision/images/vm-image-builder/README.md
+++ b/cluster-provision/images/vm-image-builder/README.md
@@ -29,6 +29,9 @@ To cross build for the Arm64 image on AMD64 machines, the following RPM needs to
 To cross build for the s390x image on AMD64 machines, the following RPM needs to be installed:
 - qemu-system-s390x
 
+To cross build for the ppc64le image on AMD64 machines, the following RPM needs to be installed:
+- qemu-system-ppc64
+
 ## Quickstart: Build and publish an existing containerdisk
 
 Choose one of the configuration directories in this folder which you want to
@@ -56,7 +59,13 @@ To build for s390x, you need to set the following environment
 variable.
 ```
 export ARCHITECTURE=s390x
-``` 
+```
+
+To build for ppc64le, you need to set the following environment
+variable.
+```
+export ARCHITECTURE=ppc64le
+```
 
 To build the Virtual Machine without console output, only need to set the
 environment variable `CONSOLE`. This is useful when the build script is
@@ -72,11 +81,12 @@ instructions are distributed between the following three files:
 
 ```
 $ ls -l example/
-cloud-config    # cloud-init configuration for virt-customize
-image-url       # download URL of the base image
-image-url-arm64 # download URL of the base image for Arm64
-image-url-s390x # download URL of the base image for s390x
-os-variant      # operating system variant (for example fedora32)
+cloud-config      # cloud-init configuration for virt-customize
+image-url         # download URL of the base image
+image-url-arm64   # download URL of the base image for Arm64
+image-url-s390x   # download URL of the base image for s390x
+image-url-ppc64le # download URL of the base image for ppc64le
+os-variant        # operating system variant (for example fedora32)
 ```
 
 To create a completely new containerdisk, best copy the `example` folder and
@@ -102,8 +112,8 @@ $ virtctl console testvm1
 ```
 
 ### Build and publish multi-arch images
-The multi-arch publish does not support building alpine-cloud-init because the [alpine-make-vm-image](https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image) project does not support building Arm64 and s390x images.
-The `publish-multiarch-containerdisk.sh` script now supports building Arm64, AMD64 and s390x images.
+The multi-arch publish does not support building alpine-cloud-init because the [alpine-make-vm-image](https://raw.githubusercontent.com/alpinelinux/alpine-make-vm-image/master/alpine-make-vm-image) project does not support building Arm64, s390x and ppc64le images natively on non-native hardware.
+The `publish-multiarch-containerdisk.sh` script now supports building Arm64, AMD64, s390x and ppc64le images.
 The script primarily performs the following tasks:
 1. Use `create-containerdisk.sh` to build images.
 2. Upload the resulting images to a specific registry.
@@ -125,9 +135,9 @@ The script primarily performs the following tasks:
 ./ publish-multiarch-containerdisk.sh example myregistry registry_org
 
 # The script will do following things:
-# 1. Build the Arm64,AMD64 and s390x example image.
+# 1. Build the Arm64, AMD64, s390x and ppc64le example image.
 # 2. Generate a tag based on the current time.
-# 3. Push the registry_org/myregistry/example:tag-arm64,registry_org/myregistry/example:tag-amd64 and registry_org/myregistry/example:tag-s390x
+# 3. Push the registry_org/myregistry/example:tag-arm64, registry_org/myregistry/example:tag-amd64, registry_org/myregistry/example:tag-s390x and registry_org/myregistry/example:tag-ppc64le
 # 4. Generate a multi-arch manifest for the image, registry_org/myregistry/example:tag.
 ```
 
@@ -164,7 +174,7 @@ Prerequisites: see the [Prerequisites](#prerequisites) section above.
 
 ### 3. Publish to quay.io (kubevirtci)
 
-Build and push for all architectures (amd64, arm64, s390x):
+Build and push for all architectures (amd64, arm64, s390x, ppc64le):
 
 ```bash
 cd cluster-provision/images/vm-image-builder
@@ -208,6 +218,12 @@ oci_pull(
     digest = "sha256:<new-s390x-digest>",
     image = "quay.io/kubevirtci/fedora-with-test-tooling",
 )
+
+oci_pull(
+    name = "fedora_with_test_tooling_ppc64le",
+    digest = "sha256:<new-ppc64le-digest>",
+    image = "quay.io/kubevirtci/fedora-with-test-tooling",
+)
 ```
 
 ### 6. Verify
@@ -232,7 +248,7 @@ create-containerdisk.sh
         │
         ▼
 publish-multiarch-containerdisk.sh
-  ├─ builds amd64, arm64, s390x
+  ├─ builds amd64, arm64, s390x, ppc64le
   ├─ pushes per-arch images
   └─ pushes multi-arch manifest
         │

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -15,6 +15,11 @@ if [ "$ARCHITECTURE" = "s390x" ]; then
    ALPINE_BRANCH="v3.20"
 fi
 
+# ppc64le uses the lts kernel flavor (same as s390x)
+if [ "$ARCHITECTURE" = "ppc64le" ]; then
+   KERNEL_FLAVOR="lts"
+fi
+
 # arm64 uses UEFI boot which requires a separate 128M EFI partition,
 # so the image needs to be larger to fit both the EFI and root partitions.
 if [ "$ARCHITECTURE" = "arm64" ]; then
@@ -30,8 +35,8 @@ else
     modprobe nbd
 fi
 
-# s390x does not support qemu-user-static
-if [ "${ARCHITECTURE}" != "s390x" ]; then
+# s390x and ppc64le do not support qemu-user-static
+if [ "${ARCHITECTURE}" != "s390x" ] && [ "${ARCHITECTURE}" != "ppc64le" ]; then
     podman run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
 fi
 

--- a/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
+++ b/cluster-provision/images/vm-image-builder/alpine-cloud-init/create-image.sh
@@ -15,6 +15,11 @@ if [ "$ARCHITECTURE" = "s390x" ]; then
    ALPINE_BRANCH="v3.20"
 fi
 
+# ppc64le uses the lts kernel flavor (same as s390x)
+if [ "$ARCHITECTURE" = "ppc64le" ]; then
+   KERNEL_FLAVOR="lts"
+fi
+
 # arm64 uses UEFI boot which requires a separate 128M EFI partition,
 # so the image needs to be larger to fit both the EFI and root partitions.
 if [ "$ARCHITECTURE" = "arm64" ]; then
@@ -30,12 +35,13 @@ else
     modprobe nbd
 fi
 
-# s390x does not support qemu-user-static
-if [ "${ARCHITECTURE}" != "s390x" ]; then
+# s390x and ppc64le do not support qemu-user-static
+if [ "${ARCHITECTURE}" != "s390x" ] && [ "${ARCHITECTURE}" != "ppc64le" ]; then
     podman run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
 fi
 
 if [ ! -f alpine-make-vm-image ]; then
+    # TODO: switch back to master once https://github.com/kubevirt/alpine-make-vm-image/pull/3 is merged.
     curl  https://raw.githubusercontent.com/kubevirt/alpine-make-vm-image/master/alpine-make-vm-image -o alpine-make-vm-image
     chmod 755 alpine-make-vm-image
 fi

--- a/cluster-provision/images/vm-image-builder/common.sh
+++ b/cluster-provision/images/vm-image-builder/common.sh
@@ -13,6 +13,9 @@ go_style_arch_name() {
     s390x)
         echo "s390x"
         ;;
+    ppc64le)
+        echo "ppc64le"
+        ;;
     *)
         echo "ERROR: invalid Arch, ${arch}"
         exit 1
@@ -32,6 +35,9 @@ linux_style_arch_name() {
         ;;
     s390x)
         echo "s390x"
+        ;;
+    ppc64le)
+        echo "ppc64le"
         ;;
     *)
         echo "ERROR: invalid Arch, ${arch}"

--- a/cluster-provision/images/vm-image-builder/example/image-url-ppc64le
+++ b/cluster-provision/images/vm-image-builder/example/image-url-ppc64le
@@ -1,0 +1,1 @@
+https://archives.fedoraproject.org/pub/fedora-secondary/releases/39/Cloud/ppc64le/images/Fedora-Cloud-Base-39-1.5.ppc64le.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url-ppc64le
+++ b/cluster-provision/images/vm-image-builder/fedora-kubeadm/image-url-ppc64le
@@ -1,0 +1,1 @@
+https://archives.fedoraproject.org/pub/fedora-secondary/releases/39/Cloud/ppc64le/images/Fedora-Cloud-Base-39-1.5.ppc64le.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-realtime/image-url-ppc64le
+++ b/cluster-provision/images/vm-image-builder/fedora-realtime/image-url-ppc64le
@@ -1,0 +1,1 @@
+https://archives.fedoraproject.org/pub/fedora-secondary/releases/39/Cloud/ppc64le/images/Fedora-Cloud-Base-39-1.5.ppc64le.qcow2

--- a/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-ppc64le
+++ b/cluster-provision/images/vm-image-builder/fedora-with-test-tooling/image-url-ppc64le
@@ -1,0 +1,1 @@
+https://download.fedoraproject.org/pub/fedora-secondary/releases/44/Cloud/ppc64le/images/Fedora-Cloud-Base-Generic-44-1.7.ppc64le.qcow2

--- a/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
+++ b/cluster-provision/images/vm-image-builder/publish-multiarch-containerdisk.sh
@@ -3,7 +3,7 @@ set -exuo pipefail
 
 SCRIPT_PATH=$(dirname "$(realpath "$0")")
 source ${SCRIPT_PATH}/common.sh
-archs=(amd64 arm64 s390x)
+archs=(amd64 arm64 s390x ppc64le)
 
 main() {
     local build_only=""

--- a/cluster-provision/k8s/1.34/provision.sh
+++ b/cluster-provision/k8s/1.34/provision.sh
@@ -87,18 +87,25 @@ dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
 
-#openvswitch for s390x is not available from the centos default repos.
-if [ "$ARCH" == "s390x" ]; then
-  dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
-  systemctl enable openvswitch
-else
-  dnf install -y centos-release-nfv-openvswitch
-  if [ "$release" == "centos10" ]; then
-    dnf install -y openvswitch3.5
-  else
-    dnf install -y openvswitch2.16
-  fi
-fi 
+#openvswitch for s390x and ppc64le is not available from the centos default repos.
+case "$ARCH" in
+  s390x)
+    dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
+    systemctl enable openvswitch
+    ;;
+  ppc64le)
+    dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/ppc64le/openvswitch-2.16.0-2.fc36.ppc64le.rpm
+    systemctl enable openvswitch
+    ;;
+  *)
+    dnf install -y centos-release-nfv-openvswitch
+    if [ "$release" == "centos10" ]; then
+      dnf install -y openvswitch3.5
+    else
+      dnf install -y openvswitch2.16
+    fi
+    ;;
+esac
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 

--- a/cluster-provision/k8s/1.34/provision.sh
+++ b/cluster-provision/k8s/1.34/provision.sh
@@ -87,9 +87,12 @@ dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
 
-#openvswitch for s390x is not available from the centos default repos.
+#openvswitch for s390x and ppc64le is not available from the centos default repos.
 if [ "$ARCH" == "s390x" ]; then
   dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
+  systemctl enable openvswitch
+elif [ "$ARCH" == "ppc64le" ]; then
+  dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/ppc64le/openvswitch-2.16.0-2.fc36.ppc64le.rpm
   systemctl enable openvswitch
 else
   dnf install -y centos-release-nfv-openvswitch
@@ -98,7 +101,7 @@ else
   else
     dnf install -y openvswitch2.16
   fi
-fi 
+fi
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 

--- a/cluster-provision/k8s/1.35/provision.sh
+++ b/cluster-provision/k8s/1.35/provision.sh
@@ -87,18 +87,25 @@ dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
 
-#openvswitch for s390x is not available from the centos default repos.
-if [ "$ARCH" == "s390x" ]; then
-  dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
-  systemctl enable openvswitch
-else
-  dnf install -y centos-release-nfv-openvswitch
-  if [ "$release" == "centos10" ]; then
-    dnf install -y openvswitch3.5
-  else
-    dnf install -y openvswitch2.16
-  fi
-fi 
+#openvswitch for s390x and ppc64le is not available from the centos default repos.
+case "$ARCH" in
+  s390x)
+    dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
+    systemctl enable openvswitch
+    ;;
+  ppc64le)
+    dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/ppc64le/openvswitch-2.16.0-2.fc36.ppc64le.rpm
+    systemctl enable openvswitch
+    ;;
+  *)
+    dnf install -y centos-release-nfv-openvswitch
+    if [ "$release" == "centos10" ]; then
+      dnf install -y openvswitch3.5
+    else
+      dnf install -y openvswitch2.16
+    fi
+    ;;
+esac
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 

--- a/cluster-provision/k8s/1.35/provision.sh
+++ b/cluster-provision/k8s/1.35/provision.sh
@@ -87,9 +87,12 @@ dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
 
-#openvswitch for s390x is not available from the centos default repos.
+#openvswitch for s390x and ppc64le is not available from the centos default repos.
 if [ "$ARCH" == "s390x" ]; then
   dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
+  systemctl enable openvswitch
+elif [ "$ARCH" == "ppc64le" ]; then
+  dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/ppc64le/openvswitch-2.16.0-2.fc36.ppc64le.rpm
   systemctl enable openvswitch
 else
   dnf install -y centos-release-nfv-openvswitch
@@ -98,7 +101,7 @@ else
   else
     dnf install -y openvswitch2.16
   fi
-fi 
+fi
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 

--- a/cluster-provision/k8s/1.36/provision.sh
+++ b/cluster-provision/k8s/1.36/provision.sh
@@ -87,18 +87,25 @@ dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
 
-#openvswitch for s390x is not available from the centos default repos.
-if [ "$ARCH" == "s390x" ]; then
-  dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
-  systemctl enable openvswitch
-else
-  dnf install -y centos-release-nfv-openvswitch
-  if [ "$release" == "centos10" ]; then
-    dnf install -y openvswitch3.5
-  else
-    dnf install -y openvswitch2.16
-  fi
-fi 
+#openvswitch for s390x and ppc64le is not available from the centos default repos.
+case "$ARCH" in
+  s390x)
+    dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
+    systemctl enable openvswitch
+    ;;
+  ppc64le)
+    dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/ppc64le/openvswitch-2.16.0-2.fc36.ppc64le.rpm
+    systemctl enable openvswitch
+    ;;
+  *)
+    dnf install -y centos-release-nfv-openvswitch
+    if [ "$release" == "centos10" ]; then
+      dnf install -y openvswitch3.5
+    else
+      dnf install -y openvswitch2.16
+    fi
+    ;;
+esac
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 

--- a/cluster-provision/k8s/1.36/provision.sh
+++ b/cluster-provision/k8s/1.36/provision.sh
@@ -87,9 +87,12 @@ dnf install -y container-selinux
 
 dnf install -y libseccomp-devel
 
-#openvswitch for s390x is not available from the centos default repos.
+#openvswitch for s390x and ppc64le is not available from the centos default repos.
 if [ "$ARCH" == "s390x" ]; then
   dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/s390x/openvswitch-2.16.0-2.fc36.s390x.rpm
+  systemctl enable openvswitch
+elif [ "$ARCH" == "ppc64le" ]; then
+  dnf install -y https://kojipkgs.fedoraproject.org//packages/openvswitch/2.16.0/2.fc36/ppc64le/openvswitch-2.16.0-2.fc36.ppc64le.rpm
   systemctl enable openvswitch
 else
   dnf install -y centos-release-nfv-openvswitch
@@ -98,7 +101,7 @@ else
   else
     dnf install -y openvswitch2.16
   fi
-fi 
+fi
 
 dnf install -y NetworkManager NetworkManager-ovs NetworkManager-config-server
 

--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -117,6 +117,8 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
             arch_suffix=""
             if [[ $(uname -m) == *s390x* ]]; then
                 arch_suffix="-s390x"
+            elif [[ $(uname -m) == *ppc64le* ]]; then
+                arch_suffix="-ppc64le"
             fi
             LATEST=$(curl -L "https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest${arch_suffix}")
             ${ksh} apply -f "https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST}/kubevirt-operator${arch_suffix}.yaml"
@@ -142,7 +144,7 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
         export SONOBUOY_EXTRA_ARGS="--plugin systemd-logs --plugin e2e --plugin-env e2e.E2E_SKIP=Pod.InPlace.Resize.Container"
         hack/conformance.sh $conformance_config
 
-        if [[ $(uname -m) != *s390x* ]]; then
+        if [[ $(uname -m) != *s390x* && $(uname -m) != *ppc64le* ]]; then
             echo "Sanity check cluster-up of single stack cluster"
             make cluster-down
             export KUBEVIRT_WITH_CNAO=false

--- a/cluster-provision/k8s/check-cluster-up.sh
+++ b/cluster-provision/k8s/check-cluster-up.sh
@@ -115,9 +115,10 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
     if [ "${CI}" == "true" ] && [ -f $conformance_config ]; then
         if [ "$RUN_KUBEVIRT_CONFORMANCE" == "true" ]; then
             arch_suffix=""
-            if [[ $(uname -m) == *s390x* ]]; then
-                arch_suffix="-s390x"
-            fi
+            case "$(uname -m)" in
+              *s390x*)  arch_suffix="-s390x" ;;
+              *ppc64le*) arch_suffix="-ppc64le" ;;
+            esac
             LATEST=$(curl -L "https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest${arch_suffix}")
             ${ksh} apply -f "https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST}/kubevirt-operator${arch_suffix}.yaml"
             ${ksh} apply -f "https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${LATEST}/kubevirt-cr${arch_suffix}.yaml"
@@ -142,7 +143,7 @@ export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest
         export SONOBUOY_EXTRA_ARGS="--plugin systemd-logs --plugin e2e --plugin-env e2e.E2E_SKIP=Pod.InPlace.Resize.Container"
         hack/conformance.sh $conformance_config
 
-        if [[ $(uname -m) != *s390x* ]]; then
+        if [[ $(uname -m) != *s390x* && $(uname -m) != *ppc64le* ]]; then
             echo "Sanity check cluster-up of single stack cluster"
             make cluster-down
             export KUBEVIRT_WITH_CNAO=false

--- a/cluster-up/check.sh
+++ b/cluster-up/check.sh
@@ -35,8 +35,12 @@ elif [ -f "/sys/module/kvm_amd/parameters/nested" ]; then
 	KVM_ARCH="amd"
 elif [ -f "/sys/module/kvm/parameters/nested" ]; then
 	KVM_NESTED=$( cat /sys/module/kvm/parameters/nested )
-	KVM_ARCH="s390x"
-	KVM_HPAGE=$( cat /sys/module/kvm/parameters/hpage )
+	if [ "$(uname -m)" = "ppc64le" ]; then
+		KVM_ARCH="ppc64le"
+	else
+		KVM_ARCH="s390x"
+		KVM_HPAGE=$( cat /sys/module/kvm/parameters/hpage )
+	fi
 fi
 
 function is_enabled() {
@@ -61,4 +65,8 @@ fi
 
 if is_enabled "$KVM_HPAGE" && [ "$(uname -m)" = "s390x" ]; then
 	echo "[ERR ] $KVM_HPAGE KVM hugepage enabled. It needs to be disabled while nested virtualization is enabled for s390x"
+fi
+
+if [ "$(uname -m)" = "ppc64le" ]; then
+	echo "[ OK ] ppc64le: KVM nested virtualization uses /sys/module/kvm/parameters/nested"
 fi

--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -118,8 +118,8 @@ function _add_common_params() {
             params=" --container-suffix=:$KUBEVIRTCI_CONTAINER_SUFFIX $params"
         fi
 
-        # Currently, the s390x architecture supports only KUBEVIRT_SLIM.
-        if [[ ${KUBEVIRT_SLIM} == "true" || $(uname -m) == "s390x" ]]; then
+        # Currently, the s390x and ppc64le architectures support only KUBEVIRT_SLIM.
+        if [[ ${KUBEVIRT_SLIM} == "true" || $(uname -m) == "s390x" || $(uname -m) == "ppc64le" ]]; then
             params=" --slim $params"
         fi
     fi

--- a/hack/publish-alpine.sh
+++ b/hack/publish-alpine.sh
@@ -17,10 +17,15 @@ fi
 # s390x requires native hardware because alpine-make-vm-image runs zipl (the
 # s390x bootloader installer) in a chroot. zipl performs low-level ioctl calls
 # on the block device to write IPL boot records, which segfaults under
-# qemu-user-static. arm64 cross-builds fine because its UEFI bootloader setup
-# is just writing a text file (startup.nsh), with no low-level disk operations.
+# qemu-user-static. ppc64le similarly requires native hardware because its
+# bootloader (grub2-ppc64le) also performs low-level disk operations that
+# segfault under qemu-user-static. arm64 cross-builds fine because its UEFI
+# bootloader setup is just writing a text file (startup.nsh), with no
+# low-level disk operations.
 if [ "$(uname -m)" = "s390x" ]; then
     BUILD_ARCHES=${BUILD_ARCHES:-"s390x"}
+elif [ "$(uname -m)" = "ppc64le" ]; then
+    BUILD_ARCHES=${BUILD_ARCHES:-"ppc64le"}
 else
     BUILD_ARCHES=${BUILD_ARCHES:-"amd64 arm64"}
 fi

--- a/hack/publish-alpine.sh
+++ b/hack/publish-alpine.sh
@@ -17,13 +17,16 @@ fi
 # s390x requires native hardware because alpine-make-vm-image runs zipl (the
 # s390x bootloader installer) in a chroot. zipl performs low-level ioctl calls
 # on the block device to write IPL boot records, which segfaults under
-# qemu-user-static. arm64 cross-builds fine because its UEFI bootloader setup
-# is just writing a text file (startup.nsh), with no low-level disk operations.
-if [ "$(uname -m)" = "s390x" ]; then
-    BUILD_ARCHES=${BUILD_ARCHES:-"s390x"}
-else
-    BUILD_ARCHES=${BUILD_ARCHES:-"amd64 arm64"}
-fi
+# qemu-user-static. ppc64le similarly requires native hardware because its
+# bootloader (grub2-ppc64le) also performs low-level disk operations that
+# segfault under qemu-user-static. arm64 cross-builds fine because its UEFI
+# bootloader setup is just writing a text file (startup.nsh), with no
+# low-level disk operations.
+case "$(uname -m)" in
+  s390x)  BUILD_ARCHES=${BUILD_ARCHES:-"s390x"} ;;
+  ppc64le) BUILD_ARCHES=${BUILD_ARCHES:-"ppc64le"} ;;
+  *)      BUILD_ARCHES=${BUILD_ARCHES:-"amd64 arm64"} ;;
+esac
 TARGET_REPO=${TARGET_REPO:-"quay.io/kubevirtci"}
 TARGET_KUBEVIRT_REPO=${TARGET_KUBEVIRT_REPO:-"quay.io/kubevirt"}
 IMAGE_NAME="alpine-with-test-tooling-container-disk"

--- a/publish.sh
+++ b/publish.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-archs=(amd64 s390x)
+archs=(amd64 s390x ppc64le)
 ARCH=$(uname -m | grep -q s390x && echo s390x || echo amd64)
 
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)}
 PREV_KUBEVIRTCI_TAG=$(curl -sL https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest?ignoreCache=1)
 BYPASS_PMAN=${BYPASS_PMAN:-false}
 
-if [ $ARCH == "s390x" ]; then
+if [ $ARCH == "s390x" ] || [ $ARCH == "ppc64le" ]; then
   BYPASS_PMAN=true
 fi
 PHASES=${PHASES:-k8s}
@@ -74,7 +74,7 @@ function build_clusters() {
 
       cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i --slim
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim
-    elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
+    elif [[ ( "$ARCH" == "s390x" || "$ARCH" == "ppc64le" ) && "$i" == "1.34" ]]; then
       echo "INFO: building $i slim"
       cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i --slim
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}
@@ -103,7 +103,7 @@ function push_cluster_images() {
 
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
       ${CRI_BIN} push "$TARGET_IMAGE"
-    elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
+    elif [[ ( "$ARCH" == "s390x" || "$ARCH" == "ppc64le" ) && "$i" == "1.34" ]]; then
       echo "INFO: push $i slim"
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
       ${CRI_BIN} push "$TARGET_IMAGE"
@@ -117,7 +117,7 @@ function push_cluster_images() {
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
-    elif [[ "$ARCH" == "s390x" && "$i" == "1.34" ]]; then
+    elif [[ ( "$ARCH" == "s390x" || "$ARCH" == "ppc64le" ) && "$i" == "1.34" ]]; then
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim-$ARCH)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim-${ARCH}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
     fi
@@ -165,6 +165,7 @@ publish_manifest() {
   local full_image_name="${target_image_repo}/${image_name}:${image_tag}"
   if [[ "$image_name" != "centos9" && "$image_name" != "centos10" && "$image_name" != "gocli" && ! ( "$image_name" == "k8s-1.34" && "$image_tag" =~ "slim" ) ]]; then
     unset 'cur_archs[1]'
+    unset 'cur_archs[2]'
   fi
   for arch in ${cur_archs[*]};do
     if [ "$arch" = "amd64" ]; then
@@ -182,7 +183,7 @@ function main() {
   if [ "$PHASES" == "linux" ]; then
     CENTOS_VERSION=${PROVISION_CENTOS_VERSION:-9}
     publish_node_base_image
-    if [ $ARCH == "s390x" ]; then
+    if [ $ARCH == "s390x" ] || [ $ARCH == "ppc64le" ]; then
       publish_manifest "centos${CENTOS_VERSION}" $KUBEVIRTCI_TAG
     elif [ $ARCH == "amd64" ]; then
       if [ "$CENTOS_VERSION" == "10" ]; then
@@ -198,7 +199,7 @@ function main() {
   run_provision_manager
   publish_clusters
   for i in "${IMAGES_TO_BUILD[@]}"; do
-    if [ $ARCH == "s390x" ]; then
+    if [ $ARCH == "s390x" ] || [ $ARCH == "ppc64le" ]; then
       echo "INFO: publish manifests of $i"
       publish_manifest k8s-$i $KUBEVIRTCI_TAG
       publish_manifest k8s-$i ${KUBEVIRTCI_TAG}-slim
@@ -206,7 +207,7 @@ function main() {
   done
 
   push_gocli
-  if [ $ARCH == "s390x" ]; then
+  if [ $ARCH == "s390x" ] || [ $ARCH == "ppc64le" ]; then
     publish_manifest "gocli" $KUBEVIRTCI_TAG
   fi
 

--- a/publish.sh
+++ b/publish.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-archs=(amd64 s390x)
+archs=(amd64 s390x ppc64le)
 ARCH=$(uname -m | grep -q s390x && echo s390x || echo amd64)
 
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)}
 PREV_KUBEVIRTCI_TAG=$(curl -sL https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest?ignoreCache=1)
 BYPASS_PMAN=${BYPASS_PMAN:-false}
 
-if [ $ARCH == "s390x" ]; then
+if [ $ARCH == "s390x" ] || [ $ARCH == "ppc64le" ]; then
   BYPASS_PMAN=true
 fi
 PHASES=${PHASES:-k8s}
@@ -76,7 +76,7 @@ function build_clusters() {
 
       cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i --slim
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim
-    elif [[ "$ARCH" == "s390x" ]]; then
+    elif [[ ( "$ARCH" == "s390x" || "$ARCH" == "ppc64le" ) && "$i" == "1.34" ]]; then
       echo "INFO: building $i slim"
       cluster-provision/gocli/build/cli provision --phases k8s cluster-provision/k8s/$i --slim
       ${CRI_BIN} tag ${TARGET_REPO}/k8s-$i ${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}
@@ -104,7 +104,7 @@ function push_cluster_images() {
 
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
       ${CRI_BIN} push "$TARGET_IMAGE"
-    elif [[ "$ARCH" == "s390x" ]]; then
+    elif [[ ( "$ARCH" == "s390x" || "$ARCH" == "ppc64le" ) && "$i" == "1.34" ]]; then
       echo "INFO: push $i slim"
       TARGET_IMAGE="${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
       ${CRI_BIN} push "$TARGET_IMAGE"
@@ -118,7 +118,7 @@ function push_cluster_images() {
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}"
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim"
-    elif [[ "$ARCH" == "s390x" ]]; then
+    elif [[ ( "$ARCH" == "s390x" || "$ARCH" == "ppc64le" ) && "$i" == "1.34" ]]; then
       echo "INFO: retagging $i (previous tag $PREV_KUBEVIRTCI_TAG-slim-$ARCH)"
       skopeo copy "docker://${TARGET_REPO}/k8s-$i:${PREV_KUBEVIRTCI_TAG}-slim-${ARCH}" "docker://${TARGET_REPO}/k8s-$i:${KUBEVIRTCI_TAG}-slim-${ARCH}"
     fi
@@ -168,6 +168,7 @@ publish_manifest() {
   local full_image_name="${target_image_repo}/${image_name}:${image_tag}"
   if [[ "$image_name" != "centos9" && "$image_name" != "centos10" && ! ( "$image_name" == k8s-* && "$image_tag" == *slim* ) ]]; then
     unset 'cur_archs[1]'
+    unset 'cur_archs[2]'
   fi
   for arch in ${cur_archs[*]};do
     if [ "$arch" = "amd64" ]; then
@@ -185,7 +186,7 @@ function main() {
   if [ "$PHASES" == "linux" ]; then
     CENTOS_VERSION=${PROVISION_CENTOS_VERSION:-9}
     publish_node_base_image
-    if [ $ARCH == "s390x" ]; then
+    if [ $ARCH == "s390x" ] || [ $ARCH == "ppc64le" ]; then
       publish_manifest "centos${CENTOS_VERSION}" $KUBEVIRTCI_TAG
     elif [ $ARCH == "amd64" ]; then
       if [ "$CENTOS_VERSION" == "10" ]; then
@@ -201,7 +202,7 @@ function main() {
   run_provision_manager
   publish_clusters
   for i in "${IMAGES_TO_BUILD[@]}"; do
-    if [ $ARCH == "s390x" ]; then
+    if [ $ARCH == "s390x" ] || [ $ARCH == "ppc64le" ]; then
       echo "INFO: publish manifests of $i"
       publish_manifest k8s-$i $KUBEVIRTCI_TAG
       publish_manifest k8s-$i ${KUBEVIRTCI_TAG}-slim
@@ -209,6 +210,9 @@ function main() {
   done
 
   push_gocli
+  if [ $ARCH == "s390x" ] || [ $ARCH == "ppc64le" ]; then
+    publish_manifest "gocli" $KUBEVIRTCI_TAG
+  fi
 
   if [ $ARCH == "amd64" ]; then
     create_git_tag


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds ppc64le architecture support to kubevirtci as part of VEP-265. This enables building and running KubeVirt CI clusters on IBM Power (ppc64le) hardware.

**Which issue(s) this PR fixes** :
Fixes [#265](https://github.com/kubevirt/enhancements/issues/265)

**Special notes for your reviewer**:

* QEMU machine type used for ppc64le is pseries,accel=kvm
* OpenVSwitch is installed from kojipkgs for ppc64le (not available in default CentOS repos)
* CPU Manager is disabled for ppc64le as it is not yet supported on this architecture
* Alpine image builds require native ppc64le hardware (no cross-build support)

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP-265 kubevirt/enhancements#265](https://github.com/kubevirt/enhancements/issues/265) was considered and is present
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: changes are minimal and follow existing architecture patterns
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ppc64le (IBM Power) architecture support to kubevirtci.
```
