### PR TITLE
fix: pull kubeadm images individually to handle CDN connection failures

### DIFF
--- a/cluster-provision/k8s/1.34/k8s_provision.sh
+++ b/cluster-provision/k8s/1.34/k8s_provision.sh
@@ -122,7 +122,13 @@ if [[ $version != $packages_version ]]; then
    replaceKubeBinaries
 fi
 
-kubeadm config images pull --kubernetes-version ${version}
+# Pull each kubeadm image individually so a CDN connection failure on one image
+# (e.g. cdn.registry.k8s.io returning 400 on a Range retry after unexpected EOF,
+# see https://github.com/kubernetes/registry.k8s.io/issues/333) does not abort
+# the entire pull and each image gets its own fresh connection with retries.
+for image in $(kubeadm config images list --kubernetes-version ${version}); do
+    pull_container_retry ${image}
+done
 
 if [[ ${slim} == false ]]; then
     # Pre pull all images from the lists

--- a/cluster-provision/k8s/1.35/k8s_provision.sh
+++ b/cluster-provision/k8s/1.35/k8s_provision.sh
@@ -130,7 +130,13 @@ if [[ $version != $packages_version ]]; then
    replaceKubeBinaries
 fi
 
-kubeadm config images pull --kubernetes-version ${version}
+# Pull each kubeadm image individually so a CDN connection failure on one image
+# (e.g. cdn.registry.k8s.io returning 400 on a Range retry after unexpected EOF,
+# see https://github.com/kubernetes/registry.k8s.io/issues/333) does not abort
+# the entire pull and each image gets its own fresh connection with retries.
+for image in $(kubeadm config images list --kubernetes-version ${version}); do
+    pull_container_retry ${image}
+done
 
 if [[ ${slim} == false ]]; then
     # Pre pull all images from the lists

--- a/cluster-provision/k8s/1.36/k8s_provision.sh
+++ b/cluster-provision/k8s/1.36/k8s_provision.sh
@@ -130,7 +130,13 @@ if [[ $version != $packages_version ]]; then
    replaceKubeBinaries
 fi
 
-kubeadm config images pull --kubernetes-version ${version}
+# Pull each kubeadm image individually so a CDN connection failure on one image
+# (e.g. cdn.registry.k8s.io returning 400 on a Range retry after unexpected EOF,
+# see https://github.com/kubernetes/registry.k8s.io/issues/333) does not abort
+# the entire pull and each image gets its own fresh connection with retries.
+for image in $(kubeadm config images list --kubernetes-version ${version}); do
+    pull_container_retry ${image}
+done
 
 if [[ ${slim} == false ]]; then
     # Pre pull all images from the lists

--- a/cluster-provision/k8s/1.37/k8s_provision.sh
+++ b/cluster-provision/k8s/1.37/k8s_provision.sh
@@ -139,7 +139,13 @@ if [[ $version != $packages_version ]]; then
    replaceKubeBinaries
 fi
 
-kubeadm config images pull --kubernetes-version ${version}
+# Pull each kubeadm image individually so a CDN connection failure on one image
+# (e.g. cdn.registry.k8s.io returning 400 on a Range retry after unexpected EOF,
+# see https://github.com/kubernetes/registry.k8s.io/issues/333) does not abort
+# the entire pull and each image gets its own fresh connection with retries.
+for image in $(kubeadm config images list --kubernetes-version ${version}); do
+    pull_container_retry ${image}
+done
 
 if [[ ${slim} == false ]]; then
     # Pre pull all images from the lists


### PR DESCRIPTION
Replaxce `kubeadm config images pull` with a per-image loop using `pull_container_retry` across k8s 1.34-1.37 scripts.

A CDN connection failure on cdn.registry.k8s.io (e.g. HTTP 400 on a Range retry after unexpected EOF - see
https://github.com/kubernetes/registry.k8s.io/issues/333) would abort the entire bulk pull. Pulling each image individually gives every image its own fresh connection with independent retries, preventing a single transient CDN error from failing the whole provisioning run.

Assisted-by: IBM Bob

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
