### PR TITLE
check: verify ip6_tables when IPv6 is enabled

### DIFF
--- a/cluster-up/check.sh
+++ b/cluster-up/check.sh
@@ -24,6 +24,20 @@ else
 	echo "[ OK ] found /dev/kvm"
 fi
 
+# IPv4-only clusters do not need the IPv6 ip6_tables module.
+if [[ "${IPFAMILY:-dual}" != "ipv4" ]]; then
+	if ! grep -q "^ip6_tables " /proc/modules; then
+		echo "[ERR ] kernel module ip6_tables is not loaded"
+		echo "[ERR ] run: sudo modprobe ip6_tables"
+		echo "[ERR ] see PODMAN.md for how to load required modules persistently"
+		exit 1
+	else
+		echo "[ OK ] kernel module ip6_tables is loaded"
+	fi
+else
+	echo "[ OK ] IPv6 is disabled; skipping ip6_tables check"
+fi
+
 KVM_ARCH=""
 KVM_NESTED="unknown"
 KVM_HPAGE="unknown"


### PR DESCRIPTION
If the module is not loaded, exit early with a non-zero status.
Without this pre-flight check, the fialure may only be reported
after the image has been downloaded and becomen difficult to
identify among the startup logs.

IPv4-only environments can set IPFAMILY=ipv4, so the ip6_tables
check is skipped when IPv6 is disabled.

Assisted-by: IBM Bob

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
