### PR TITLE
fix(cluster-provision): install s390utils-core for s390x dracut initramfs generation

### DIFF
--- a/cluster-provision/centos10/Dockerfile
+++ b/cluster-provision/centos10/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.fedoraproject.org/fedora:43 AS base
 
+ARG BUILDARCH
+
 RUN dnf -y install \
     bind-utils \
     dnsmasq \
@@ -12,7 +14,8 @@ RUN dnf -y install \
     screen \
     socat \
     tcpdump \
-    qemu-kvm-core && \
+    qemu-kvm-core \
+    $([ "$BUILDARCH" = "s390x" ] && echo "s390utils-base") && \
     dnf clean all
 
 FROM base AS imageartifactdownload

--- a/cluster-provision/centos10/Dockerfile
+++ b/cluster-provision/centos10/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.fedoraproject.org/fedora:43 AS base
 
+ARG BUILDARCH
+
 RUN dnf -y install \
     bind-utils \
     dnsmasq \
@@ -12,7 +14,8 @@ RUN dnf -y install \
     screen \
     socat \
     tcpdump \
-    qemu-kvm-core && \
+    qemu-kvm-core \
+    $([ "$BUILDARCH" = "s390x" ] && echo "s390utils-core") && \
     dnf clean all
 
 FROM base AS imageartifactdownload

--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.fedoraproject.org/fedora:43 AS base
 
+ARG BUILDARCH
+
 RUN dnf -y install \
     bind-utils \
     dnsmasq \
@@ -12,7 +14,8 @@ RUN dnf -y install \
     screen \
     socat \
     tcpdump \
-    qemu-kvm-core && \
+    qemu-kvm-core \
+    $([ "$BUILDARCH" = "s390x" ] && echo "s390utils-base") && \
     dnf clean all
 
 FROM base AS imageartifactdownload

--- a/cluster-provision/centos9/Dockerfile
+++ b/cluster-provision/centos9/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.fedoraproject.org/fedora:43 AS base
 
+ARG BUILDARCH
+
 RUN dnf -y install \
     bind-utils \
     dnsmasq \
@@ -12,7 +14,8 @@ RUN dnf -y install \
     screen \
     socat \
     tcpdump \
-    qemu-kvm-core && \
+    qemu-kvm-core \
+    $([ "$BUILDARCH" = "s390x" ] && echo "s390utils-core") && \
     dnf clean all
 
 FROM base AS imageartifactdownload


### PR DESCRIPTION
**What this PR does / why we need it**:

On s390x, the `kernel-core` `%posttrans` scriptlet invokes `dracut` to generate an initramfs. dracut's s390 module requires the `cio_ignore` binary (provided by `s390utils-base`) to manage the channel I/O device blacklist. Without it, dracut fails with:

```
dracut-install: ERROR: installing 'cio_ignore'
dracut[E]: FAILED: /usr/lib/dracut/dracut-install -D /var/tmp/dracut.dhUzOet
```

This error is present in both centos9 and centos10 s390x base image builds. It is currently non-fatal (dnf treats the scriptlet failure as a warning), but it produces noisy error output and results in a broken initramfs.

This PR adds `s390utils-base` conditionally when `BUILDARCH=s390x` so it is part of the same dnf transaction and available before dracut runs.

**Special notes for your reviewer**:

Verified locally under QEMU s390x emulation by building the centos10 `base` stage with `--platform linux/s390x --build-arg BUILDARCH=s390x`. Before the fix, the `cio_ignore` error is present. After the fix, `s390utils-base` is installed as part of the same dnf transaction (package 8/339), and the `kernel-core` posttrans scriptlet runs dracut cleanly with no `cio_ignore` error.

Also confirmed the centos9 s390x build log ([latest run](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-centos-base-s390x/2084489636318547968)) has the same error, so the fix is applied to both Dockerfiles.

On amd64 builds, the conditional expands to nothing and the package list is unchanged.

This PR was created with AI assistance, but every change has been manually verified and tested.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:

```release-note
NONE
```