### PR TITLE
fix(registry.k8s.io): directly pull images from Google registry without CDN

### DIFF
--- a/cluster-provision/k8s/1.34/k8s_provision.sh
+++ b/cluster-provision/k8s/1.34/k8s_provision.sh
@@ -78,8 +78,6 @@ EOF
 
 dnf install -y cri-o
 
-systemctl enable --now crio
-
 cat << EOF > /etc/containers/registries.conf
 [registries.search]
 registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
@@ -90,6 +88,17 @@ registries = ['registry:5000']
 [registries.block]
 registries = []
 EOF
+
+cat << EOF > /etc/containers/registries.conf.d/registry-k8s-io-no-cdn.conf
+# Workaround for https://github.com/kubernetes/registry.k8s.io/issues/333
+[[registry]]
+location = "registry.k8s.io"
+
+[[registry.mirror]]
+location = "us-central1-docker.pkg.dev/k8s-artifacts-prod/images"
+EOF
+
+systemctl enable --now crio
 
 packages_version=$(getKubernetesClosestStableVersion)
 major_version=$(echo $packages_version | cut -d "." -f 2)

--- a/cluster-provision/k8s/1.35/k8s_provision.sh
+++ b/cluster-provision/k8s/1.35/k8s_provision.sh
@@ -84,8 +84,6 @@ EOF
 
 dnf install -y cri-o
 
-systemctl enable --now crio
-
 cat << EOF > /etc/containers/registries.conf
 [registries.search]
 registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
@@ -96,6 +94,17 @@ registries = ['registry:5000']
 [registries.block]
 registries = []
 EOF
+
+cat << EOF > /etc/containers/registries.conf.d/registry-k8s-io-no-cdn.conf
+# Workaround for https://github.com/kubernetes/registry.k8s.io/issues/333
+[[registry]]
+location = "registry.k8s.io"
+
+[[registry.mirror]]
+location = "us-central1-docker.pkg.dev/k8s-artifacts-prod/images"
+EOF
+
+systemctl enable --now crio
 
 create_sriov_udev_rule
 

--- a/cluster-provision/k8s/1.36/k8s_provision.sh
+++ b/cluster-provision/k8s/1.36/k8s_provision.sh
@@ -84,8 +84,6 @@ EOF
 
 dnf install -y cri-o
 
-systemctl enable --now crio
-
 cat << EOF > /etc/containers/registries.conf
 [registries.search]
 registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
@@ -96,6 +94,17 @@ registries = ['registry:5000']
 [registries.block]
 registries = []
 EOF
+
+cat << EOF > /etc/containers/registries.conf.d/registry-k8s-io-no-cdn.conf
+# Workaround for https://github.com/kubernetes/registry.k8s.io/issues/333
+[[registry]]
+location = "registry.k8s.io"
+
+[[registry.mirror]]
+location = "us-central1-docker.pkg.dev/k8s-artifacts-prod/images"
+EOF
+
+systemctl enable --now crio
 
 create_sriov_udev_rule
 

--- a/cluster-provision/k8s/1.37/k8s_provision.sh
+++ b/cluster-provision/k8s/1.37/k8s_provision.sh
@@ -96,8 +96,6 @@ curl -Ro "/etc/yum.repos.d/cri-o-v${CRIO_VERSION}-${CRIO_CHANNEL}.repo" \
 
 dnf install -y cri-o
 
-systemctl enable --now crio
-
 cat << EOF > /etc/containers/registries.conf
 [registries.search]
 registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'quay.io', 'docker.io']
@@ -108,6 +106,17 @@ registries = ['registry:5000']
 [registries.block]
 registries = []
 EOF
+
+cat << EOF > /etc/containers/registries.conf.d/registry-k8s-io-no-cdn.conf
+# Workaround for https://github.com/kubernetes/registry.k8s.io/issues/333
+[[registry]]
+location = "registry.k8s.io"
+
+[[registry.mirror]]
+location = "us-central1-docker.pkg.dev/k8s-artifacts-prod/images"
+EOF
+
+systemctl enable --now crio
 
 create_sriov_udev_rule
 


### PR DESCRIPTION
**What this PR does / why we need it**:

registry.k8s.io CDN switched to Fastly, which is causing CRI-O / Podman to fail to pull some container image blobs.

This change configure them to pull K8S images directly from Google Artifact Registry without going through the CDN, until the CDN-related issue is resolved.

**Special notes for your reviewer**:

/cc @Whitedyl