### PR TITLE
gocli, node bridges: Disable stp

### DIFF
--- a/cluster-provision/gocli/opts/node01/scripts/setup-bridges.sh
+++ b/cluster-provision/gocli/opts/node01/scripts/setup-bridges.sh
@@ -15,7 +15,8 @@ for iface in $(ls /sys/class/net/ 2>/dev/null | grep -E '^eth[1-9]$|^eth[0-9]{2,
     nmcli connection delete ${bridge_name} 2>/dev/null || true
 
     # Create bridge connection (disable DHCP to avoid timeouts)
-    nmcli connection add type bridge ifname ${bridge_name} con-name ${bridge_name} ipv4.method disabled ipv6.method disabled
+    nmcli connection add type bridge ifname ${bridge_name} con-name ${bridge_name} \
+      bridge.stp no ipv4.method disabled ipv6.method disabled
 
     # Add ethernet interface as bridge slave
     nmcli connection add type ethernet ifname ${iface} con-name ${iface} master ${bridge_name}

--- a/cluster-provision/gocli/opts/nodes/scripts/setup-bridges.sh
+++ b/cluster-provision/gocli/opts/nodes/scripts/setup-bridges.sh
@@ -15,7 +15,8 @@ for iface in $(ls /sys/class/net/ 2>/dev/null | grep -E '^eth[1-9]$|^eth[0-9]{2,
     nmcli connection delete ${bridge_name} 2>/dev/null || true
 
     # Create bridge connection (disable DHCP to avoid timeouts)
-    nmcli connection add type bridge ifname ${bridge_name} con-name ${bridge_name} ipv4.method disabled ipv6.method disabled
+    nmcli connection add type bridge ifname ${bridge_name} con-name ${bridge_name} \
+        bridge.stp no ipv4.method disabled ipv6.method disabled
 
     # Add ethernet interface as bridge slave
     nmcli connection add type ethernet ifname ${iface} con-name ${iface} master ${bridge_name}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently bridges are created with stp enabled.
This causes delays in their availability to forward. Disable stp as it is not needed for the acyclic networks that are tested in this suite.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
