### PR TITLE
vm based: Support NUMA configuration also for NUMA=1

### DIFF
--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -193,7 +193,8 @@ fi
 numa_arg=""
 sriov_pxb_numa_arg=""
 secondary_nic_pxb_args=""
-if [ "${NUMA}" -gt 1 ]; then
+host_arch="$(uname -m)"
+if [ "${host_arch}" != "s390x" ] && [ "${NUMA}" != 0 ]; then
     numa_mem_unit="${MEMORY//[[:digit:]]/}"
     numa_mem_value="${MEMORY//[!0-9]/}"
     if [ $((CPU % NUMA)) -gt 0 ] || [ $((numa_mem_value % NUMA)) -gt 0 ]; then
@@ -216,7 +217,7 @@ if [ "${NUMA}" -gt 1 ]; then
     done
 fi
 
-if [ "$(uname -m)" == "s390x" ]; then
+if [ "${host_arch}" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
   qemu_system_cmd="qemu-system-s390x \
     -enable-kvm \

--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -233,7 +233,7 @@ if [ "${host_arch}" == "s390x" ]; then
     -vnc :${n} \
     -cpu host \
     -m ${MEMORY} \
-    -smp ${CPU} ${numa_arg} \
+    -smp ${CPU} \
     -serial pty \
     -machine s390-ccw-virtio,accel=kvm \
     -uuid $(cat /proc/sys/kernel/random/uuid) \

--- a/cluster-provision/centos10/scripts/vm.sh
+++ b/cluster-provision/centos10/scripts/vm.sh
@@ -191,30 +191,27 @@ if [ "$n" = "01" ] ; then
 fi
 
 numa_arg=""
-sriov_pxb_numa_arg=""
-secondary_nic_pxb_args=""
-if [ "${NUMA}" -gt 1 ]; then
-    numa_mem_unit="${MEMORY//[[:digit:]]/}"
-    numa_mem_value="${MEMORY//[!0-9]/}"
-    if [ $((CPU % NUMA)) -gt 0 ] || [ $((numa_mem_value % NUMA)) -gt 0 ]; then
-        echo "unable to calculate symmetric NUMA topology with vCPUs:${CPU} Memory:${MEMORY} NUMA:${NUMA}"
-        exit 1
-    fi
-    node_mem="$((numa_mem_value / NUMA))${numa_mem_unit}"
-    node_first_cpu=0
-    node_cpu_step=$((CPU / NUMA - 1))
-    for node_id in $(seq 0 $((NUMA - 1))); do
-        node_last_cpu=$((node_first_cpu + node_cpu_step))
-        numa_arg+=" -object memory-backend-ram,size=${node_mem},id=m${node_id}"
-        numa_arg+=" -numa node,nodeid=${node_id},memdev=m${node_id},cpus=${node_first_cpu}-${node_last_cpu}"
-        node_first_cpu=$((node_last_cpu + 1))
-    done
-    sriov_pxb_numa_arg=",numa_node=0"
-    for node_id in $(seq 0 $((NUMA - 1))); do
-        # Leave enough room for the downstream buses allocated under each NUMA bridge.
-        secondary_nic_pxb_args+=" -device pxb-pcie,id=secondarypxb${node_id},bus=pcie.0,bus_nr=$((160 + (node_id * 32))),numa_node=${node_id}"
-    done
+sriov_pxb_numa_arg=",numa_node=0"
+numa_mem_unit="${MEMORY//[[:digit:]]/}"
+numa_mem_value="${MEMORY//[!0-9]/}"
+if [ $((CPU % NUMA)) -gt 0 ] || [ $((numa_mem_value % NUMA)) -gt 0 ]; then
+    echo "unable to calculate symmetric NUMA topology with vCPUs:${CPU} Memory:${MEMORY} NUMA:${NUMA}"
+    exit 1
 fi
+node_mem="$((numa_mem_value / NUMA))${numa_mem_unit}"
+node_first_cpu=0
+node_cpu_step=$((CPU / NUMA - 1))
+for node_id in $(seq 0 $((NUMA - 1))); do
+    node_last_cpu=$((node_first_cpu + node_cpu_step))
+    numa_arg+=" -object memory-backend-ram,size=${node_mem},id=m${node_id}"
+    numa_arg+=" -numa node,nodeid=${node_id},memdev=m${node_id},cpus=${node_first_cpu}-${node_last_cpu}"
+    node_first_cpu=$((node_last_cpu + 1))
+done
+secondary_nic_pxb_args=""
+for node_id in $(seq 0 $((NUMA - 1))); do
+    # Leave enough room for the downstream buses allocated under each NUMA bridge.
+    secondary_nic_pxb_args+=" -device pxb-pcie,id=secondarypxb${node_id},bus=pcie.0,bus_nr=$((160 + (node_id * 32))),numa_node=${node_id}"
+done
 
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -193,7 +193,8 @@ fi
 numa_arg=""
 sriov_pxb_numa_arg=""
 secondary_nic_pxb_args=""
-if [ "${NUMA}" -gt 1 ]; then
+host_arch="$(uname -m)"
+if [ "${host_arch}" != "s390x" ] && [ "${NUMA}" != 0 ]; then
     numa_mem_unit="${MEMORY//[[:digit:]]/}"
     numa_mem_value="${MEMORY//[!0-9]/}"
     if [ $((CPU % NUMA)) -gt 0 ] || [ $((numa_mem_value % NUMA)) -gt 0 ]; then
@@ -216,7 +217,7 @@ if [ "${NUMA}" -gt 1 ]; then
     done
 fi
 
-if [ "$(uname -m)" == "s390x" ]; then
+if [ "${host_arch}" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x
   qemu_system_cmd="qemu-system-s390x \
     -enable-kvm \

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -233,7 +233,7 @@ if [ "${host_arch}" == "s390x" ]; then
     -vnc :${n} \
     -cpu host \
     -m ${MEMORY} \
-    -smp ${CPU} ${numa_arg} \
+    -smp ${CPU} \
     -serial pty \
     -machine s390-ccw-virtio,accel=kvm \
     -uuid $(cat /proc/sys/kernel/random/uuid) \

--- a/cluster-provision/centos9/scripts/vm.sh
+++ b/cluster-provision/centos9/scripts/vm.sh
@@ -191,30 +191,27 @@ if [ "$n" = "01" ] ; then
 fi
 
 numa_arg=""
-sriov_pxb_numa_arg=""
-secondary_nic_pxb_args=""
-if [ "${NUMA}" -gt 1 ]; then
-    numa_mem_unit="${MEMORY//[[:digit:]]/}"
-    numa_mem_value="${MEMORY//[!0-9]/}"
-    if [ $((CPU % NUMA)) -gt 0 ] || [ $((numa_mem_value % NUMA)) -gt 0 ]; then
-        echo "unable to calculate symmetric NUMA topology with vCPUs:${CPU} Memory:${MEMORY} NUMA:${NUMA}"
-        exit 1
-    fi
-    node_mem="$((numa_mem_value / NUMA))${numa_mem_unit}"
-    node_first_cpu=0
-    node_cpu_step=$((CPU / NUMA - 1))
-    for node_id in $(seq 0 $((NUMA - 1))); do
-        node_last_cpu=$((node_first_cpu + node_cpu_step))
-        numa_arg+=" -object memory-backend-ram,size=${node_mem},id=m${node_id}"
-        numa_arg+=" -numa node,nodeid=${node_id},memdev=m${node_id},cpus=${node_first_cpu}-${node_last_cpu}"
-        node_first_cpu=$((node_last_cpu + 1))
-    done
-    sriov_pxb_numa_arg=",numa_node=0"
-    for node_id in $(seq 0 $((NUMA - 1))); do
-        # Leave enough room for the downstream buses allocated under each NUMA bridge.
-        secondary_nic_pxb_args+=" -device pxb-pcie,id=secondarypxb${node_id},bus=pcie.0,bus_nr=$((160 + (node_id * 32))),numa_node=${node_id}"
-    done
+sriov_pxb_numa_arg=",numa_node=0"
+numa_mem_unit="${MEMORY//[[:digit:]]/}"
+numa_mem_value="${MEMORY//[!0-9]/}"
+if [ $((CPU % NUMA)) -gt 0 ] || [ $((numa_mem_value % NUMA)) -gt 0 ]; then
+    echo "unable to calculate symmetric NUMA topology with vCPUs:${CPU} Memory:${MEMORY} NUMA:${NUMA}"
+    exit 1
 fi
+node_mem="$((numa_mem_value / NUMA))${numa_mem_unit}"
+node_first_cpu=0
+node_cpu_step=$((CPU / NUMA - 1))
+for node_id in $(seq 0 $((NUMA - 1))); do
+    node_last_cpu=$((node_first_cpu + node_cpu_step))
+    numa_arg+=" -object memory-backend-ram,size=${node_mem},id=m${node_id}"
+    numa_arg+=" -numa node,nodeid=${node_id},memdev=m${node_id},cpus=${node_first_cpu}-${node_last_cpu}"
+    node_first_cpu=$((node_last_cpu + 1))
+done
+secondary_nic_pxb_args=""
+for node_id in $(seq 0 $((NUMA - 1))); do
+    # Leave enough room for the downstream buses allocated under each NUMA bridge.
+    secondary_nic_pxb_args+=" -device pxb-pcie,id=secondarypxb${node_id},bus=pcie.0,bus_nr=$((160 + (node_id * 32))),numa_node=${node_id}"
+done
 
 if [ "$(uname -m)" == "s390x" ]; then
   # As per https://www.qemu.org/docs/master/system/s390x/bootdevices.html#booting-without-bootindex-parameter -drive if=virtio can't be specified with bootindex for s390x

--- a/cluster-provision/gocli/cmd/run.go
+++ b/cluster-provision/gocli/cmd/run.go
@@ -675,7 +675,7 @@ func run(cmd *cobra.Command, args []string) (retErr error) {
 			} else { //devices like virtio-net-pci doesn't support hot-plug
 				rootPortArgs := ""
 				bus := "pcie.0"
-				if numaNodes > 1 {
+				if numaNodes > 0 {
 					numaNode := i % numaNodes
 					bus = fmt.Sprintf("secondaryrp%d", i)
 					slot := secondaryNicRootPortBaseSlot + i/numaNodes

--- a/cluster-up/cluster/k8s-1.35/provider.sh
+++ b/cluster-up/cluster/k8s-1.35/provider.sh
@@ -9,7 +9,6 @@ if [ "${KUBEVIRT_WITH_SRIOV}" == "true" ]; then
     if [ "${KUBEVIRT_WITH_CNAO}" != "true" ]; then
         export KUBEVIRT_WITH_MULTUS=true
     fi
-    export KUBEVIRT_NUM_NUMA_NODES=2
 fi
 
 # shellcheck disable=SC1090

--- a/cluster-up/cluster/k8s-1.36/provider.sh
+++ b/cluster-up/cluster/k8s-1.36/provider.sh
@@ -9,7 +9,6 @@ if [ "${KUBEVIRT_WITH_SRIOV}" == "true" ]; then
     if [ "${KUBEVIRT_WITH_CNAO}" != "true" ]; then
         export KUBEVIRT_WITH_MULTUS=true
     fi
-    export KUBEVIRT_NUM_NUMA_NODES=2
 fi
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the VM NUMA and PCI bridge setup so it works with NUMA=1,
and set the required numa_node in such case.
It is a private case, where all the resources belong to the single NUMA.
s390x doesn't support NUMA, so exclude it.

In addition, remove the NUMA count setting to allow different consumers 
(such as emulated-igb and sig-network) to set the count according needs.
See 2nd commit for more info.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
