### PR TITLE
fix(cluster-provision): get pre-release kube binaries for the node arch

### DIFF
--- a/cluster-provision/k8s/1.37/k8s_provision.sh
+++ b/cluster-provision/k8s/1.37/k8s_provision.sh
@@ -35,17 +35,24 @@ function getKubernetesClosestStableVersion() {
 }
 
 function replaceKubeBinaries() {
+  local bin_dir release arch
+
   command -v which >/dev/null || dnf install -y which
   rm -f $(which kubeadm kubelet)
 
-  BIN_DIR="/usr/bin"
-  RELEASE="v$version"
-  ARCH="amd64"
+  bin_dir="/usr/bin"
+  release="v$version"
+  arch="$(uname -m)"
 
-  curl --output-dir "${BIN_DIR}" --parallel \
-    -RO "https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/{kubeadm,kubelet}" \
+  case "${arch}" in
+    aarch64) arch=arm64;;
+    x86_64)  arch=amd64;;
+  esac
 
-  chmod +x ${BIN_DIR}/kubeadm ${BIN_DIR}/kubelet
+  curl --output-dir "${bin_dir}" --parallel \
+    -RO "https://dl.k8s.io/release/${release}/bin/linux/${arch}/{kubeadm,kubelet}" \
+
+  chmod +x "${bin_dir}"/kubeadm "${bin_dir}"/kubelet
 }
 
 if [ ! -f "/tmp/extra-pre-pull-images" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

This change add support to download pre-release kube binaries for non amd64 architectures.

Job [check-provision-k8s-1.37-s390x](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/1804/check-provision-k8s-1.37-s390x/2089312469997588480) is currently failing because it downloads the amd64 binaries in a s390x VM:

```
+ ARCH=amd64
+ curl --output-dir /usr/bin --parallel -RO 'https://dl.k8s.io/release/v1.37.0-beta.0/bin/linux/amd64/{kubeadm,kubelet}'
+ chmod +x /usr/bin/kubeadm /usr/bin/kubelet
+ kubeadm config images pull --kubernetes-version 1.37.0-beta.0
/bin/bash: line 135: /bin/kubeadm: cannot execute binary file: Exec format error
```

**Special notes for your reviewer**:

/cc @Whitedyl