### PR TITLE
fix(docker-mirror-proxy): add cluster local registry to no_proxy

### DIFF
--- a/cluster-up/cluster/kind/configure-registry-proxy.sh
+++ b/cluster-up/cluster/kind/configure-registry-proxy.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # source: https://github.com/rpardini/docker-registry-proxy#kind-cluster
 #
 # This script execute docker-registry-proxy cluster nodes
@@ -16,8 +18,6 @@
 #   ./configure-registry-proxy.sh
 #
 
-#! /bin/bash
-
 set -ex
 
 SCRIPT_PATH=$(dirname "$(realpath "$0")")
@@ -35,7 +35,7 @@ for node in $($KIND_BIN get nodes --name "$CLUSTER_NAME"); do
    $CRI_BIN exec "$node" sh -c "\
       curl $SETUP_URL | \
       sed s/docker\.service/containerd\.service/g | \
-      sed '/Environment/ s/$/ \"NO_PROXY=127.0.0.0\/8,10.0.0.0\/8,172.16.0.0\/12,192.168.0.0\/16\"/' | \
+      sed '/Environment=/ s|$| \"NO_PROXY=localhost,registry,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16\"/' | \
       bash" &
    pids="$pids $!"
 done


### PR DESCRIPTION
**What this PR does / why we need it**:

Newer versions of the docker-mirror-proxy generate a large number of errors in the logs:

```
2026/08/25 10:14:44 [error] 131#131: *52104 proxy_connect: registry could not be resolved (3: Host not found), client: 100.66.18.33, server: proxy_director_, request: "CONNECT registry:5000 HTTP/1.1", host: "registry:5000"
```

Exclude the cluster local registry from being proxied in kubevirtci kind providers like it is done for the k8s providers.

**Special notes for your reviewer**:

/cc @Whitedyl